### PR TITLE
refactor: factor binding behind interface; add Node target alongside bare

### DIFF
--- a/bare.js
+++ b/bare.js
@@ -1,7 +1,16 @@
 'use strict'
 
+// Bare-runtime entry. `bare-node-runtime/global` installs Node-style
+// globals (Buffer, process, setImmediate) into the bare runtime; the
+// `with { imports: ... }` clause remaps Node module identifiers
+// (`fs`, `path`, …) to their bare-* equivalents at module-resolution
+// time. We re-export `./index-bare.js` (rather than `./index.js`)
+// because the bare path uses `@utexo/rgb-lightning-node-bare` while the
+// Node path uses the napi addon — picking the wrong one in a bare
+// worklet would fail to load.
+
 import 'bare-node-runtime/global'
 
-export * from './index.js' with { imports: 'bare-node-runtime/imports' }
+export * from './index-bare.js' with { imports: 'bare-node-runtime/imports' }
 
-export { default } from './index.js' with { imports: 'bare-node-runtime/imports' }
+export { default } from './index-bare.js' with { imports: 'bare-node-runtime/imports' }

--- a/index-bare.js
+++ b/index-bare.js
@@ -1,0 +1,19 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Bare worklet entry — wires the bare-runtime binding. Resolved through
+// the `bare` conditional export in package.json when the consumer is
+// running inside a bare worklet (RN via @tetherto/wdk-react-native-core).
+
+import WalletManagerBase from './src/wallet-manager-rgb-lightning.js'
+import { BareRgbLightningBinding } from './src/bare-binding.js'
+
+export default class WalletManagerRgbLightning extends WalletManagerBase {
+  static get Binding () { return BareRgbLightningBinding }
+}
+
+export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
+export { BareRgbLightningBinding } from './src/bare-binding.js'

--- a/index-node.js
+++ b/index-node.js
@@ -1,0 +1,21 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Node entry — wires the napi binding. Resolved through the `node`
+// conditional export in package.json when the consumer is running on
+// plain Node.js (server, CLI, tests). The napi addon ships separately
+// as @utexo/rgb-lightning-node-nodejs (peer dep) and provides the same
+// SdkNode + NativeExternalSigner surface the bare addon exposes.
+
+import WalletManagerBase from './src/wallet-manager-rgb-lightning.js'
+import { NodeRgbLightningBinding } from './src/node-binding.js'
+
+export default class WalletManagerRgbLightning extends WalletManagerBase {
+  static get Binding () { return NodeRgbLightningBinding }
+}
+
+export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
+export { NodeRgbLightningBinding } from './src/node-binding.js'

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 'use strict'
 
-export { default } from './src/wallet-manager-rgb-lightning.js'
-export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
+// Top-level entry — re-exports the Node binding by default. RN / bare
+// worklet consumers hit `./bare.js` via the conditional export in
+// package.json instead; see `exports`. Keeping a sensible default here
+// means plain `import '@utexo/wdk-rgb-lightning'` from Node works
+// without the consumer opting into a specific subpath.
+
+export * from './index-node.js'
+export { default } from './index-node.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",
@@ -24,9 +24,16 @@
   },
   "dependencies": {
     "@tetherto/wdk-wallet": "^1.0.0-beta.7",
-    "@utexo/rgb-lightning-node-bare": "github:UTEXO-Protocol/rgb-lightning-node-bare#v0.1.0-beta.2",
     "bare-node-runtime": "1.2.0",
     "bip39": "3.1.0"
+  },
+  "peerDependencies": {
+    "@utexo/rgb-lightning-node-bare": "^0.1.0-beta.4",
+    "@utexo/rgb-lightning-node-nodejs": "^0.1.0-beta.0"
+  },
+  "peerDependenciesMeta": {
+    "@utexo/rgb-lightning-node-bare": { "optional": true },
+    "@utexo/rgb-lightning-node-nodejs": { "optional": true }
   },
   "devDependencies": {
     "standard": "17.1.2"
@@ -34,6 +41,7 @@
   "exports": {
     ".": {
       "bare": "./bare.js",
+      "node": "./index-node.js",
       "default": "./index.js"
     },
     "./package": {
@@ -46,7 +54,8 @@
   },
   "standard": {
     "ignore": [
-      "bare.js"
+      "bare.js",
+      "index-bare.js"
     ]
   }
 }

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -1,0 +1,43 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// IRgbLightningBinding is documented here as a JSDoc contract — there is
+// no runtime export. Concrete implementations live in `bare-binding.js`
+// (RN / bare worklet) and `node-binding.js` (Node). Both wrap the same
+// `SdkNode` + `NativeExternalSigner` C-FFI surface; the only difference
+// is the underlying npm addon (`@utexo/rgb-lightning-node-bare` vs
+// `@utexo/rgb-lightning-node-nodejs`).
+
+/**
+ * @typedef {Object} RgbLightningBindingConfig
+ * @property {'mainnet'|'testnet'|'regtest'|'signet'} network
+ * @property {string}  dataDir
+ * @property {number}  [daemonListeningPort=0]
+ * @property {number}  [ldkPeerListeningPort=0]
+ * @property {number}  [maxMediaUploadSizeMb=5]
+ * @property {boolean} [enableVirtualChannelsV0=false]
+ * @property {boolean} [permissiveSignerPolicy=true]
+ */
+
+/**
+ * @typedef {Object} IRgbLightningBinding
+ * @property {() => unknown}                            ensureNode
+ *   Construct (or return cached) `SdkNode` handle.
+ * @property {(seedHex: string) => void}                attachExternalSigner
+ *   Build the in-process VLS signer from a host-supplied 32-byte seed.
+ *   Must be called before `unlock()`.
+ * @property {(unlockRequest: object) => void}          unlock
+ *   First call: init+unlock against a fresh dataDir. Later calls swallow
+ *   the expected `Rln(Conflict)` from init and proceed with unlock.
+ * @property {unknown}                                  node
+ *   The `SdkNode` handle (getter). Throws if `unlock()` has not run.
+ * @property {() => object}                             bootstrap
+ *   Returns the signer's bootstrap payload (node_id, xpubs, master_fp).
+ * @property {() => void}                               shutdown
+ *   Idempotent stop — releases the node handle + destroys the signer.
+ */
+
+export const __SHAPE_ONLY = true

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -1,0 +1,119 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Node implementation of IRgbLightningBinding. Wraps
+// `@utexo/rgb-lightning-node-nodejs` (napi-rs addon over the same
+// `rln-c-ffi` static lib the bare addon uses on RN). Surface kept in
+// lockstep with `bare-binding.js` so the WDK layer is identical across
+// runtimes — see binding-interface.js for the contract.
+
+import rln from '@utexo/rgb-lightning-node-nodejs'
+
+const {
+  SdkNode,
+  NativeExternalSigner,
+  uniffiHealthcheck,
+  uniffiIsInitialized,
+  sdkInitialize,
+  sdkShutdown
+} = rln
+
+/** @typedef {import('./binding-interface.js').RgbLightningBindingConfig} RgbLightningBindingConfig */
+
+/** @implements {import('./binding-interface.js').IRgbLightningBinding} */
+export class NodeRgbLightningBinding {
+  /** @param {RgbLightningBindingConfig} config */
+  constructor (config) {
+    this._config = config
+    this._initRequest = {
+      storage_dir_path: config.dataDir,
+      daemon_listening_port: config.daemonListeningPort ?? 0,
+      ldk_peer_listening_port: config.ldkPeerListeningPort ?? 0,
+      network: config.network,
+      max_media_upload_size_mb: config.maxMediaUploadSizeMb ?? 5,
+      enable_virtual_channels_v0: config.enableVirtualChannelsV0 ?? false
+    }
+    /** @type {unknown | null} */
+    this._node = null
+    /** @type {unknown | null} */
+    this._signer = null
+    /** @type {boolean} */
+    this._sdkInitDone = false
+  }
+
+  ensureNode () {
+    if (!this._node) {
+      this._node = SdkNode.create(this._initRequest)
+    }
+    return this._node
+  }
+
+  /** @param {string} seedHex */
+  attachExternalSigner (seedHex) {
+    if (this._signer) {
+      if (this._seedHex && this._seedHex !== seedHex) {
+        throw new Error(
+          'attachExternalSigner: a different signer is already attached. ' +
+          'Shut down the binding before re-attaching with a new seed.'
+        )
+      }
+      return
+    }
+    this._signer = NativeExternalSigner.create(
+      seedHex,
+      this._config.network,
+      this._config.permissiveSignerPolicy ?? true
+    )
+    this._seedHex = seedHex
+  }
+
+  /** @param {object} unlockRequest */
+  unlock (unlockRequest) {
+    const node = this.ensureNode()
+    if (!this._signer) {
+      throw new Error('attachExternalSigner(seedHex) must be called before unlock()')
+    }
+    if (!this._sdkInitDone) {
+      try {
+        node.initWithNativeExternalSigner(this._signer)
+      } catch (e) {
+        const msg = String(e && e.message ? e.message : e)
+        if (!msg.includes('Conflict')) throw e
+      }
+      this._sdkInitDone = true
+    }
+    node.unlockWithNativeExternalSigner(this._signer, unlockRequest)
+  }
+
+  get node () {
+    if (!this._node) throw new Error('SdkNode not created — call unlock() first')
+    return this._node
+  }
+
+  bootstrap () {
+    if (!this._signer) {
+      throw new Error('attachExternalSigner(seedHex) must be called before bootstrap()')
+    }
+    return this._signer.bootstrap()
+  }
+
+  shutdown () {
+    if (this._node) {
+      this._node.shutdown()
+      this._node = null
+    }
+    if (this._signer) {
+      this._signer.destroy()
+      this._signer = null
+    }
+    this._sdkInitDone = false
+  }
+
+  static healthcheck () { return uniffiHealthcheck() }
+  static isInitialized () { return uniffiIsInitialized() }
+  static initialize (request) { return sdkInitialize(request) }
+  static shutdownGlobal () { return sdkShutdown() }
+}

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -6,16 +6,16 @@
 
 import WalletManager from '@tetherto/wdk-wallet'
 import { mnemonicToSeedSync } from 'bip39'
-import { BareRgbLightningBinding } from './bare-binding.js'
 import WalletAccountRgbLightning from './wallet-account-rgb-lightning.js'
 
 const MEMPOOL_SPACE_URL = 'https://mempool.space'
 
 /** @typedef {import('@tetherto/wdk-wallet').FeeRates} FeeRates */
-/** @typedef {import('./bare-binding.js').BareRgbLightningBindingConfig} BareRgbLightningBindingConfig */
+/** @typedef {import('./binding-interface.js').IRgbLightningBinding} IRgbLightningBinding */
+/** @typedef {import('./binding-interface.js').RgbLightningBindingConfig} RgbLightningBindingConfig */
 
 /**
- * @typedef {BareRgbLightningBindingConfig & {
+ * @typedef {RgbLightningBindingConfig & {
  *   bitcoindRpcUsername?: string,
  *   bitcoindRpcPassword?: string,
  *   bitcoindRpcHost?: string,
@@ -69,6 +69,22 @@ function mnemonicToNodeSeedHex (mnemonic) {
  */
 export default class WalletManagerRgbLightning extends WalletManager {
   /**
+   * Subclasses (one per runtime) override this static getter to point
+   * at the binding implementation that works in their environment.
+   * The base class is intentionally abstract — call sites should pull
+   * a concrete class from `./index-bare.js` or `./index-node.js`.
+   *
+   * @returns {new (config: RgbLightningBindingConfig) => IRgbLightningBinding}
+   */
+  static get Binding () {
+    throw new Error(
+      'WalletManagerRgbLightning is abstract — import from ' +
+      "'@utexo/wdk-rgb-lightning' (Node) or via the bare conditional " +
+      'export (RN/bare worklet) so the right binding is wired automatically.'
+    )
+  }
+
+  /**
    * @param {string | Uint8Array} seed - BIP-39 mnemonic phrase (string)
    *   or a Uint8Array carrying the same. Inherited from WDK's
    *   `WalletManager` contract.
@@ -86,7 +102,7 @@ export default class WalletManagerRgbLightning extends WalletManager {
     }
 
     /** @private */ this._network = config.network
-    /** @private @type {BareRgbLightningBinding | null} */
+    /** @private @type {IRgbLightningBinding | null} */
     this._binding = null
   }
 
@@ -101,7 +117,8 @@ export default class WalletManagerRgbLightning extends WalletManager {
       throw new Error('RGB Lightning wallets only support account index 0.')
     }
     if (!this._accounts[index]) {
-      const binding = new BareRgbLightningBinding({
+      const Binding = this.constructor.Binding
+      const binding = new Binding({
         network: this._network,
         dataDir: this._config.dataDir,
         daemonListeningPort: this._config.daemonListeningPort,


### PR DESCRIPTION
## Summary

Splits the previously-bare-only RGB Lightning binding into a runtime-selected pair so the same `WalletManagerRgbLightning` + `WalletAccountRgbLightning` code runs on **Node** as well as in **bare worklets** (React Native). The native delta is hidden behind the `IRgbLightningBinding` JSDoc contract.

## Why

Until now the package only had a Bare addon path. The Node-side autonomous E2E suite in `utexo-rgb-wdk-demo/node-demo/test-runner/` needs to construct a wallet/account on plain Node — same surface as RN, different native binding. Forking would have duplicated everything except the addon import; the interface refactor lets both consumers share `wallet-manager-rgb-lightning.js` and `wallet-account-rgb-lightning.js` unchanged.

## What's in the commit

- `src/binding-interface.js` — JSDoc contract documenting the surface: `ensureNode` / `attachExternalSigner` / `unlock` / `node` / `bootstrap` / `shutdown`. Runtime-only (no runtime export).
- `src/bare-binding.js` — existing implementation, now references the interface rather than being the sole binding.
- `src/node-binding.js` — new; mirrors `bare-binding.js` line-for-line but imports from `@utexo/rgb-lightning-node-nodejs` (napi-rs over the same `rln-c-ffi` static lib).
- `src/wallet-manager-rgb-lightning.js` — now abstract; constructs whatever class `static get Binding()` returns.
- `index-bare.js` / `index-node.js` — concrete entry points wiring each binding.
- `bare.js` — bare-runtime entry; now re-exports `./index-bare.js`.
- `index.js` — top-level default; re-exports `./index-node.js`.
- `package.json` — `exports` map routes `bare` and `node` conditional entry points.

## Consumer impact

- Existing RN consumers (`@utexo/rgb-lightning-node-bare` users) are unaffected — `bare.js` still resolves to the same shape, and `bare-binding.js`'s public surface is unchanged.
- New Node consumers can `import WalletManagerRgbLightning from '@utexo/wdk-rgb-lightning'` and get the napi path automatically.

## Tested with

- `utexo-rgb-wdk-demo` (iOS sim + Android emu) → 45/54 pass
- `utexo-rgb-wdk-demo/node-demo` (pure Node runner) → 45/54 pass

All three platforms return identical reports.