### PR TITLE
feat: implement IWalletAccount surface (transfer, quotes, key-pair, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.log
 .DS_Store
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -20,6 +20,28 @@
 export const PENDING_ADDRESS = 'tb1qpendingunlock00000000000000000000000000'
 
 /**
+ * Approximate vbyte count for a typical 1-input 2-output P2WPKH spend.
+ * Used by `quoteTransfer` / `quoteSendTransaction` since RLN doesn't
+ * expose a tx-shape-aware fee estimator. Calibrate against actual
+ * sendTransaction telemetry if accuracy ever becomes load-bearing.
+ */
+const APPROX_BTC_TX_VBYTES = 141
+
+/**
+ * Basis points used to approximate LN routing fees in `quoteTransfer`
+ * when no probe path is available. ~50 bps (0.5%) is a conservative
+ * over-estimate vs typical mainnet routing fees (~0.1-0.3%); favours
+ * not under-quoting.
+ */
+const LN_FEE_BPS = 50
+
+/**
+ * Fallback sat/vB rate when `estimateFee` fails (regtest or network
+ * hiccup). Picks a moderate value — better to over-quote than to fail.
+ */
+const DEFAULT_FEE_RATE_SAT_PER_VB = 5
+
+/**
  * Watch-only via RLN's `NativeExternalSigner`: the WDK secret manager
  * owns the BIP-39 mnemonic; the manager derives a 32-byte VLS node
  * entropy from it and attaches a `NativeExternalSigner` to RLN. RLN's
@@ -200,6 +222,7 @@ export default class WalletAccountRgbLightning {
     this._node.cancelHodlInvoice(request)
     return { ok: true }
   }
+
   /** @param {Object} request */
   async claimHodlInvoice (request) { return this._node.claimHodlInvoice(request) }
 
@@ -256,6 +279,7 @@ export default class WalletAccountRgbLightning {
     this._node.refreshTransfers(request)
     return { ok: true }
   }
+
   /** @param {Object} request */
   async failTransfers (request) { return this._node.failTransfers(request) }
 
@@ -364,61 +388,269 @@ export default class WalletAccountRgbLightning {
   }
 
   // ==========================================================================
-  // IWalletAccount surface that doesn't map cleanly onto LN — 🚧 stubs
+  // IWalletAccount surface — generic operations routed onto RLN
   // ==========================================================================
 
-  /** 🚧 RLN exposes `signMessage` (BIP-322 style) but not the inverse
-   *  verify-by-pubkey. We have the account xpub from
-   *  `getBootstrap().account_xpub_vanilla` and can do BIP-322 verification
-   *  locally — wire that up when a consumer actually needs it.
-   *  @returns {Promise<never>} */
+  /**
+   * Identifies the recipient form so `transfer()` / `quoteTransfer()`
+   * can dispatch to the right backing RLN method.
+   * @private
+   * @param {string} recipient
+   * @returns {'bolt11'|'rgb-invoice'|'ln-pubkey'|'btc-address'}
+   */
+  static _classifyRecipient (recipient) {
+    if (typeof recipient !== 'string' || recipient.length === 0) {
+      throw new Error('transfer: recipient must be a non-empty string')
+    }
+    const r = recipient.trim()
+    // BOLT11 — bech32-encoded; case is normalised to lowercase here. The
+    // human-readable prefix is `lnbc`/`lntb`/`lnbcrt`/`lnsb` (mainnet /
+    // testnet / regtest / signet) followed by an amount + payload.
+    if (/^ln(bc|tb|bcrt|sb)/i.test(r)) return 'bolt11'
+    // RGB invoice — defined by the rgb-rs invoice URI scheme.
+    if (r.toLowerCase().startsWith('rgb:') || r.toLowerCase().startsWith('utxob:')) return 'rgb-invoice'
+    // 33-byte compressed secp256k1 pubkey in hex (LN node id form).
+    if (/^[0-9a-fA-F]{66}$/.test(r)) return 'ln-pubkey'
+    // Default: assume bitcoin address; let RLN's address parser reject
+    // malformed values rather than re-implementing the bech32/base58
+    // bitcoin-address grammar here.
+    return 'btc-address'
+  }
+
+  /**
+   * Verify a message signature.
+   *
+   * RLN's `sign_message` produces a recoverable LN-style signature
+   * (zbase32-encoded over `"Lightning Signed Message:" + msg`).
+   * The c-ffi does NOT currently expose a matching `verify_message`,
+   * so we cannot round-trip the signature without either:
+   *   a) wiring `lightning::util::message_signing::verify` into c-ffi
+   *      (upstream change), or
+   *   b) reimplementing the zbase32 + ecdsa-recover path in JS.
+   *
+   * Both are out of scope for this iteration; verify stays a documented
+   * gap. Track upstream + bump when c-ffi exposes verify_message.
+   *
+   * @param {string} _message
+   * @param {string} _signature
+   * @returns {Promise<boolean>}
+   */
   async verify (_message, _signature) {
-    throw new Error('verify() not yet implemented — needs local BIP-322 verifier against account xpub')
+    throw new Error(
+      'verify() requires upstream c-ffi support for rln_verify_message — ' +
+      'pending: expose lightning::util::message_signing::verify in rgb-lightning-node/bindings/c-ffi.'
+    )
   }
 
-  /** 🚧 `transfer` is the generic ERC-20-style entry on IWalletAccount.
-   *  The LN equivalent is `keysend` / `sendPayment`. Once a higher-level
-   *  router exists that picks between LN and on-chain RGB based on the
-   *  recipient form, wire it through here.
-   *  @param {TransferOptions} _options @returns {Promise<never>} */
-  async transfer (_options) {
-    throw new Error('transfer() not yet implemented — use sendPayment / keysend / sendRgbAsset directly')
+  /**
+   * Sign an arbitrary tx. RLN's external signer signs the LN+RGB tx
+   * shapes it constructs internally; raw PSBT signing is not exposed
+   * via the c-ffi surface (VLS policy filter would reject anything it
+   * didn't construct itself anyway). Callers should use
+   * `sendTransaction` (auto-signs an on-chain spend) or the LN /
+   * RGB-specific methods instead.
+   *
+   * @returns {Promise<never>}
+   */
+  async signTransaction (_tx) {
+    throw new Error(
+      'signTransaction() is not exposed on RGB Lightning accounts — ' +
+      'use sendTransaction(request) for on-chain spends (VLS signs in-process), ' +
+      'sendPayment/keysend for LN, or sendRgbAsset for RGB transfers.'
+    )
   }
 
-  /** 🚧 Quote requires a probe path. RLN doesn't currently expose one;
-   *  estimate client-side from `decodeInvoice`'s amount + a configurable
-   *  fee bps when this is needed.
-   *  @param {TransferOptions} _options @returns {Promise<never>} */
-  async quoteTransfer (_options) {
-    throw new Error('quoteTransfer() not yet implemented')
+  /**
+   * Generic transfer router. Inspects the recipient form and dispatches:
+   *   - BOLT11 invoice → `sendPayment({ invoice, amt_msat?, asset_id? })`
+   *   - LN node pubkey  → `keysend({ dest_pubkey, amt_msat, asset_id? })`
+   *   - BTC address     → `sendTransaction({ address, amount, fee_rate, skip_sync })`
+   *   - RGB invoice     → `sendRgbAsset` (asset_id picked from invoice)
+   *
+   * `options.token` is interpreted as an RGB asset_id when present.
+   * `options.amount` is treated as **msats** for LN flows and **sats**
+   * for on-chain flows — callers using `transfer()` for on-chain need to
+   * pass sats, not msats. For finer control, call the underlying method
+   * directly.
+   *
+   * @param {TransferOptions} options
+   * @returns {Promise<TransferResult>}
+   */
+  async transfer (options) {
+    if (!options || typeof options !== 'object') {
+      throw new Error('transfer: options must be { recipient, amount, token? }')
+    }
+    const recipient = options.recipient
+    const amount = options.amount
+    const assetId = options.token && options.token.length > 0 ? options.token : null
+    const kind = WalletAccountRgbLightning._classifyRecipient(recipient)
+
+    switch (kind) {
+      case 'bolt11': {
+        const req = { invoice: recipient }
+        if (amount !== undefined && amount !== null) req.amt_msat = Number(amount)
+        if (assetId) req.asset_id = assetId
+        const r = await this.sendPayment(req)
+        return { hash: r?.payment_hash ?? '', fee: BigInt(r?.fee_msat ?? 0n) }
+      }
+      case 'ln-pubkey': {
+        if (amount === undefined || amount === null) {
+          throw new Error('transfer(keysend): amount (msats) is required')
+        }
+        const req = { dest_pubkey: recipient, amt_msat: Number(amount) }
+        if (assetId) req.asset_id = assetId
+        const r = await this.keysend(req)
+        return { hash: r?.payment_hash ?? '', fee: BigInt(r?.fee_msat ?? 0n) }
+      }
+      case 'btc-address': {
+        if (amount === undefined || amount === null) {
+          throw new Error('transfer(on-chain): amount (sats) is required')
+        }
+        const feeRate = options.feeRate ?? await this._defaultFeeRate(6)
+        const req = {
+          address: recipient,
+          amount: Number(amount),
+          fee_rate: Number(feeRate),
+          skip_sync: false
+        }
+        const r = await this.sendTransaction(req)
+        const fee = BigInt(Math.round(Number(feeRate) * APPROX_BTC_TX_VBYTES))
+        return { hash: r?.txid ?? '', fee }
+      }
+      case 'rgb-invoice': {
+        // RGB on-chain transfer: recipient IS the rgb invoice. Asset id
+        // is encoded in it; RLN parses it server-side.
+        const req = { recipient_id: recipient }
+        if (amount !== undefined && amount !== null) req.amount = Number(amount)
+        if (assetId) req.asset_id = assetId
+        const r = await this.sendRgbAsset(req)
+        return { hash: r?.txid ?? '', fee: BigInt(0) }
+      }
+      default:
+        throw new Error(`transfer: unhandled recipient kind "${kind}"`)
+    }
   }
 
-  /** 🚧 On-chain fee estimate. RLN has `estimateFee(blocks)` for a sat/vB
-   *  rate; deriving a fee for a specific tx shape needs us to size the
-   *  PSBT first. Punt until a caller actually needs the per-tx number. */
+  /**
+   * Approximate quote for a transfer without actually sending. Per
+   * Renat: accept the approximation while RLN does not expose a probe
+   * endpoint.
+   *
+   *   - on-chain → `estimateFee(blocks) × APPROX_BTC_TX_VBYTES`
+   *   - LN       → flat percentage of amount (`LN_FEE_BPS` basis points)
+   *   - RGB invoice → on-chain quote (RGB transfers settle on-chain)
+   *
+   * Returns `{ fee }` (no `hash`), matching `Omit<TransferResult, 'hash'>`.
+   *
+   * @param {TransferOptions} options
+   * @returns {Promise<Omit<TransferResult, 'hash'>>}
+   */
+  async quoteTransfer (options) {
+    if (!options || typeof options !== 'object') {
+      throw new Error('quoteTransfer: options must be { recipient, amount, token? }')
+    }
+    const kind = WalletAccountRgbLightning._classifyRecipient(options.recipient)
+    if (kind === 'bolt11' || kind === 'ln-pubkey') {
+      const amt = Number(options.amount ?? 0)
+      const fee = BigInt(Math.max(1, Math.ceil(amt * LN_FEE_BPS / 10000)))
+      return { fee }
+    }
+    // on-chain (BTC or RGB)
+    const rate = await this._defaultFeeRate(6)
+    return { fee: BigInt(Math.round(Number(rate) * APPROX_BTC_TX_VBYTES)) }
+  }
+
+  /**
+   * Approximate quote for a single on-chain spend. Sizes the tx as a
+   * typical 1-input 2-output P2WPKH spend (~141 vbytes) and multiplies
+   * by the current sat/vB rate.
+   *
+   * @param {Transaction} _tx
+   * @returns {Promise<Omit<TransactionResult, 'hash'>>}
+   */
   async quoteSendTransaction (_tx) {
-    throw new Error('quoteSendTransaction() not yet implemented — use estimateFee(blocks) for sat/vB')
+    const rate = await this._defaultFeeRate(6)
+    return { fee: BigInt(Math.round(Number(rate) * APPROX_BTC_TX_VBYTES)) }
   }
 
-  /** 🚧 RLN doesn't expose a transaction-by-hash lookup. Could stitch by
-   *  calling `listTransactions` + filtering. Wire when needed. */
-  async getTransactionReceipt (_hash) {
-    throw new Error('getTransactionReceipt() not yet implemented')
+  /**
+   * Look up a transaction by hash by filtering `listTransactions` (BTC)
+   * then falling back to `listPayments` (LN). Returns the raw entry, or
+   * `null` if not found.
+   *
+   * @param {string} hash
+   * @returns {Promise<unknown | null>}
+   */
+  async getTransactionReceipt (hash) {
+    if (typeof hash !== 'string' || hash.length === 0) {
+      throw new Error('getTransactionReceipt: hash is required')
+    }
+    try {
+      const txs = await this.getTransactions(false)
+      const onchain = Array.isArray(txs?.transactions) ? txs.transactions : (Array.isArray(txs) ? txs : [])
+      const hit = onchain.find((t) => t?.txid === hash)
+      if (hit) return hit
+    } catch (_e) { /* fall through to LN lookup */ }
+    try {
+      const sent = await this.getPayment(hash, 'sent')
+      if (sent && sent.payment_hash) return sent
+    } catch (_e) { /* not a sent payment */ }
+    try {
+      const recv = await this.getPayment(hash, 'received')
+      if (recv && recv.payment_hash) return recv
+    } catch (_e) { /* not a received payment either */ }
+    return null
   }
 
-  /** 🚧 Derive on-chain pubkey for the IWalletAccount.getKeyPair contract.
-   *  We have the account xpub via bootstrap; derive child as needed when
-   *  a consumer requires this. */
+  /**
+   * Returns the LN node identity as the account's key pair.
+   *
+   * Rationale: the account's "identity" on the LN network is the
+   * node_id (33-byte compressed secp256k1 pubkey). For on-chain
+   * receive addresses we use the account xpub (also in bootstrap) but
+   * the IWalletAccount contract asks for a single `KeyPair`. The
+   * privateKey is always `null` — VLS owns the signing material and
+   * never exposes it.
+   *
+   * @returns {KeyPair}
+   */
   getKeyPair () {
-    throw new Error('getKeyPair() not yet implemented — derive via account_xpub_vanilla from bootstrap()')
+    const b = this._binding.bootstrap()
+    if (!b || typeof b.node_id !== 'string') {
+      throw new Error('getKeyPair: bootstrap did not return a node_id')
+    }
+    const publicKey = Buffer.from(b.node_id, 'hex')
+    return { publicKey, privateKey: null }
   }
 
-  /** 🚧 Read-only view of the account. We already run "watch-only" via
-   *  the external signer (RLN never has the seed), but the WDK
-   *  `IWalletAccountReadOnly` contract is a distinct type. Wire it as a
-   *  thin façade exposing only the read methods when needed. */
-  toReadOnlyAccount () {
-    throw new Error('toReadOnlyAccount() not yet implemented')
+  /**
+   * Read-only façade — exposes the safe (non-mutating) IWalletAccount
+   * methods and throws on anything that would broadcast.
+   *
+   * The underlying account is already watch-only at the signer level
+   * (VLS holds keys, RLN never sees seed); this just enforces the
+   * `IWalletAccountReadOnly` *type* contract.
+   *
+   * @returns {Promise<IWalletAccountReadOnly>}
+   */
+  async toReadOnlyAccount () {
+    return new ReadOnlyRgbLightningAccount(this)
+  }
+
+  /**
+   * @private
+   * @param {number} blocks
+   * @returns {Promise<number>}
+   */
+  async _defaultFeeRate (blocks) {
+    try {
+      const r = await this.estimateFee(blocks)
+      const rate = r?.fee_rate ?? r?.feerate ?? r
+      const n = Number(rate)
+      return Number.isFinite(n) && n > 0 ? n : DEFAULT_FEE_RATE_SAT_PER_VB
+    } catch (_e) {
+      return DEFAULT_FEE_RATE_SAT_PER_VB
+    }
   }
 
   // ==========================================================================
@@ -430,4 +662,51 @@ export default class WalletAccountRgbLightning {
     // shut down by the manager's dispose(); the account itself holds
     // no sensitive state.
   }
+}
+
+/**
+ * Read-only façade returned by `WalletAccountRgbLightning.toReadOnlyAccount`.
+ * Implements the `IWalletAccountReadOnly` shape over the same underlying
+ * account but rejects any mutating call. We don't subclass
+ * `WalletAccountReadOnly` from `@tetherto/wdk-wallet` because the abstract
+ * surface there assumes ERC-20 semantics (token addresses, native
+ * balances as bigints) that don't translate to LN; we provide the same
+ * method names and let duck-typing handle the contract.
+ */
+class ReadOnlyRgbLightningAccount {
+  /** @param {WalletAccountRgbLightning} account */
+  constructor (account) {
+    this._account = account
+  }
+
+  /** @returns {Promise<string>} */
+  async getAddress () {
+    const a = this._account.getAddress()
+    return a instanceof Promise ? a : Promise.resolve(a)
+  }
+
+  /** @param {string} message @param {string} signature @returns {Promise<boolean>} */
+  async verify (message, signature) { return this._account.verify(message, signature) }
+
+  /** @returns {Promise<bigint>} balance in sats */
+  async getBalance () {
+    const s = await this._account.getBalance(false)
+    return BigInt(s ?? 0)
+  }
+
+  /** Per-asset balance — `tokenAddress` is interpreted as an RGB asset id. */
+  async getTokenBalance (tokenAddress) {
+    const r = await this._account.getAssetBalance(tokenAddress)
+    const settled = r?.settled ?? r?.spendable ?? 0
+    return BigInt(settled)
+  }
+
+  /** @param {Transaction} tx */
+  async quoteSendTransaction (tx) { return this._account.quoteSendTransaction(tx) }
+
+  /** @param {TransferOptions} options */
+  async quoteTransfer (options) { return this._account.quoteTransfer(options) }
+
+  /** @param {string} hash */
+  async getTransactionReceipt (hash) { return this._account.getTransactionReceipt(hash) }
 }


### PR DESCRIPTION
Replaces the 🚧-stub block at the bottom of `WalletAccountRgbLightning` with real implementations of the generic IWalletAccount surface, so consumers can use the same call shape they use for BTC / EVM / RGB wallets — no need to special-case the RGB Lightning path.

Discovered while running the autonomous E2E suite on the Node path: with `wdk-rgb-lightning@v0.1.0-alpha.1` (the binding-interface refactor), tests `t91.getKeyPair`, `t92.toReadOnlyAccount`, `t93.quoteTransferOnchain`, `t94.quoteSendTransaction`, `t96.getTransactionReceipt` all returned `not yet implemented`. The implementations in this PR bring those tests to green on all three platforms (iOS / Android / Node).

## What's wired

- **`_classifyRecipient(string)`** — helper returning `'bolt11' | 'rgb-invoice' | 'ln-pubkey' | 'btc-address'`. Used by `transfer` / `quoteTransfer` to dispatch.
- **`transfer({ recipient, amount, token? })`** — generic router:
  - BOLT11 invoice → `sendPayment`
  - LN node pubkey → `keysend`
  - BTC address → `sendTransaction`
  - RGB invoice → `sendRgbAsset`
- **`quoteTransfer({ recipient, amount, token? })`** — fee estimate. On-chain uses ~141 vbyte (P2WPKH 1-in 2-out) × `estimateFee(6)` sat/vB (5 sat/vB fallback). LN uses 50 bps over `amount` — conservative.
- **`quoteSendTransaction({ to, value })`** — wraps the on-chain branch of `quoteTransfer`.
- **`getTransactionReceipt(hash)`** — looks up an on-chain tx by id via `listTransactions()`; returns the daemon record or null.
- **`toReadOnlyAccount()`** — façade exposing public account state without the signer-bound binding.
- **`getKeyPair()`** — returns `{ publicKey, privateKey: null }`. `publicKey` is the LN node-id (decoded from `getBootstrap().node_id`). `privateKey` is `null` by design — VLS never exposes raw key material to JS.
- **`verify(_message, _signature)`** — documented gap. Throws with a clear message pointing at the missing `rln_verify_message` c-ffi symbol.
- **`signTransaction(_tx)`** — explicitly unsupported. VLS policy filter would reject externally-constructed PSBTs anyway. Throws pointing callers at `sendTransaction` / `sendPayment` / `keysend` / `sendRgbAsset`.

## Module-level constants

Pulled out for inspectability:

- `APPROX_BTC_TX_VBYTES = 141` — P2WPKH 1-in 2-out
- `LN_FEE_BPS = 50` — ~0.5% LN routing fallback
- `DEFAULT_FEE_RATE_SAT_PER_VB = 5` — fallback when `estimateFee` is unavailable

## Also

- `package.json`: bump 0.1.0-alpha.1 → 0.1.0-alpha.2
- `.gitignore`: drop `package-lock.json` (library convention)

## Test coverage

Re-running the autonomous E2E suite (54 cases) against `wdk-rgb-lightning@feat/extend-iwalletaccount-surface` from the Node runner: lifts the pass count from 40/54 (alpha.1) back to 45/54 — matches iOS + Android.