### PR TITLE
chore: cut v0.1.0-beta.1 — first beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ while pre-`1.0`.
 
 ## [Unreleased]
 
+## [0.1.0-beta.1] — 2026-06-01
+
+First public beta. Status promoted from alpha; README, LICENSE, and
+CHANGELOG brought to beta quality.
+
 ### Added
 - LSP client surface (`LspClient`, `LnurlPay`, helpers) for routed
   Lightning Address payments and RGB-over-LSP deposits.
@@ -16,6 +21,17 @@ while pre-`1.0`.
 - `apayNew(hostNodeId)` for receiver-side async-payments (APay)
   registration against an LSP (upstream RLN PR #51).
 - `min_final_cltv_expiry_delta` documented on `createInvoice`.
+- Apache-2.0 `LICENSE` file.
+- This `CHANGELOG.md` (Keep a Changelog format).
+
+### Changed
+- Peer-dep floors raised to the validated bindings: `^0.1.0-beta.11`
+  for `@utexo/rgb-lightning-node-bare` and `^0.1.0-beta.7` for
+  `@utexo/rgb-lightning-node-nodejs` — the versions this beta was
+  exercised against (47/59 Node E2E baseline, iOS sim parity on
+  iPhone 17 Pro Max).
+- README expanded to beta depth: install matrix, end-to-end example
+  with VSS + APay, security model section, troubleshooting.
 
 ## [0.1.0-alpha.2] — 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to `@utexo/wdk-rgb-lightning` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+while pre-`1.0`.
+
+## [Unreleased]
+
+### Added
+- LSP client surface (`LspClient`, `LnurlPay`, helpers) for routed
+  Lightning Address payments and RGB-over-LSP deposits.
+- `clearVssFence(password)` and VSS init options (`vssUrl`,
+  `vssAllowHttp`, `vssAllowEmptyRestore`) on the wallet manager.
+- `apayNew(hostNodeId)` for receiver-side async-payments (APay)
+  registration against an LSP (upstream RLN PR #51).
+- `min_final_cltv_expiry_delta` documented on `createInvoice`.
+
+## [0.1.0-alpha.2] — 2026-05-20
+
+### Added
+- Extended `IWalletAccount` surface to cover the full RLN method set
+  (PR #5).
+
+## [0.1.0-alpha.1] — 2026-05-20
+
+### Changed
+- Refactored the binding interface to support a Node target alongside
+  the Bare worklet target — same JS surface, two underlying addons.
+
+## [0.1.0-alpha.0] — 2026-05-13
+
+### Added
+- Initial WDK manager + account integration on top of
+  `rgb-lightning-node`'s external-signer path. Host owns the BIP-39
+  mnemonic; the binding derives a 32-byte BIP-32 seed and wires it
+  to `NativeExternalSigner`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -1,45 +1,73 @@
 # @utexo/wdk-rgb-lightning
 
-WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, swaps, hodl, RGB-over-LN.
+WDK module for RGB-over-Lightning, built on [`rgb-lightning-node`][rgb-lightning-node]
+(RLN) — channels, BOLT11 + RGB invoices, payments, hodl, atomic swaps,
+async payments (APay), and optional VSS cloud backup.
 
-Pairs with [`@utexo/wdk-wallet-rgb`](https://github.com/UTEXO-Protocol/wdk-wallet-rgb) for on-chain RGB. They share the same rgb-lib SQLite dataDir so on-chain views stay unified.
+Pairs with [`@utexo/wdk-wallet-rgb`][wdk-wallet-rgb] for the on-chain
+RGB side. They share the same `rgb-lib` SQLite `dataDir`, so on-chain
+balances and Lightning balances surface against the same asset records.
 
 ## Status
 
-Alpha skeleton. Layer A (rgb-lightning-node C-FFI) and Layer B
-(`@utexo/rgb-lightning-node-bare`) are in place; this Layer C module
-mirrors `wdk-wallet-rgb`'s structure and wires every method that doesn't
-need the upstream watch-only / external-signer rework. See the inline
-`✅ / 🚧 / ⏸` markers in `src/wallet-account-rgb-lightning.js` for the
-per-method status.
+**Beta.** External-signer integration is end-to-end validated on both
+Node and React Native (iPhone simulator, real-device builds via the
+[utexo-rgb-wdk-demo] showcase app). VSS cloud backup is wired and
+working on regtest. APay receiver-side registration (PR #51) is
+exposed but requires LSP-side support to complete the round trip.
+
+Per-method status markers (`✅ / 🚧 / ⏸`) live inline in
+`src/wallet-account-rgb-lightning.js`.
 
 ## Architecture
 
 ```
-@utexo/wdk-rgb-lightning              ← this package
-        │
-        ▼
-@utexo/rgb-lightning-node-bare        ← bare native addon
-        │
-        ▼
-rgb-lightning-node/bindings/c-ffi     ← Rust C-FFI (PR #25)
-        │
-        ▼
-LDK + tokio + rgb-lib
+@utexo/wdk-rgb-lightning                    ← this package (Layer C)
+       │                                       (WDK manager + account)
+       ▼
+[bare runtime]                  [Node runtime]
+@utexo/rgb-lightning-node-bare  @utexo/rgb-lightning-node-nodejs
+       │                                │
+       └──────────────┬─────────────────┘
+                      ▼
+   rgb-lightning-node/bindings/c-ffi      ← Rust C FFI (librlncffi.a)
+                      │
+                      ▼
+              LDK + tokio + rgb-lib
 ```
+
+The package exposes one entry per runtime through `exports`:
+
+- `import '@utexo/wdk-rgb-lightning'` from Node → `index-node.js`
+- `require('@utexo/wdk-rgb-lightning')` from a bare worklet (RN) →
+  `bare.js`
+
+Both paths re-export the same `WalletManagerRgbLightning` + account
+class; the only difference is the underlying binding selected at
+module-load.
+
+## Installation
+
+```sh
+npm install @utexo/wdk-rgb-lightning
+# plus the runtime-matching peer:
+npm install @utexo/rgb-lightning-node-nodejs   # Node host
+# or
+npm install @utexo/rgb-lightning-node-bare     # bare / RN host
+```
+
+Both bindings are declared as optional peer deps — install the one
+that matches your runtime.
 
 ## Why a separate module from `wdk-wallet-rgb`?
 
-`rgb-lightning-node` *owns* its seed today (LDK `KeysManager` derives
-from a stored mnemonic), which is incompatible with WDK's
+Historically RLN *owned* its seed (LDK `KeysManager` derived from a
+stored mnemonic), which is incompatible with WDK's
 secret-manager-owned-seed contract. Rather than fork the on-chain
-module to accommodate, we ship a separate LN-only module. The two
-share the same rgb-lib SQLite dataDir so balances stay unified.
-
-Once Roman's upstream RLN update lands (watch-only + `*Begin/*End` PSBT
-endpoints + remote-signer wrapper for `KeysManager`), the seed argument
-will be removed from `WalletManagerRgbLightning` and a `BareSigner`
-implementation will plug into the LDK signing path.
+module, we ship a separate LN-only module that uses the
+**external-signer** path (`NativeExternalSigner`) so the seed stays in
+the host. The two modules share the same `rgb-lib` SQLite `dataDir`,
+so on-chain views stay unified.
 
 ## Usage
 
@@ -49,10 +77,14 @@ import WalletManagerRgbLightning from '@utexo/wdk-rgb-lightning'
 const manager = new WalletManagerRgbLightning(seedPhrase, {
   network: 'regtest',
   dataDir: '/path/to/persistent/dir',
-  password: 'wallet-password'   // RLN-owned encryption key (TEMP)
+  // Optional VSS cloud backup — leave undefined to disable.
+  vssUrl: 'https://vss.example.com',
+  vssAllowHttp: false,
+  vssAllowEmptyRestore: false
 })
 
 const account = await manager.getAccount(0)
+
 await account.unlock({
   bitcoind_rpc_username: 'user',
   bitcoind_rpc_password: 'pass',
@@ -68,6 +100,7 @@ const info = await account.getNodeInfo()
 console.log(info.pubkey)
 
 await account.connectPeer('<pubkey>@<host>:<port>')
+
 const channel = await account.openChannel({
   peer_pubkey_and_addr: '<pubkey>@<host>:<port>',
   capacity_sat: 1_000_000,
@@ -83,14 +116,77 @@ const channel = await account.openChannel({
 const invoice = await account.createInvoice({
   amount_msat: 5000,
   expiry_sec: 3600,
-  description: 'test',
-  asset_id: undefined,
-  asset_amount: undefined
+  description: 'demo',
+  min_final_cltv_expiry_delta: 144
 })
+
+// Pay an invoice.
+await account.sendPayment({ invoice: '<bolt11>' })
+
+// Optional: register with an LSP as an async-payments recipient.
+await account.apayNew('<lsp-node-id-hex>')
 
 await manager.dispose()
 ```
 
+A more complete end-to-end example — including LSP wiring, RGB asset
+issuance over LN, and a regtest stack via Docker Compose — lives in
+[utexo-rgb-wdk-demo].
+
+## Security model
+
+- **Seed never leaves the host.** The mnemonic is owned by the WDK
+  secret manager. The binding derives a 32-byte BIP-32 entropy
+  (`seedHex`), passes it once to `NativeExternalSigner.create`, and
+  RLN persists only public identifying material (xpubs, node id,
+  master fingerprint) in its key-source file. Re-deriving from the
+  same mnemonic on the next launch reproduces the same `seedHex`,
+  matches the on-disk key-source, and keeps the LDK node identity
+  stable across restarts.
+- **All channel-state crypto runs in-process** through
+  [`vls-protocol-signer`][vls]. The VLS signer's lifecycle is tied to
+  the binding — it's destroyed on `manager.dispose()`.
+- **VSS payloads are client-side encrypted.** When `vssUrl` is set,
+  channel state and RGB wallet data are mirrored to the configured
+  VSS endpoint using XChaCha20-Poly1305, keyed via HKDF of a
+  signing key derived from the BIP-39 mnemonic (BIP-32 path
+  `m/535'/1'`). Recovery requires the original seed; the VSS server
+  sees only ciphertext.
+- **Plain `http://` is rejected by default.** Set `vssAllowHttp:
+  true` only for loopback / development use.
+
+## VSS recovery + fence takeover
+
+If a previous node crashed while holding the VSS ownership fence,
+restarts will fail with `Rln(VssFenceHeld)`. `account.clearVssFence(
+password)` forcibly takes over. Only call this when you're certain
+the previous owner is gone — pointing two live nodes at the same VSS
+store corrupts state.
+
+## Troubleshooting
+
+- **`Rln(Conflict)` on first launch after `unlock()` returned OK** —
+  expected on every re-launch after the initial wallet create. The
+  binding swallows this internally; if you see it bubble up, you're
+  calling the lower-level binding directly instead of going through
+  the WDK account.
+- **`Rln(FailedVssInit)`** — the VSS URL is unreachable or rejected
+  the auth challenge. Check `vssUrl` (https vs http) and network
+  reachability; for fence takeover see above.
+- **Port already in use on Metro / Expo launcher** — the default VSS
+  test server squats on port 8081 (Metro's default). Stop the local
+  VSS container before starting Metro, or move VSS to a different
+  port.
+- **Channels fail to open with a fresh node** — confirm bitcoind RPC
+  is reachable from inside the worklet's network sandbox; on regtest,
+  set `rpcallowip=127.0.0.1/32` so loopback connections are
+  accepted.
+
 ## License
 
-Apache-2.0
+Apache-2.0. See [`LICENSE`](./LICENSE).
+
+[rgb-lightning-node]: https://github.com/UTEXO-Protocol/rgb-lightning-node
+[wdk-wallet-rgb]: https://github.com/UTEXO-Protocol/wdk-wallet-rgb
+[utexo-rgb-wdk-demo]: https://github.com/UTEXO-Protocol/utexo-rgb-wdk-demo
+[vls]: https://gitlab.com/lightning-signer/validating-lightning-signer

--- a/index-bare.js
+++ b/index-bare.js
@@ -17,3 +17,20 @@ export default class WalletManagerRgbLightning extends WalletManagerBase {
 
 export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
 export { BareRgbLightningBinding } from './src/bare-binding.js'
+
+// LSP client surface — see ./src/lsp-client.js, lnurl-pay.js, lsp-helpers.js.
+// Pure-fetch implementations; work in Bare (via bare-fetch/global, already
+// installed by ./bare.js) and Node ≥18 (native fetch) without per-runtime
+// branches.
+export { LspClient, LspError } from './src/lsp-client.js'
+export {
+  LnurlPayError,
+  parseLightningAddress,
+  fetchDiscovery,
+  resolveAddressToInvoice
+} from './src/lnurl-pay.js'
+export {
+  payLightningAddress,
+  requestLspRgbDeposit,
+  payRgbViaLsp
+} from './src/lsp-helpers.js'

--- a/index-node.js
+++ b/index-node.js
@@ -19,3 +19,18 @@ export default class WalletManagerRgbLightning extends WalletManagerBase {
 
 export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
 export { NodeRgbLightningBinding } from './src/node-binding.js'
+
+// LSP client surface — see ./src/lsp-client.js, lnurl-pay.js, lsp-helpers.js.
+// Pure-fetch implementations; identical module under Bare (./index-bare.js).
+export { LspClient, LspError } from './src/lsp-client.js'
+export {
+  LnurlPayError,
+  parseLightningAddress,
+  fetchDiscovery,
+  resolveAddressToInvoice
+} from './src/lnurl-pay.js'
+export {
+  payLightningAddress,
+  requestLspRgbDeposit,
+  payRgbViaLsp
+} from './src/lsp-helpers.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-beta.1",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",
@@ -28,8 +28,8 @@
     "bip39": "3.1.0"
   },
   "peerDependencies": {
-    "@utexo/rgb-lightning-node-bare": "^0.1.0-beta.4",
-    "@utexo/rgb-lightning-node-nodejs": "^0.1.0-beta.0"
+    "@utexo/rgb-lightning-node-bare": "^0.1.0-beta.11",
+    "@utexo/rgb-lightning-node-nodejs": "^0.1.0-beta.7"
   },
   "peerDependenciesMeta": {
     "@utexo/rgb-lightning-node-bare": { "optional": true },

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -189,6 +189,23 @@ export class BareRgbLightningBinding {
   }
 
   /**
+   * Register this node with an LSP as an async-payments (APay) recipient.
+   * Used for offline-receive over Lightning Address — the wallet uploads
+   * a batch of pre-allocated payment hashes to the LSP, which then
+   * accepts payments addressed to those hashes on the wallet's behalf
+   * while the wallet is offline.
+   *
+   * @param {string} hostNodeId  - LSP's node_id (hex, 33-byte compressed secp256k1)
+   * @returns {object}  AsyncOrderNewResponse — request_id, host_node_id,
+   *   protocol_version, order_id, status, accepted_through_index,
+   *   next_index_expected, unused_hashes, refill_batch_size, first_hash_index
+   */
+  apayNew (hostNodeId) {
+    const node = this.node
+    return node.apayNew(hostNodeId)
+  }
+
+  /**
    * Register with an LSP as an APay (async-payments) recipient. The
    * wallet uploads a batch of pre-allocated payment hashes to the LSP;
    * the LSP then accepts Lightning payments addressed to those hashes

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -188,6 +188,22 @@ export class BareRgbLightningBinding {
     node.vssClearFence({ password })
   }
 
+  /**
+   * Register with an LSP as an APay (async-payments) recipient. The
+   * wallet uploads a batch of pre-allocated payment hashes to the LSP;
+   * the LSP then accepts Lightning payments addressed to those hashes
+   * on the wallet's behalf, even while the wallet is offline.
+   *
+   * @param {string} hostNodeId - the LSP's node_id (hex, compressed secp256k1)
+   * @returns {object} AsyncOrderNewResponse — request_id, host_node_id,
+   *   protocol_version, order_id, status, accepted_through_index,
+   *   next_index_expected, unused_hashes, refill_batch_size, first_hash_index
+   */
+  apayNew (hostNodeId) {
+    const node = this.ensureNode()
+    return node.apayNew(hostNodeId)
+  }
+
   /** Best-effort shutdown. Idempotent. */
   shutdown () {
     if (this._node) {

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -45,6 +45,9 @@ const {
  * @property {boolean} [permissiveSignerPolicy=true] - VLS policy filter;
  *   pass `false` to enforce the full simple policy. Defaults to
  *   permissive for in-process use.
+ * @property {string} [vssUrl]               - opt-in VSS cloud backup URL
+ * @property {boolean} [vssAllowHttp=false]  - allow http:// for non-loopback
+ * @property {boolean} [vssAllowEmptyRestore=false] - tolerate failed restore
  */
 
 /**
@@ -73,6 +76,11 @@ export class BareRgbLightningBinding {
       max_media_upload_size_mb: config.maxMediaUploadSizeMb ?? 5,
       enable_virtual_channels_v0: config.enableVirtualChannelsV0 ?? false
     }
+    // VSS fields are only forwarded when the host opts in. Omitting them
+    // lets the RLN-side `#[serde(default)]` keep VSS fully disabled.
+    if (config.vssUrl) this._initRequest.vss_url = config.vssUrl
+    if (config.vssAllowHttp) this._initRequest.vss_allow_http = true
+    if (config.vssAllowEmptyRestore) this._initRequest.vss_allow_empty_restore = true
     /** @type {SdkNode | null} */
     this._node = null
     /** @type {NativeExternalSigner | null} */
@@ -166,6 +174,18 @@ export class BareRgbLightningBinding {
       throw new Error('attachExternalSigner(seedHex) must be called before bootstrap()')
     }
     return this._signer.bootstrap()
+  }
+
+  /**
+   * Take over a stale VSS ownership fence after a previous node died
+   * holding it. Authenticates with the wallet password. Throws
+   * `Rln(FailedVssInit)` if VSS isn't configured or the takeover fails.
+   *
+   * @param {string} password
+   */
+  clearVssFence (password) {
+    const node = this.ensureNode()
+    node.vssClearFence({ password })
   }
 
   /** Best-effort shutdown. Idempotent. */

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -58,6 +58,13 @@
  *   used at unlock). Throws if VSS isn't configured. Pointing two
  *   live nodes at the same VSS store corrupts state — only call this
  *   when you're certain the previous owner is gone.
+ * @property {(hostNodeId: string) => object}           apayNew
+ *   Register this node with an LSP as an async-payments (APay) recipient.
+ *   Used for offline-receive over Lightning Address: the wallet uploads
+ *   a batch of pre-allocated payment hashes to the LSP, which then
+ *   accepts payments addressed to those hashes on the wallet's behalf
+ *   while the wallet is offline. Argument is the LSP's node_id (hex).
+ *   Returns the AsyncOrderNewResponse from upstream PR #51.
  * @property {() => void}                               shutdown
  *   Idempotent stop — releases the node handle + destroys the signer.
  */

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -20,6 +20,22 @@
  * @property {number}  [maxMediaUploadSizeMb=5]
  * @property {boolean} [enableVirtualChannelsV0=false]
  * @property {boolean} [permissiveSignerPolicy=true]
+ * @property {string}  [vssUrl]
+ *   Enables VSS cloud backup. Setting it points the node at a remote
+ *   key-value store that mirrors LDK channel state + RGB wallet data
+ *   in near-real-time. The encryption key is derived from the BIP-39
+ *   mnemonic, so recovery requires the original seed. Leave undefined
+ *   to disable VSS (default). Only `https://` URLs (or loopback http)
+ *   are accepted unless `vssAllowHttp` is set.
+ * @property {boolean} [vssAllowHttp=false]
+ *   Permit plain `http://` for non-loopback hosts. Off by default so
+ *   channel state can't be sent in plaintext to an untrusted server
+ *   by accident.
+ * @property {boolean} [vssAllowEmptyRestore=false]
+ *   On a fresh device, start with empty local state if the VSS
+ *   restore step fails (e.g. server unreachable). Off by default —
+ *   set true only when bootstrapping a new node from scratch and you
+ *   accept that any previously-backed-up state will not be pulled in.
  */
 
 /**
@@ -36,6 +52,12 @@
  *   The `SdkNode` handle (getter). Throws if `unlock()` has not run.
  * @property {() => object}                             bootstrap
  *   Returns the signer's bootstrap payload (node_id, xpubs, master_fp).
+ * @property {(password: string) => void}               clearVssFence
+ *   Forcibly take over a stale VSS ownership fence after the previous
+ *   node died holding it. Requires the wallet password (the same one
+ *   used at unlock). Throws if VSS isn't configured. Pointing two
+ *   live nodes at the same VSS store corrupts state — only call this
+ *   when you're certain the previous owner is gone.
  * @property {() => void}                               shutdown
  *   Idempotent stop — releases the node handle + destroys the signer.
  */

--- a/src/lnurl-pay.js
+++ b/src/lnurl-pay.js
@@ -1,0 +1,276 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Generic LUD-06 (Lightning Address) client. NOT utexo-lsp specific:
+// any LNURL-pay server that follows the spec works. We split this out
+// from LspClient so a wallet can pay an external Lightning Address
+// (e.g. `alice@getalby.com`) without any utexo-lsp knowledge.
+//
+// Spec references:
+//   https://github.com/lnurl/luds/blob/luds/16.md   (Lightning Address)
+//   https://github.com/lnurl/luds/blob/luds/06.md   (LNURL-pay)
+//
+// We deliberately do NOT verify the BOLT11 invoice's description-hash
+// matches the metadata here — that's the responsibility of the caller
+// once it decodes the invoice via the local RLN node. Doing it here
+// would force a duplicate bolt11 parser into this package.
+
+/**
+ * Thrown for malformed Lightning Addresses, malformed LUD-06 responses,
+ * or transport errors fetching the metadata / callback. HTTP failures
+ * carry `status` and `body`; programmer / protocol errors carry just
+ * the message.
+ */
+export class LnurlPayError extends Error {
+  constructor (message, { status = 0, body = '', cause } = {}) {
+    super(message)
+    this.name = 'LnurlPayError'
+    this.status = status
+    this.body = body
+    if (cause) this.cause = cause
+  }
+}
+
+/** Default request timeout for both discovery + callback fetches. */
+const DEFAULT_TIMEOUT_MS = 15_000
+
+/**
+ * Parse `user@host` (case-insensitive on the host part, lowercase on
+ * the local-part per LUD-16). Returns the canonical components plus
+ * the discovery URL the wallet should fetch.
+ *
+ * `allowHttp` defaults to false for safety. We auto-allow http for
+ * loopback hosts (`localhost`, `127.0.0.1`, `[::1]`, `*.local`) since
+ * those are almost always dev/regtest. `.onion` per LUD-16 always uses
+ * http.
+ *
+ * @param {string} addr
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowHttp]
+ * @returns {{ username:string, host:string, discoveryUrl:string }}
+ */
+export function parseLightningAddress (addr, opts = {}) {
+  if (typeof addr !== 'string' || addr.length === 0) {
+    throw new LnurlPayError('parseLightningAddress: address required')
+  }
+  const at = addr.lastIndexOf('@')
+  if (at <= 0 || at === addr.length - 1) {
+    throw new LnurlPayError(`parseLightningAddress: malformed address '${addr}'`)
+  }
+  // LUD-16 §spec normalises the local-part to lowercase. The host is
+  // already case-insensitive at the DNS layer; we lowercase too so the
+  // discovery URL is stable.
+  const username = addr.slice(0, at).toLowerCase()
+  const host = addr.slice(at + 1).toLowerCase()
+  if (!/^[a-z0-9._+-]+$/.test(username)) {
+    throw new LnurlPayError(`parseLightningAddress: invalid local-part '${username}'`)
+  }
+  if (!/^[a-z0-9.[\]:_-]+$/.test(host)) {
+    throw new LnurlPayError(`parseLightningAddress: invalid host '${host}'`)
+  }
+  const scheme = pickScheme(host, opts.allowHttp === true)
+  const discoveryUrl = `${scheme}://${host}/.well-known/lnurlp/${encodeURIComponent(username)}`
+  return { username, host, discoveryUrl }
+}
+
+function pickScheme (host, allowHttp) {
+  if (host.endsWith('.onion')) return 'http'
+  if (isLoopback(host)) return 'http'
+  return allowHttp ? 'http' : 'https'
+}
+
+function isLoopback (host) {
+  // Strip port if present (`[::1]:8080`, `127.0.0.1:8080`, `localhost:8080`).
+  const noPort = host.replace(/:\d+$/, '').replace(/^\[(.+)\]$/, '$1')
+  return noPort === 'localhost' ||
+    noPort === '127.0.0.1' ||
+    noPort === '::1' ||
+    noPort.endsWith('.local') ||
+    noPort.endsWith('.localhost')
+}
+
+/**
+ * Fetch the LUD-06 discovery document for an address. Returns the
+ * server's response verbatim (no schema validation beyond shape). The
+ * caller is expected to honour `minSendable` / `maxSendable` and
+ * compute `metadata` hash from the returned `metadata` string when
+ * checking the invoice's description-hash anchor.
+ *
+ * @param {string} addr Lightning Address (`user@host`) OR a full URL
+ *                      to a `/.well-known/lnurlp/<user>` endpoint
+ *                      (useful for `LspClient.lnurlDiscovery` callers
+ *                      who already have an LSP URL).
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetch]
+ * @param {number} [opts.timeoutMs]
+ * @param {boolean} [opts.allowHttp]
+ */
+export async function fetchDiscovery (addr, opts = {}) {
+  const fetcher = opts.fetch ?? globalThis.fetch
+  if (typeof fetcher !== 'function') {
+    throw new LnurlPayError('fetchDiscovery: no global fetch; pass opts.fetch')
+  }
+  const url = addr.startsWith('http://') || addr.startsWith('https://')
+    ? addr
+    : parseLightningAddress(addr, opts).discoveryUrl
+
+  const data = await fetchJson(fetcher, url, {
+    signal: timeoutSignal(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  })
+  validateDiscovery(data, url)
+  return /** @type {LnurlPayDiscovery} */ (data)
+}
+
+/**
+ * Resolve a Lightning Address to a BOLT11 invoice for `amountMsat`.
+ * Returns `{ pr, routes, discovery, callbackUrl }` — the wallet pays
+ * `pr` through its local RLN node. `discovery` is included so callers
+ * can verify the description-hash anchor against the returned invoice
+ * after decoding it.
+ *
+ * @param {string} addr
+ * @param {bigint|number|string} amountMsat
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetch]
+ * @param {number} [opts.timeoutMs]
+ * @param {boolean} [opts.allowHttp]
+ * @param {string} [opts.comment]   LUD-12 comment (server-policy gated).
+ * @returns {Promise<{ pr:string, routes:Array, discovery:LnurlPayDiscovery, callbackUrl:string }>}
+ */
+export async function resolveAddressToInvoice (addr, amountMsat, opts = {}) {
+  const fetcher = opts.fetch ?? globalThis.fetch
+  if (typeof fetcher !== 'function') {
+    throw new LnurlPayError('resolveAddressToInvoice: no global fetch; pass opts.fetch')
+  }
+
+  const discovery = await fetchDiscovery(addr, opts)
+  const amount = toIntString(amountMsat, 'amountMsat')
+  enforceRange(amount, discovery)
+
+  const callbackUrl = appendQuery(discovery.callback, {
+    amount,
+    ...(opts.comment ? { comment: opts.comment } : {})
+  })
+
+  const data = await fetchJson(fetcher, callbackUrl, {
+    signal: timeoutSignal(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  })
+  if (data.status === 'ERROR') {
+    throw new LnurlPayError(`LUD-06 callback rejected: ${data.reason ?? 'no reason'}`, {
+      status: 200,
+      body: JSON.stringify(data)
+    })
+  }
+  if (typeof data.pr !== 'string' || data.pr.length === 0) {
+    throw new LnurlPayError(`LUD-06 callback missing 'pr': ${truncate(JSON.stringify(data))}`)
+  }
+  return {
+    pr: data.pr,
+    routes: Array.isArray(data.routes) ? data.routes : [],
+    discovery,
+    callbackUrl
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function fetchJson (fetcher, url, init) {
+  let res
+  try {
+    res = await fetcher(url, { ...init, headers: { Accept: 'application/json', ...(init?.headers ?? {}) } })
+  } catch (cause) {
+    throw new LnurlPayError(`fetch failed for ${url}`, { cause })
+  }
+  const text = await res.text()
+  if (!res.ok) {
+    throw new LnurlPayError(`HTTP ${res.status} from ${url}`, { status: res.status, body: text.trim() })
+  }
+  try {
+    return JSON.parse(text)
+  } catch (cause) {
+    throw new LnurlPayError(`invalid JSON from ${url}: ${truncate(text)}`, { status: res.status, body: text, cause })
+  }
+}
+
+function validateDiscovery (data, url) {
+  if (data == null || typeof data !== 'object') {
+    throw new LnurlPayError(`LUD-06 discovery from ${url} is not an object`)
+  }
+  if (data.status === 'ERROR') {
+    throw new LnurlPayError(`LUD-06 discovery rejected: ${data.reason ?? 'no reason'}`)
+  }
+  if (data.tag !== 'payRequest') {
+    throw new LnurlPayError(`LUD-06 discovery: expected tag='payRequest', got '${data.tag}'`)
+  }
+  if (typeof data.callback !== 'string' || !/^https?:\/\//i.test(data.callback)) {
+    throw new LnurlPayError(`LUD-06 discovery: invalid callback '${data.callback}'`)
+  }
+  const min = numOrNull(data.minSendable)
+  const max = numOrNull(data.maxSendable)
+  if (min == null || max == null || min > max || min <= 0) {
+    throw new LnurlPayError(`LUD-06 discovery: invalid sendable range min=${data.minSendable} max=${data.maxSendable}`)
+  }
+  if (typeof data.metadata !== 'string') {
+    throw new LnurlPayError('LUD-06 discovery: missing metadata string')
+  }
+}
+
+function enforceRange (amountStr, d) {
+  // Compare as BigInt to avoid 2^53 truncation on large msat values.
+  const amount = BigInt(amountStr)
+  if (amount < BigInt(d.minSendable) || amount > BigInt(d.maxSendable)) {
+    throw new LnurlPayError(`amount ${amountStr} outside server range [${d.minSendable}, ${d.maxSendable}]`)
+  }
+}
+
+function appendQuery (url, params) {
+  const sep = url.includes('?') ? '&' : '?'
+  const enc = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) enc.set(k, String(v))
+  return `${url}${sep}${enc.toString()}`
+}
+
+function toIntString (v, field) {
+  if (typeof v === 'bigint') {
+    if (v < 0n) throw new LnurlPayError(`${field} must be ≥ 0`)
+    return v.toString()
+  }
+  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) return Math.trunc(v).toString()
+  if (typeof v === 'string' && /^\d+$/.test(v)) return v
+  throw new LnurlPayError(`${field} must be a non-negative integer`)
+}
+
+function numOrNull (v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string' && /^\d+$/.test(v)) return Number(v)
+  return null
+}
+
+function timeoutSignal (ms) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(ms)
+  }
+  if (typeof AbortController !== 'undefined') {
+    const ctrl = new AbortController()
+    setTimeout(() => ctrl.abort(new Error(`LNURL request timed out after ${ms}ms`)), ms).unref?.()
+    return ctrl.signal
+  }
+  return undefined
+}
+
+function truncate (s) { return s.length > 200 ? s.slice(0, 197) + '…' : s }
+
+/**
+ * @typedef {object} LnurlPayDiscovery
+ * @property {'payRequest'} tag
+ * @property {string} callback
+ * @property {number|string} minSendable
+ * @property {number|string} maxSendable
+ * @property {string} metadata             JSON string per LUD-06.
+ * @property {number|string} [commentAllowed]
+ */

--- a/src/lsp-client.js
+++ b/src/lsp-client.js
@@ -1,0 +1,292 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Thin typed wrapper around utexo-lsp's HTTP API. Side-effect free:
+// methods build URLs, send JSON, validate response status, and return
+// parsed JSON DTOs. Anything that combines an LSP call with a local
+// daemon call (e.g. "pay this LSP-issued invoice via our own RLN")
+// lives in lsp-helpers.js, not here.
+//
+// Bare + Node both supply WHATWG `fetch` globally: in Bare via
+// bare-fetch/global (pulled in by `bare-node-runtime/global` from
+// ./bare.js); in Node 18+ natively. We accept an optional `fetch`
+// override for tests and proxy scenarios but default to the global so
+// the common case stays one-liner constructible.
+
+/**
+ * Error thrown for non-2xx responses or transport failures from the
+ * LSP. Carries the endpoint path, HTTP status (0 for transport errors)
+ * and the raw response body so callers can map specific failures
+ * (e.g. 400 from /onchain_send when an asset is outside the LSP's
+ * allowlist) without re-parsing the message string.
+ */
+export class LspError extends Error {
+  constructor (endpoint, status, body, cause) {
+    const head = `LSP ${endpoint}`
+    const msg = status
+      ? `${head} → HTTP ${status}: ${body}`
+      : `${head} → ${cause?.message ?? 'request failed'}`
+    super(msg)
+    this.name = 'LspError'
+    this.endpoint = endpoint
+    this.status = status
+    this.body = body
+    if (cause) this.cause = cause
+  }
+}
+
+/** Default request timeout if the caller doesn't override. */
+const DEFAULT_TIMEOUT_MS = 15_000
+
+/** Max response body we'll buffer (1 MiB). Mirrors the LSP's own cap. */
+const MAX_RESPONSE_BYTES = 1 << 20
+
+export class LspClient {
+  /**
+   * @param {object} opts
+   * @param {string} opts.baseUrl       Origin of the LSP API, e.g. `https://lsp.utexo.io`.
+   *                                    Trailing slash optional; we normalise.
+   * @param {number} [opts.timeoutMs]   Per-request timeout. Default 15 s.
+   * @param {typeof fetch} [opts.fetch] Override the global `fetch` (testing / proxies).
+   * @param {Record<string,string>} [opts.defaultHeaders]
+   *                                    Headers merged into every request. Useful for
+   *                                    operator-provided API keys once the LSP grows them.
+   */
+  constructor ({ baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, fetch: fetchImpl, defaultHeaders } = {}) {
+    if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+      throw new TypeError('LspClient: baseUrl is required')
+    }
+    const fetcher = fetchImpl ?? globalThis.fetch
+    if (typeof fetcher !== 'function') {
+      throw new TypeError('LspClient: no fetch available; pass opts.fetch or run in an environment that exposes global fetch (Bare via bare-fetch/global, Node ≥18)')
+    }
+    this._base = baseUrl.replace(/\/+$/, '')
+    this._timeoutMs = Math.max(1, Number(timeoutMs) || DEFAULT_TIMEOUT_MS)
+    this._fetch = fetcher
+    this._headers = { ...(defaultHeaders ?? {}) }
+  }
+
+  get baseUrl () { return this._base }
+
+  /** Liveness probe. Cheap; safe to call every few seconds. */
+  health () { return this._req('GET', '/health') }
+
+  /** Returns the LSP's view of its upstream RLN node (pubkey, channel summary, etc). */
+  getInfo () { return this._req('GET', '/get_info') }
+
+  /**
+   * LUD-06 discovery for a Lightning Address hosted by this LSP.
+   * @param {string} username The local-part of `user@host` (no '@', no host).
+   */
+  lnurlDiscovery (username) {
+    if (!isNonEmptyString(username)) throw new TypeError('LspClient.lnurlDiscovery: username required')
+    return this._req('GET', `/.well-known/lnurlp/${encodeURIComponent(username)}`)
+  }
+
+  /**
+   * LUD-06 callback. Returns `{ pr, routes }`. The wallet pays `pr`
+   * through its own RLN node.
+   * @param {string} username
+   * @param {bigint|number|string} amountMsat
+   * @param {object} [opts]
+   * @param {string} [opts.assetId]     Optional RGB asset filter the LSP may honour.
+   * @param {bigint|number|string} [opts.assetAmount] Optional RGB amount.
+   */
+  lnurlCallback (username, amountMsat, opts = {}) {
+    if (!isNonEmptyString(username)) throw new TypeError('LspClient.lnurlCallback: username required')
+    const params = new URLSearchParams()
+    params.set('amount', toIntString(amountMsat, 'amountMsat'))
+    if (opts.assetId !== undefined) params.set('asset_id', String(opts.assetId))
+    if (opts.assetAmount !== undefined) params.set('asset_amount', toIntString(opts.assetAmount, 'assetAmount'))
+    return this._req('GET', `/pay/callback/${encodeURIComponent(username)}?${params.toString()}`)
+  }
+
+  /**
+   * Bridge: caller hands the LSP an RGB invoice + LN-side parameters;
+   * the LSP returns a BOLT11 invoice for the caller to pay. Once paid,
+   * the LSP runs `sendrgb` to the recipient embedded in the RGB
+   * invoice. Caller monitors completion via its own RLN node.
+   *
+   * @param {object} params
+   * @param {string} params.rgbInvoice
+   * @param {object} params.ln
+   * @param {bigint|number} params.ln.amtMsat
+   * @param {number} params.ln.expirySec
+   * @param {string} [params.ln.assetId]
+   * @param {bigint|number} [params.ln.assetAmount]
+   * @param {string} [params.ln.descriptionHash]
+   * @param {string} [params.ln.paymentHash]
+   * @param {number} [params.ln.minFinalCltvExpiryDelta]
+   * @returns {Promise<{rgb_invoice:string, ln_invoice:string, mapping_id:number}>}
+   */
+  onchainSend ({ rgbInvoice, ln } = {}) {
+    if (!isNonEmptyString(rgbInvoice)) throw new TypeError('LspClient.onchainSend: rgbInvoice required')
+    if (!ln || typeof ln !== 'object') throw new TypeError('LspClient.onchainSend: ln params required')
+    const body = {
+      rgb_invoice: rgbInvoice,
+      lninvoice: snakeCaseLnParams(ln)
+    }
+    return this._req('POST', '/onchain_send', body)
+  }
+
+  /**
+   * Bridge: caller hands the LSP a BOLT11 invoice + RGB-side
+   * parameters; the LSP returns an RGB invoice. The caller shares the
+   * RGB invoice with their sender; once the RGB transfer settles, the
+   * LSP pays the BOLT11 invoice. Caller monitors completion via its
+   * own RLN node's invoice status.
+   *
+   * @param {object} params
+   * @param {string} params.lnInvoice
+   * @param {object} params.rgb
+   * @param {string} params.rgb.assetId
+   * @param {string} [params.rgb.assignment]   default 'Any'
+   * @param {number} [params.rgb.durationSeconds]
+   * @param {number} [params.rgb.minConfirmations] Backend-controlled; LSP may ignore.
+   * @param {boolean} [params.rgb.witness]     default false
+   * @returns {Promise<{ln_invoice:string, rgb_invoice:string, mapping_id:number}>}
+   */
+  lightningReceive ({ lnInvoice, rgb } = {}) {
+    if (!isNonEmptyString(lnInvoice)) throw new TypeError('LspClient.lightningReceive: lnInvoice required')
+    if (!rgb || typeof rgb !== 'object') throw new TypeError('LspClient.lightningReceive: rgb params required')
+    if (!isNonEmptyString(rgb.assetId)) throw new TypeError('LspClient.lightningReceive: rgb.assetId required')
+    const body = {
+      ln_invoice: lnInvoice,
+      rgb_invoice: snakeCaseRgbParams(rgb)
+    }
+    return this._req('POST', '/lightning_receive', body)
+  }
+
+  // ---------------------------------------------------------------------------
+
+  async _req (method, path, body) {
+    const url = `${this._base}${path}`
+    const init = {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...this._headers
+      },
+      signal: this._timeoutSignal()
+    }
+    if (body !== undefined && body !== null) {
+      init.headers['Content-Type'] = 'application/json'
+      init.body = JSON.stringify(body)
+    }
+
+    let res
+    try {
+      res = await this._fetch(url, init)
+    } catch (cause) {
+      throw new LspError(path, 0, '', cause)
+    }
+
+    // Read at most MAX_RESPONSE_BYTES. WHATWG Response doesn't expose a
+    // hard byte cap, so we accept the body in full but reject anything
+    // suspiciously large. Avoids OOM on a misconfigured LSP that
+    // returns megabytes of HTML.
+    const text = await res.text()
+    if (text.length > MAX_RESPONSE_BYTES) {
+      throw new LspError(path, res.status, `response too large (${text.length} bytes)`)
+    }
+
+    if (!res.ok) {
+      throw new LspError(path, res.status, text.trim())
+    }
+    if (text.length === 0) return null
+    try {
+      return JSON.parse(text)
+    } catch (cause) {
+      throw new LspError(path, res.status, `invalid JSON: ${text.slice(0, 200)}`, cause)
+    }
+  }
+
+  /**
+   * `AbortSignal.timeout()` is supported in Bare (via bare-abort-controller)
+   * and Node ≥17. Falls back to a manually plumbed AbortController for
+   * older runtimes — keeps the package portable without bumping the
+   * `engines.node` floor.
+   */
+  _timeoutSignal () {
+    if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+      return AbortSignal.timeout(this._timeoutMs)
+    }
+    if (typeof AbortController !== 'undefined') {
+      const ctrl = new AbortController()
+      setTimeout(() => ctrl.abort(new Error(`LSP request timed out after ${this._timeoutMs}ms`)), this._timeoutMs).unref?.()
+      return ctrl.signal
+    }
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shape adapters
+// ---------------------------------------------------------------------------
+
+function snakeCaseLnParams (ln) {
+  const out = {}
+  if (ln.amtMsat !== undefined) out.amt_msat = toUint64Json(ln.amtMsat, 'ln.amtMsat')
+  if (ln.expirySec !== undefined) out.expiry_sec = toUint32(ln.expirySec, 'ln.expirySec')
+  if (ln.assetId !== undefined) out.asset_id = String(ln.assetId)
+  if (ln.assetAmount !== undefined) out.asset_amount = toUint64Json(ln.assetAmount, 'ln.assetAmount')
+  if (ln.descriptionHash !== undefined) out.description_hash = String(ln.descriptionHash)
+  if (ln.paymentHash !== undefined) out.payment_hash = String(ln.paymentHash)
+  if (ln.minFinalCltvExpiryDelta !== undefined) {
+    out.min_final_cltv_expiry_delta = toUint32(ln.minFinalCltvExpiryDelta, 'ln.minFinalCltvExpiryDelta')
+  }
+  return out
+}
+
+function snakeCaseRgbParams (rgb) {
+  const out = {
+    asset_id: rgb.assetId,
+    min_confirmations: rgb.minConfirmations !== undefined ? toUint32(rgb.minConfirmations, 'rgb.minConfirmations') : 1,
+    witness: !!rgb.witness
+  }
+  if (rgb.assignment !== undefined) out.assignment = String(rgb.assignment)
+  if (rgb.durationSeconds !== undefined) out.duration_seconds = toUint32(rgb.durationSeconds, 'rgb.durationSeconds')
+  return out
+}
+
+function isNonEmptyString (v) {
+  return typeof v === 'string' && v.length > 0
+}
+
+function toIntString (v, field) {
+  if (typeof v === 'bigint' && v >= 0n) return v.toString()
+  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) return Math.trunc(v).toString()
+  if (typeof v === 'string' && /^\d+$/.test(v)) return v
+  throw new TypeError(`${field} must be a non-negative integer`)
+}
+
+/**
+ * The Go side uses uint64 fields. JS numbers lose precision above 2^53.
+ * Emit bigint values as numeric JSON (rgb-lightning-node accepts both
+ * 1234 and "1234" but we prefer numeric for amt_msat to match the
+ * canonical shape). For values above 2^53 we drop to strings — RLN
+ * tolerates this on amt_msat (see daemon JsonLnInvoiceRequest).
+ */
+function toUint64Json (v, field) {
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v) || v < 0) throw new TypeError(`${field} must be ≥ 0`)
+    return Math.trunc(v)
+  }
+  if (typeof v === 'bigint') {
+    if (v < 0n) throw new TypeError(`${field} must be ≥ 0`)
+    return v <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(v) : v.toString()
+  }
+  if (typeof v === 'string' && /^\d+$/.test(v)) return v
+  throw new TypeError(`${field} must be a non-negative integer`)
+}
+
+function toUint32 (v, field) {
+  const n = typeof v === 'bigint' ? Number(v) : Number(v)
+  if (!Number.isFinite(n) || n < 0 || n > 0xffffffff || !Number.isInteger(n)) {
+    throw new TypeError(`${field} must fit in uint32`)
+  }
+  return n
+}

--- a/src/lsp-helpers.js
+++ b/src/lsp-helpers.js
@@ -1,0 +1,168 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Higher-level orchestration on top of LspClient and LnurlPay. These
+// helpers take an "account-like" object — anything that exposes
+// `sendPayment`, `lnInvoice` / `createInvoice`, `decodeLnInvoice` —
+// so they work standalone or, via the small thunks in
+// wallet-account-rgb-lightning.js, as account instance methods.
+//
+// All three helpers return plain DTOs. None of them poll for
+// completion: the LSP runs an internal cron and the wallet monitors
+// final state through its own RLN node (e.g. account.getInvoiceStatus).
+
+import { LspClient } from './lsp-client.js'
+import { resolveAddressToInvoice } from './lnurl-pay.js'
+
+/**
+ * Pay a Lightning Address end-to-end.
+ *
+ * 1. Resolve `addr` via LUD-06 (server-agnostic — works for
+ *    `alice@getalby.com`, not just utexo-lsp Lightning Addresses).
+ * 2. Hand the returned BOLT11 invoice to the account's `sendPayment`.
+ *
+ * @param {object} account                  Anything with `sendPayment({ invoice })`.
+ * @param {string} addr                     `user@host` Lightning Address.
+ * @param {bigint|number|string} amountMsat
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetch]
+ * @param {number} [opts.timeoutMs]
+ * @param {boolean} [opts.allowHttp]        Allow http on non-loopback hosts (regtest).
+ * @param {string} [opts.comment]           LUD-12 comment.
+ * @param {boolean} [opts.skipAmount]       Don't pass `amt_msat` to sendPayment.
+ * @param {(invoice:string, discovery:object) => void|Promise<void>} [opts.beforePay]
+ *                                          Hook to inspect the LSP-issued invoice
+ *                                          before paying (e.g. to verify the
+ *                                          description-hash anchor against
+ *                                          discovery.metadata).
+ * @returns {Promise<{ invoice:string, sendResult:any, discovery:object, callbackUrl:string }>}
+ */
+export async function payLightningAddress (account, addr, amountMsat, opts = {}) {
+  if (account == null || typeof account.sendPayment !== 'function') {
+    throw new TypeError('payLightningAddress: account.sendPayment(request) required')
+  }
+  const { pr, discovery, callbackUrl } = await resolveAddressToInvoice(addr, amountMsat, opts)
+  if (typeof opts.beforePay === 'function') await opts.beforePay(pr, discovery)
+  const req = opts.skipAmount ? { invoice: pr } : { invoice: pr, amt_msat: toUint64(amountMsat) }
+  const sendResult = await account.sendPayment(req)
+  return { invoice: pr, sendResult, discovery, callbackUrl }
+}
+
+/**
+ * Request the LSP to act as the LN-payer for an RGB transfer the
+ * wallet wants to receive.
+ *
+ * Flow:
+ *   1. Wallet creates a BOLT11 invoice on its own RLN node (if not
+ *      already supplied).
+ *   2. Wallet posts the BOLT11 + RGB params to the LSP.
+ *   3. LSP returns an RGB invoice. Wallet shares with sender.
+ *   4. Sender pays the RGB invoice → LSP settles, then pays the
+ *      wallet's BOLT11 invoice. Wallet observes completion via
+ *      `account.getInvoiceStatus(lnInvoice)`.
+ *
+ * @param {object} account
+ * @param {object} args
+ * @param {string|LspClient} args.lsp           LSP base URL or pre-built client.
+ * @param {string} [args.lnInvoice]             Existing BOLT11 invoice; if omitted, we mint one via account.
+ * @param {object} [args.lnInvoiceRequest]      Override for the lnInvoice mint call. Required if lnInvoice omitted.
+ * @param {object} args.rgb                     RGB params (assetId, assignment, durationSeconds, witness).
+ * @param {object} [args.lspOpts]               Forwarded to new LspClient if lsp is a string.
+ * @returns {Promise<{ lnInvoice:string, rgbInvoice:string, mappingId:number }>}
+ */
+export async function requestLspRgbDeposit (account, { lsp, lnInvoice, lnInvoiceRequest, rgb, lspOpts } = {}) {
+  if (account == null) throw new TypeError('requestLspRgbDeposit: account required')
+  if (rgb == null || typeof rgb !== 'object') throw new TypeError('requestLspRgbDeposit: rgb params required')
+  const client = asLspClient(lsp, lspOpts)
+
+  let invoice = lnInvoice
+  if (!invoice) {
+    if (lnInvoiceRequest == null) {
+      throw new TypeError('requestLspRgbDeposit: provide either args.lnInvoice or args.lnInvoiceRequest')
+    }
+    const minter = pickInvoiceMinter(account)
+    const minted = await minter(lnInvoiceRequest)
+    invoice = typeof minted === 'string' ? minted : minted?.invoice
+    if (typeof invoice !== 'string') {
+      throw new Error(`requestLspRgbDeposit: account invoice mint returned no invoice: ${truncate(JSON.stringify(minted))}`)
+    }
+  }
+
+  const res = await client.lightningReceive({ lnInvoice: invoice, rgb })
+  return {
+    lnInvoice: res.ln_invoice,
+    rgbInvoice: res.rgb_invoice,
+    mappingId: res.mapping_id
+  }
+}
+
+/**
+ * Pay an RGB invoice via the LSP-mediated bridge. The LSP issues a
+ * BOLT11 invoice for an equivalent LN amount; the wallet pays it
+ * locally; the LSP runs `sendrgb` to the recipient embedded in the
+ * RGB invoice once the LN payment settles.
+ *
+ * Caller is responsible for `ln.amtMsat` / `ln.expirySec` — the LSP
+ * does not auto-quote.
+ *
+ * @param {object} account
+ * @param {object} args
+ * @param {string|LspClient} args.lsp
+ * @param {string} args.rgbInvoice
+ * @param {object} args.ln                 `{ amtMsat, expirySec, assetId?, assetAmount?, … }`
+ * @param {object} [args.lspOpts]
+ * @returns {Promise<{ lnInvoice:string, rgbInvoice:string, mappingId:number, sendResult:any }>}
+ */
+export async function payRgbViaLsp (account, { lsp, rgbInvoice, ln, lspOpts } = {}) {
+  if (account == null || typeof account.sendPayment !== 'function') {
+    throw new TypeError('payRgbViaLsp: account.sendPayment required')
+  }
+  if (typeof rgbInvoice !== 'string' || rgbInvoice.length === 0) {
+    throw new TypeError('payRgbViaLsp: rgbInvoice required')
+  }
+  if (ln == null) throw new TypeError('payRgbViaLsp: ln params required')
+
+  const client = asLspClient(lsp, lspOpts)
+  const issued = await client.onchainSend({ rgbInvoice, ln })
+  const sendResult = await account.sendPayment({ invoice: issued.ln_invoice })
+
+  return {
+    lnInvoice: issued.ln_invoice,
+    rgbInvoice: issued.rgb_invoice,
+    mappingId: issued.mapping_id,
+    sendResult
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function asLspClient (lsp, lspOpts) {
+  if (lsp instanceof LspClient) return lsp
+  if (typeof lsp === 'string' && lsp.length > 0) return new LspClient({ baseUrl: lsp, ...(lspOpts ?? {}) })
+  throw new TypeError('lsp must be an LspClient or a base URL string')
+}
+
+/**
+ * The account exposes `createInvoice` (our naming convention) and the
+ * underlying daemon also accepts `lnInvoice`. Support both so callers
+ * don't have to remember which name the account has.
+ */
+function pickInvoiceMinter (account) {
+  if (typeof account.createInvoice === 'function') return account.createInvoice.bind(account)
+  if (typeof account.lnInvoice === 'function') return account.lnInvoice.bind(account)
+  throw new TypeError('requestLspRgbDeposit: account must expose createInvoice or lnInvoice')
+}
+
+function toUint64 (v) {
+  if (typeof v === 'bigint') return v <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(v) : v.toString()
+  if (typeof v === 'number') return Math.trunc(v)
+  if (typeof v === 'string' && /^\d+$/.test(v)) return v
+  throw new TypeError(`amountMsat must be a non-negative integer; got ${typeof v}`)
+}
+
+function truncate (s) { return s.length > 200 ? s.slice(0, 197) + '…' : s }

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -118,6 +118,17 @@ export class NodeRgbLightningBinding {
   }
 
   /**
+   * Register this node with an LSP as an async-payments (APay) recipient.
+   *
+   * @param {string} hostNodeId  - LSP's node_id (hex)
+   * @returns {object}  AsyncOrderNewResponse from upstream PR #51
+   */
+  apayNew (hostNodeId) {
+    const node = this.node
+    return node.apayNew(hostNodeId)
+  }
+
+  /**
    * Register with an LSP as an APay (async-payments) recipient. See
    * BareRgbLightningBinding.apayNew for the full contract.
    *

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -36,6 +36,11 @@ export class NodeRgbLightningBinding {
       max_media_upload_size_mb: config.maxMediaUploadSizeMb ?? 5,
       enable_virtual_channels_v0: config.enableVirtualChannelsV0 ?? false
     }
+    // VSS fields are only forwarded when the host opts in. Omitting them
+    // lets the RLN-side `#[serde(default)]` keep VSS fully disabled.
+    if (config.vssUrl) this._initRequest.vss_url = config.vssUrl
+    if (config.vssAllowHttp) this._initRequest.vss_allow_http = true
+    if (config.vssAllowEmptyRestore) this._initRequest.vss_allow_empty_restore = true
     /** @type {unknown | null} */
     this._node = null
     /** @type {unknown | null} */
@@ -98,6 +103,18 @@ export class NodeRgbLightningBinding {
       throw new Error('attachExternalSigner(seedHex) must be called before bootstrap()')
     }
     return this._signer.bootstrap()
+  }
+
+  /**
+   * Take over a stale VSS ownership fence after a previous node died
+   * holding it. Authenticates with the wallet password. Throws
+   * `Rln(FailedVssInit)` if VSS isn't configured or the takeover fails.
+   *
+   * @param {string} password
+   */
+  clearVssFence (password) {
+    const node = this.ensureNode()
+    node.vssClearFence({ password })
   }
 
   shutdown () {

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -117,6 +117,18 @@ export class NodeRgbLightningBinding {
     node.vssClearFence({ password })
   }
 
+  /**
+   * Register with an LSP as an APay (async-payments) recipient. See
+   * BareRgbLightningBinding.apayNew for the full contract.
+   *
+   * @param {string} hostNodeId
+   * @returns {object} AsyncOrderNewResponse
+   */
+  apayNew (hostNodeId) {
+    const node = this.ensureNode()
+    return node.apayNew(hostNodeId)
+  }
+
   shutdown () {
     if (this._node) {
       this._node.shutdown()

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -10,6 +10,13 @@
 /** @typedef {import('@tetherto/wdk-wallet').TransferOptions} TransferOptions */
 /** @typedef {import('@tetherto/wdk-wallet').TransferResult} TransferResult */
 /** @typedef {import('./bare-binding.js').BareRgbLightningBinding} BareRgbLightningBinding */
+/** @typedef {import('./lsp-client.js').LspClient} LspClient */
+
+import {
+  payLightningAddress as _payLightningAddress,
+  requestLspRgbDeposit as _requestLspRgbDeposit,
+  payRgbViaLsp as _payRgbViaLsp
+} from './lsp-helpers.js'
 
 /**
  * Sentinel placeholder address returned by `getAddress()` before the
@@ -652,6 +659,37 @@ export default class WalletAccountRgbLightning {
       return DEFAULT_FEE_RATE_SAT_PER_VB
     }
   }
+
+  // ==========================================================================
+  // LSP integration — utexo-lsp (or any LUD-06 / utexo-lsp-compatible server)
+  // ==========================================================================
+  // Thin pass-throughs to ./lsp-helpers.js so callers can do
+  //   await account.payLightningAddress('alice@lsp.example', 5_000_000n)
+  // without importing the helpers module. The helpers are also
+  // exported standalone for advanced callers that prefer functional
+  // composition over instance methods (e.g. for read-only accounts).
+
+  /**
+   * Pay a Lightning Address (LUD-06). Works against any LNURL-pay
+   * server, including but not limited to utexo-lsp.
+   * @see ./lsp-helpers.js#payLightningAddress
+   */
+  payLightningAddress (addr, amountMsat, opts) {
+    return _payLightningAddress(this, addr, amountMsat, opts)
+  }
+
+  /**
+   * Ask an LSP to broker an RGB→LN deposit: wallet supplies (or mints)
+   * a BOLT11 invoice; LSP returns an RGB invoice for the sender.
+   * @see ./lsp-helpers.js#requestLspRgbDeposit
+   */
+  requestLspRgbDeposit (args) { return _requestLspRgbDeposit(this, args) }
+
+  /**
+   * Pay an RGB invoice via an LSP-mediated LN payment.
+   * @see ./lsp-helpers.js#payRgbViaLsp
+   */
+  payRgbViaLsp (args) { return _payRgbViaLsp(this, args) }
 
   // ==========================================================================
   // Cleanup

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -131,6 +131,27 @@ export default class WalletAccountRgbLightning {
   }
 
   /**
+   * Register this node with an LSP as an async-payments (APay) recipient.
+   * Used for offline-receive over Lightning Address — the wallet uploads
+   * a batch of pre-allocated payment hashes to the LSP, which then
+   * accepts payments addressed to those hashes on the wallet's behalf
+   * while this wallet is offline. The LSP later forwards the funds when
+   * the wallet comes back online, redeeming the pre-allocated hash.
+   *
+   * Backed by upstream rgb-lightning-node PR #51 (`apay_new` UniFFI
+   * method). Requires bare ≥ v0.1.0-beta.11 / nodejs ≥ v0.1.0-beta.7.
+   *
+   * @param {string} hostNodeId  - LSP's node_id (hex, 33-byte compressed secp256k1).
+   * @returns {Promise<object>}  AsyncOrderNewResponse:
+   *   `{ request_id, host_node_id, protocol_version, order_id, status,
+   *      accepted_through_index, next_index_expected, unused_hashes,
+   *      refill_batch_size, first_hash_index }`
+   */
+  async apayNew (hostNodeId) {
+    return this._binding.apayNew(hostNodeId)
+  }
+
+  /**
    * Register this wallet with an LSP as an APay (async-payments)
    * recipient. Enables offline-receive over Lightning Address: the
    * wallet uploads a batch of pre-allocated payment hashes to the LSP,

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -130,6 +130,25 @@ export default class WalletAccountRgbLightning {
     return { ok: true }
   }
 
+  /**
+   * Register this wallet with an LSP as an APay (async-payments)
+   * recipient. Enables offline-receive over Lightning Address: the
+   * wallet uploads a batch of pre-allocated payment hashes to the LSP,
+   * which then accepts Lightning payments addressed to those hashes
+   * on the wallet's behalf even while the wallet is offline.
+   *
+   * Upstream: PR #51 (`apay_new` SDK method).
+   *
+   * @param {string} hostNodeId - the LSP's node_id (hex, compressed secp256k1)
+   * @returns {Promise<object>} AsyncOrderNewResponse:
+   *   `{ request_id, host_node_id, protocol_version, order_id, status,
+   *      accepted_through_index, next_index_expected, unused_hashes,
+   *      refill_batch_size, first_hash_index }`
+   */
+  async apayNew (hostNodeId) {
+    return this._binding.apayNew(hostNodeId)
+  }
+
   // ==========================================================================
   // Node info / network / sync — ✅ wired
   // ==========================================================================

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -114,6 +114,22 @@ export default class WalletAccountRgbLightning {
     return { ok: true }
   }
 
+  /**
+   * Forcibly take over a stale VSS ownership fence after the previous
+   * node died holding it. Authenticates with the wallet password.
+   * Throws if VSS isn't configured (no `vssUrl` at construction).
+   *
+   * Recovery flow only — DO NOT call while another live node may still
+   * hold the fence. Doing so corrupts the shared VSS state. See the VSS
+   * docs section "Single-writer ownership" for the contract.
+   *
+   * @param {string} password
+   */
+  async clearVssFence (password) {
+    this._binding.clearVssFence(password)
+    return { ok: true }
+  }
+
   // ==========================================================================
   // Node info / network / sync — ✅ wired
   // ==========================================================================
@@ -214,7 +230,22 @@ export default class WalletAccountRgbLightning {
   // BOLT11 invoices — ✅ wired
   // ==========================================================================
 
-  /** @param {Object} request - JsonLnInvoiceRequest (amount_msat, expiry_sec, asset_id, asset_amount, ...) */
+  /**
+   * Create a BOLT11 invoice (BTC or RGB-asset-bound).
+   *
+   * @param {Object}  request
+   * @param {number}  [request.amt_msat]            Optional fixed amount.
+   * @param {number}   request.expiry_sec           Invoice expiry, seconds.
+   * @param {string}  [request.asset_id]            RGB contract id for an asset-bound invoice.
+   * @param {number}  [request.asset_amount]        RGB units (with asset_id).
+   * @param {string}  [request.payment_hash]        Pre-image hash for HODL invoices.
+   * @param {string}  [request.description_hash]    LUD-06 description hash (hex).
+   * @param {number}  [request.min_final_cltv_expiry_delta]
+   *   Override the min_final_cltv_expiry on the BOLT11. Required for APay
+   *   outbound flows where the LSP needs the wallet's outbound invoice to
+   *   honor a tunable claim-deadline policy. Passthrough — RLN-side default
+   *   applies when omitted.
+   */
   async createInvoice (request) { return this._node.lnInvoice(request) }
 
   /** @param {string} invoice */

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -125,7 +125,10 @@ export default class WalletManagerRgbLightning extends WalletManager {
         ldkPeerListeningPort: this._config.ldkPeerListeningPort,
         maxMediaUploadSizeMb: this._config.maxMediaUploadSizeMb,
         enableVirtualChannelsV0: this._config.enableVirtualChannelsV0,
-        permissiveSignerPolicy: this._config.permissiveSignerPolicy
+        permissiveSignerPolicy: this._config.permissiveSignerPolicy,
+        vssUrl: this._config.vssUrl,
+        vssAllowHttp: this._config.vssAllowHttp,
+        vssAllowEmptyRestore: this._config.vssAllowEmptyRestore
       })
       this._binding = binding
 


### PR DESCRIPTION
## Summary

First public beta. Promotes `wdk-rgb-lightning` from `0.1.0-alpha.2` →
`0.1.0-beta.1` and folds in all `feat/lsp-client` work:

- **LSP client surface** — `LspClient`, `LnurlPay`, and helpers for
  routed Lightning Address payments and RGB-over-LSP deposits.
- **VSS cloud backup** — `vssUrl`, `vssAllowHttp`,
  `vssAllowEmptyRestore` init options + `clearVssFence(password)`
  fence-takeover helper.
- **APay receiver registration** — `apayNew(hostNodeId)` exposed on
  the wallet account (upstream RLN PR #51).
- **`min_final_cltv_expiry_delta`** documented on `createInvoice`.
- **Beta-quality README** — install matrix, end-to-end example with
  VSS + APay, security-model section, troubleshooting.
- **Apache-2.0 `LICENSE`** file.
- **`CHANGELOG.md`** in Keep a Changelog format.

### Peer-dep floors raised

Tightened to the bindings this beta was validated against:

```
"@utexo/rgb-lightning-node-bare":   "^0.1.0-beta.11"
"@utexo/rgb-lightning-node-nodejs": "^0.1.0-beta.7"
```

These are the versions the iOS 47/59 E2E baseline and Node E2E
parity run were exercised against.

## Test plan

- [x] Node E2E baseline (47/59 same failures as alpha.2 — no regressions)
- [x] iOS sim baseline on iPhone 17 Pro Max (parity with Node)
- [ ] Repoint demo SHA pins to the new tag and re-smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)