### PR TITLE
feat(sdk): TypeScript declarations + typed error hierarchy + vssStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ while pre-`1.0`.
 ## [Unreleased]
 
 ### Added
+- **`virtualPeerPubkeys` config** — plumbed through manager → binding →
+  init request (`virtual_peer_pubkeys`). Required (together with
+  `enableVirtualChannelsV0`) for async-payments against a production
+  LSP: every mobile client must list the LSP's node_id so RLN's
+  `allows_peer` accepts the `trusted_no_broadcast` virtual channel.
+  Per Yurii's Signet LSP setup. The native layer already accepted the
+  field via the init JSON, so no native rebuild; forwarded only when a
+  non-empty array. Also documents `virtual_open_mode:
+  'trusted_no_broadcast'` on `openChannel` and the 3_000_000-msat RGB
+  HTLC minimum (`MIN_AMT_MSAT`).
 - **TypeScript declarations.** Ship a hand-authored `index.d.ts`
   covering the full public surface (manager, account, bindings,
   errors, `LspClient`, LNURL + LSP helpers) and wire it via the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ while pre-`1.0`.
 
 ## [Unreleased]
 
+### Added
+- **TypeScript declarations.** Ship a hand-authored `index.d.ts`
+  covering the full public surface (manager, account, bindings,
+  errors, `LspClient`, LNURL + LSP helpers) and wire it via the
+  `types` field + the `types` condition in the `exports` map. The
+  package previously shipped no types; consumers now get IntelliSense
+  + type-checking. Verified with `tsc --strict` (internal + consumer
+  resolution under `nodenext`).
+- **Typed error hierarchy** (`src/errors.js`): `RgbLightningError`
+  (base, with `code` + `cause` + `toJSON()`) and `UnlockError`,
+  `VssError`, `VssNotConfiguredError`, `ApayError`,
+  `NotImplementedError`. `unlock`, `clearVssFence`, `vssBackup`,
+  `apayNew`, `bootstrapLsp`, `verify`, and `signTransaction` now throw
+  these instead of bare `Error`, so callers branch on `err.name` /
+  `err.code` rather than substring-matching `Rln(...)` strings. The
+  original RLN message is preserved verbatim and attached as `cause`,
+  so existing substring checks keep working.
+- `account.vssStatus()` — local-view VSS status
+  (`{ configured, url, allowHttp, lastBackupVersion }`) with no server
+  round-trip. (RLN's C-FFI has no read-only server-side backup-info
+  query; call `vssBackup()` for a live version.)
+- `account.createLightningInvoice(request)` — cross-SDK alias for
+  `createInvoice` (matches `@utexo/rgb-sdk-rn`'s naming), accepting
+  either the native snake_case request or a camelCase convenience
+  shape.
+
+### Fixed
+- Removed a duplicate `apayNew` method definition in both
+  `node-binding.js` and `bare-binding.js` (the shadowed first copy
+  used `this.node`, which throws pre-unlock).
+
 ### Changed
 - README: tightened the *"Why a separate module from `wdk-wallet-rgb`?"*
   section. Added a *"Use `wdk-wallet-rgb` for asset issuance +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ while pre-`1.0`.
 ## [Unreleased]
 
 ### Added
+- **`UtexoLsp` composed-flow class** (`src/utexo-lsp.js`) — brings the
+  LSP surface to parity with `@utexo/rgb-sdk-rn`'s `UtexoLsp`. A
+  stateful orchestration object over an account + `LspClient` covering
+  the full lifecycle: `connect`, `waitForChannel`, `receiveAsset`,
+  `awaitReceiveSettlement`, `waitForOutboundLiquidity`, `sendAsset`,
+  `payAddress`, `enableLightningAddress`, and `claimPendingPayments`.
+  All poll loops accept `WaitOptions` (`timeoutMs`, `pollIntervalMs`,
+  `signal`, `onProgress`, `onEachPoll`). Construct via
+  `account.createLsp(peer?)` — the no-arg form auto-discovers the peer
+  from the wallet's `lspBaseUrl`. Also exports `LspChannelTimeoutError`,
+  `LspSettlementError`, `peerUri()`, and `normalizeReceiveStatus()`.
+- **`LspClient.resolveAddress(username, amtMsat, opts)`** — full LUD-06
+  resolution (discovery + callback) routed through the LSP's `baseUrl`,
+  with the callback URL rewritten onto the base origin so the second hop
+  inherits the client's retry/timeout rails and survives an LSP that
+  advertises an internal/emulator host (e.g. `10.0.2.2`). Mirrors
+  `rgb-sdk-rn`'s `UtexoLSPClient.resolveAddress`.
+- **`LspClient.getLightningAddressByPubkey(pubkey, opts)`** — reads back
+  the auto-assigned `{ username, domain }` the LSP minted for a node
+  pubkey (post-`apayNew`). The one raw-client endpoint we were missing.
+- **`account.createLsp(peer?, peerPort?)`** + **`account.getLspConfig()`**
+  — factory for `UtexoLsp` and a read of the `lspBaseUrl`/
+  `lspBearerToken` the node was constructed with.
+- **`account.createHodlInvoice(params)`** — named convenience over
+  `createInvoice({ payment_hash })`, returning `{ bolt11, paymentHash }`.
+  Parity with `rgb-sdk-rn`'s `createHodlInvoice`.
+- TS declarations extended for all of the above (`UtexoLsp`, `LspPeer`,
+  `WaitOptions`, `ReceiveStatus`, `ChannelReadyInfo`,
+  `CreateHodlInvoiceParams`, the two new error classes, etc.).
 - **`virtualPeerPubkeys` config** — plumbed through manager → binding →
   init request (`virtual_peer_pubkeys`). Required (together with
   `enableVirtualChannelsV0`) for async-payments against a production

--- a/index-bare.js
+++ b/index-bare.js
@@ -18,6 +18,17 @@ export default class WalletManagerRgbLightning extends WalletManagerBase {
 export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
 export { BareRgbLightningBinding } from './src/bare-binding.js'
 
+// Typed error hierarchy — see ./src/errors.js. Lets callers branch on
+// `err.name` / `err.code` instead of substring-matching RLN messages.
+export {
+  RgbLightningError,
+  UnlockError,
+  VssError,
+  VssNotConfiguredError,
+  ApayError,
+  NotImplementedError
+} from './src/errors.js'
+
 // LSP client surface — see ./src/lsp-client.js, lnurl-pay.js, lsp-helpers.js.
 // Pure-fetch implementations; work in Bare (via bare-fetch/global, already
 // installed by ./bare.js) and Node ≥18 (native fetch) without per-runtime

--- a/index-bare.js
+++ b/index-bare.js
@@ -45,3 +45,13 @@ export {
   requestLspRgbDeposit,
   payRgbViaLsp
 } from './src/lsp-helpers.js'
+// Composed LSP flows — connect → wait-for-channel → receive/send →
+// settle → pay-address → enable-Lightning-Address → claim. API parity
+// with @utexo/rgb-sdk-rn's UtexoLsp. See ./src/utexo-lsp.js.
+export {
+  UtexoLsp,
+  LspChannelTimeoutError,
+  LspSettlementError,
+  peerUri,
+  normalizeReceiveStatus
+} from './src/utexo-lsp.js'

--- a/index-node.js
+++ b/index-node.js
@@ -45,3 +45,13 @@ export {
   requestLspRgbDeposit,
   payRgbViaLsp
 } from './src/lsp-helpers.js'
+// Composed LSP flows — connect → wait-for-channel → receive/send →
+// settle → pay-address → enable-Lightning-Address → claim. API parity
+// with @utexo/rgb-sdk-rn's UtexoLsp. See ./src/utexo-lsp.js.
+export {
+  UtexoLsp,
+  LspChannelTimeoutError,
+  LspSettlementError,
+  peerUri,
+  normalizeReceiveStatus
+} from './src/utexo-lsp.js'

--- a/index-node.js
+++ b/index-node.js
@@ -20,6 +20,17 @@ export default class WalletManagerRgbLightning extends WalletManagerBase {
 export { default as WalletAccountRgbLightning } from './src/wallet-account-rgb-lightning.js'
 export { NodeRgbLightningBinding } from './src/node-binding.js'
 
+// Typed error hierarchy — see ./src/errors.js. Lets callers branch on
+// `err.name` / `err.code` instead of substring-matching RLN messages.
+export {
+  RgbLightningError,
+  UnlockError,
+  VssError,
+  VssNotConfiguredError,
+  ApayError,
+  NotImplementedError
+} from './src/errors.js'
+
 // LSP client surface — see ./src/lsp-client.js, lnurl-pay.js, lsp-helpers.js.
 // Pure-fetch implementations; identical module under Bare (./index-bare.js).
 export { LspClient, LspError } from './src/lsp-client.js'

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,40 @@ export interface CreateLightningInvoiceRequest {
   assetAmount?: number
   paymentHash?: string
   descriptionHash?: string
+  /**
+   * Override the BOLT11 min_final_cltv_expiry. For APay this is set by
+   * the LSP policy (`APAY_*_MIN_FINAL_CLTV_EXPIRY_DELTA`): inbound
+   * (merchant-offline window, e.g. 864 blocks) and outbound (LDK
+   * minimum, 42). Passthrough; RLN default applies when omitted.
+   */
   minFinalCltvExpiryDelta?: number
+}
+
+/**
+ * Channel-open request forwarded verbatim to RLN. Only the fields most
+ * relevant to APay are typed here; any other RLN openchannel field may
+ * also be passed.
+ *
+ * NOTE (RGB HTLC minimum): an RGB-routed HTLC has a hard minimum of
+ * 3_000_000 msat (the LSP's `MIN_AMT_MSAT`). Invoices/payments below
+ * this will fail to route on RGB channels.
+ */
+export interface OpenChannelRequest {
+  peer_pubkey_and_opt_addr: string
+  capacity_sat: number
+  push_msat?: number
+  asset_id?: string
+  asset_amount?: number
+  public?: boolean
+  with_anchors?: boolean
+  /**
+   * Open as a virtual (non-broadcast) channel. Set to
+   * `'trusted_no_broadcast'` for APay against a production LSP. The
+   * counterparty must trust this node via its `virtualPeerPubkeys`
+   * (and vice-versa). Requires `enableVirtualChannelsV0` at construction.
+   */
+  virtual_open_mode?: 'trusted_no_broadcast'
+  [key: string]: unknown
 }
 
 // ───────────────────────────────────────────────────────────────────
@@ -95,7 +128,18 @@ export interface RgbLightningBindingConfig {
   daemonListeningPort?: number
   ldkPeerListeningPort?: number
   maxMediaUploadSizeMb?: number
+  /**
+   * Enable virtual-channels-v0. REQUIRED (with `virtualPeerPubkeys`)
+   * for async-payments against a production LSP — mobile clients reject
+   * standard channels and must use `trusted_no_broadcast` virtual channels.
+   */
   enableVirtualChannelsV0?: boolean
+  /**
+   * Trust list of peer node_ids (hex) allowed to open/receive
+   * `trusted_no_broadcast` virtual channels with this node. For APay,
+   * set to `[lspNodeId]`. Forwarded as `virtual_peer_pubkeys`.
+   */
+  virtualPeerPubkeys?: string[]
   permissiveSignerPolicy?: boolean
   /** Enables VSS cloud backup. Only https:// (or loopback http) unless `vssAllowHttp`. */
   vssUrl?: string
@@ -202,7 +246,7 @@ export class WalletAccountRgbLightning {
   getAddress(): string
 
   // Channels
-  openChannel(request: object): Promise<object>
+  openChannel(request: OpenChannelRequest | object): Promise<object>
   closeChannel(request: object): Promise<{ ok: true }>
   listChannels(): Promise<object>
   getChannelId(temporaryChannelIdHex: string): Promise<object>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,433 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+//
+// TypeScript declarations for @utexo/wdk-rgb-lightning.
+//
+// The package ships as pure ES modules with no compile step; these
+// declarations are hand-authored to match the runtime surface of
+// index-node.js / index-bare.js (identical public API; only the
+// underlying native binding differs). Payloads that forward verbatim
+// to rgb-lightning-node (RLN) are typed loosely as `object` /
+// `Record<string, unknown>` because their shape is owned upstream;
+// shapes this module owns (config, results, errors, LSP DTOs) are
+// typed precisely.
+
+// ───────────────────────────────────────────────────────────────────
+// Shared primitives
+// ───────────────────────────────────────────────────────────────────
+
+export type Network = 'mainnet' | 'testnet' | 'regtest' | 'signet'
+
+/** Placeholder address returned by `getAddress()` before `unlock()`. */
+export const PENDING_ADDRESS: string
+
+export interface FeeRates {
+  /** Economy rate (sat/vB), targets ~1 hour confirmation. */
+  normal: bigint
+  /** Priority rate (sat/vB), targets next block. */
+  fast: bigint
+}
+
+export interface KeyPair {
+  /** LN node id — 33-byte compressed secp256k1 pubkey. */
+  publicKey: Uint8Array
+  /** Always null: VLS holds signing material and never exposes it. */
+  privateKey: null
+}
+
+export interface TransferOptions {
+  /** BOLT11 invoice, LN node pubkey (hex), BTC address, or RGB invoice. */
+  recipient: string
+  /** msats for LN flows, sats for on-chain flows. */
+  amount: number | bigint
+  /** RGB asset id, when transferring an asset. */
+  token?: string
+  /** sat/vB override for on-chain flows. */
+  feeRate?: number
+}
+
+export interface TransferResult {
+  /** Payment hash (LN) or txid (on-chain/RGB). */
+  hash: string
+  /** Fee paid, in msats (LN) or sats (on-chain). */
+  fee: bigint
+}
+
+export type QuoteResult = Omit<TransferResult, 'hash'>
+
+/** Local-view VSS status (no server round-trip). See `vssStatus()`. */
+export interface VssStatus {
+  configured: boolean
+  url: string | null
+  allowHttp: boolean
+  /** Snapshot version from the most recent `vssBackup()` this session. */
+  lastBackupVersion: number | null
+}
+
+export interface BootstrapLspResult {
+  /** connectPeer response. */
+  connect: object
+  /** Whether the peer reached listPeers within the window. */
+  peerVisible: boolean
+  /** AsyncOrderNewResponse from apayNew — omitted if hostNodeId was undefined. */
+  apay?: object
+}
+
+export interface CreateLightningInvoiceRequest {
+  amountMsat?: number
+  expirySec: number
+  assetId?: string
+  assetAmount?: number
+  paymentHash?: string
+  descriptionHash?: string
+  minFinalCltvExpiryDelta?: number
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Config
+// ───────────────────────────────────────────────────────────────────
+
+export interface RgbLightningBindingConfig {
+  network: Network
+  /** Persistent, app-private path for RLN's SQLite + LDK state. */
+  dataDir: string
+  daemonListeningPort?: number
+  ldkPeerListeningPort?: number
+  maxMediaUploadSizeMb?: number
+  enableVirtualChannelsV0?: boolean
+  permissiveSignerPolicy?: boolean
+  /** Enables VSS cloud backup. Only https:// (or loopback http) unless `vssAllowHttp`. */
+  vssUrl?: string
+  vssAllowHttp?: boolean
+  vssAllowEmptyRestore?: boolean
+  /** LSP base URL for RLN's internal APay client. Required for apayNew/bootstrapLsp. */
+  lspBaseUrl?: string
+  /** Bearer token for the LSP's /internal/* endpoints. */
+  lspBearerToken?: string
+}
+
+export interface RgbLightningWalletConfig extends RgbLightningBindingConfig {
+  bitcoindRpcUsername?: string
+  bitcoindRpcPassword?: string
+  bitcoindRpcHost?: string
+  bitcoindRpcPort?: number
+  indexerUrl?: string
+  proxyEndpoint?: string
+  announceAddresses?: string[]
+  announceAlias?: string
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Bindings (low-level; usually not constructed directly)
+// ───────────────────────────────────────────────────────────────────
+
+export interface IRgbLightningBinding {
+  ensureNode(): unknown
+  attachExternalSigner(seedHex: string): void
+  unlock(unlockRequest: object): void
+  readonly node: unknown
+  bootstrap(): object
+  clearVssFence(password: string): void
+  vssBackup(): { version: number }
+  vssStatus(): VssStatus
+  apayNew(hostNodeId: string): object
+  shutdown(): void
+}
+
+export class NodeRgbLightningBinding implements IRgbLightningBinding {
+  constructor(config: RgbLightningBindingConfig)
+  ensureNode(): unknown
+  attachExternalSigner(seedHex: string): void
+  unlock(unlockRequest: object): void
+  readonly node: unknown
+  bootstrap(): object
+  clearVssFence(password: string): void
+  vssBackup(): { version: number }
+  vssStatus(): VssStatus
+  apayNew(hostNodeId: string): object
+  shutdown(): void
+  static healthcheck(): unknown
+  static isInitialized(): boolean
+}
+
+export class BareRgbLightningBinding implements IRgbLightningBinding {
+  constructor(config: RgbLightningBindingConfig)
+  ensureNode(): unknown
+  attachExternalSigner(seedHex: string): void
+  unlock(unlockRequest: object): void
+  readonly node: unknown
+  bootstrap(): object
+  clearVssFence(password: string): void
+  vssBackup(): { version: number }
+  vssStatus(): VssStatus
+  apayNew(hostNodeId: string): object
+  shutdown(): void
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Account
+// ───────────────────────────────────────────────────────────────────
+
+export class WalletAccountRgbLightning {
+  constructor(bindings: { binding: IRgbLightningBinding })
+
+  // Lifecycle
+  unlock(unlockRequest: object): Promise<{ ok: true }>
+  getBootstrap(): Promise<object>
+  shutdown(): Promise<{ ok: true }>
+
+  // VSS
+  /** @throws {VssNotConfiguredError} if built without a vssUrl. @throws {VssError} on server rejection. */
+  clearVssFence(password: string): Promise<{ ok: true }>
+  /** @throws {VssNotConfiguredError} if built without a vssUrl. @throws {VssError} on failure. */
+  vssBackup(): Promise<{ version: number }>
+  /** Local-view status; does not hit the server. */
+  vssStatus(): Promise<VssStatus>
+
+  // APay / LSP bootstrap
+  /** @throws {ApayError} on LSP failure. */
+  apayNew(hostNodeId: string): Promise<object>
+  bootstrapLsp(opts: {
+    peerPubkeyAndAddr: string
+    hostNodeId?: string
+    waitForPeerMs?: number
+    pollIntervalMs?: number
+  }): Promise<BootstrapLspResult>
+
+  // Node info / network / sync
+  getNodeInfo(): Promise<object>
+  getNetworkInfo(): Promise<object>
+  sync(): Promise<{ ok: true }>
+  getAddress(): string
+
+  // Channels
+  openChannel(request: object): Promise<object>
+  closeChannel(request: object): Promise<{ ok: true }>
+  listChannels(): Promise<object>
+  getChannelId(temporaryChannelIdHex: string): Promise<object>
+
+  // Peers
+  connectPeer(peerPubkeyAndAddr: string): Promise<{ ok: true }>
+  disconnectPeer(request: object): Promise<{ ok: true }>
+  listPeers(): Promise<object>
+
+  // BOLT11 invoices
+  createInvoice(request: object): Promise<object>
+  /** Cross-SDK alias for createInvoice; accepts native snake_case or camelCase. */
+  createLightningInvoice(request: CreateLightningInvoiceRequest | object): Promise<object>
+  decodeInvoice(invoice: string): Promise<object>
+  getInvoiceStatus(invoice: string): Promise<object>
+  cancelHodlInvoice(request: object): Promise<{ ok: true }>
+  claimHodlInvoice(request: object): Promise<object>
+
+  // Payments
+  sendPayment(request: object): Promise<object>
+  keysend(request: object): Promise<object>
+  listPayments(): Promise<object>
+  getPayment(paymentHashHex: string, paymentType: 'sent' | 'received'): Promise<object>
+
+  // RGB assets
+  issueAssetNia(request: object): Promise<object>
+  issueAssetUda(request: object): Promise<object>
+  issueAssetCfa(request: object): Promise<object>
+  issueAssetIfa(request: object): Promise<object>
+  listAssets(filterAssetSchemas?: string[]): Promise<object>
+  getAssetBalance(assetId: string): Promise<object>
+  getAssetMetadata(assetId: string): Promise<object>
+  listTransfers(assetId?: string): Promise<object>
+  refreshTransfers(request: object): Promise<{ ok: true }>
+  failTransfers(request: object): Promise<object>
+  createRgbInvoice(request: object): Promise<object>
+  decodeRgbInvoice(invoice: string): Promise<object>
+  sendRgbAsset(request: object): Promise<object>
+  inflate(request: object): Promise<object>
+  getAssetMedia(digest: string): Promise<object>
+  postAssetMedia(request: object): Promise<object>
+
+  // BTC on-chain
+  getBalance(skipSync?: boolean): Promise<string>
+  getBalanceDetails(skipSync?: boolean): Promise<object>
+  sendTransaction(request: object): Promise<object>
+  getTransactions(skipSync?: boolean): Promise<object>
+  listUnspents(skipSync?: boolean): Promise<object>
+  createUtxos(request: object): Promise<{ ok: true }>
+  estimateFee(blocks: number): Promise<object>
+
+  // Onion / signing / diagnostics
+  sendOnionMessage(request: object): Promise<{ ok: true }>
+  sign(message: string): Promise<{ signature: string }>
+  checkIndexerUrl(indexerUrl: string): Promise<object>
+  checkProxyEndpoint(proxyEndpoint: string): Promise<{ ok: true }>
+
+  // Generic IWalletAccount surface
+  transfer(options: TransferOptions): Promise<TransferResult>
+  quoteTransfer(options: TransferOptions): Promise<QuoteResult>
+  quoteSendTransaction(tx: object): Promise<QuoteResult>
+  getTransactionReceipt(hash: string): Promise<unknown | null>
+  getKeyPair(): KeyPair
+  toReadOnlyAccount(): Promise<IWalletAccountReadOnlyRgbLightning>
+  /** @throws {NotImplementedError} — upstream c-ffi lacks verify_message. */
+  verify(message: string, signature: string): Promise<boolean>
+  /** @throws {NotImplementedError} — use sendTransaction/sendPayment/sendRgbAsset. */
+  signTransaction(tx: object): Promise<never>
+
+  // LSP integration (thin pass-throughs to lsp-helpers)
+  payLightningAddress(addr: string, amountMsat: bigint | number, opts?: PayLightningAddressOptions): Promise<PayLightningAddressResult>
+  requestLspRgbDeposit(args: RequestLspRgbDepositArgs): Promise<LspRgbDepositResult>
+  payRgbViaLsp(args: PayRgbViaLspArgs): Promise<PayRgbViaLspResult>
+
+  dispose(): void
+}
+
+export interface IWalletAccountReadOnlyRgbLightning {
+  getAddress(): Promise<string>
+  verify(message: string, signature: string): Promise<boolean>
+  getBalance(): Promise<bigint>
+  getTokenBalance(assetId: string): Promise<bigint>
+  quoteSendTransaction(tx: object): Promise<QuoteResult>
+  quoteTransfer(options: TransferOptions): Promise<QuoteResult>
+  getTransactionReceipt(hash: string): Promise<unknown | null>
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Manager (default export)
+// ───────────────────────────────────────────────────────────────────
+
+export default class WalletManagerRgbLightning {
+  constructor(seed: string | Uint8Array, config: RgbLightningWalletConfig)
+  getAccount(index?: number): Promise<WalletAccountRgbLightning>
+  getAccountByPath(path: string): Promise<never>
+  getFeeRates(): Promise<FeeRates>
+  dispose(): void
+  static readonly Binding: new (config: RgbLightningBindingConfig) => IRgbLightningBinding
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Error hierarchy
+// ───────────────────────────────────────────────────────────────────
+
+export class RgbLightningError extends Error {
+  constructor(message: string, opts?: { code?: string; cause?: unknown })
+  code: string
+  cause?: unknown
+  toJSON(): { name: string; code: string; message: string; cause: unknown }
+}
+export class UnlockError extends RgbLightningError {}
+export class VssError extends RgbLightningError {}
+export class VssNotConfiguredError extends VssError {}
+export class ApayError extends RgbLightningError {}
+export class NotImplementedError extends RgbLightningError {}
+
+// ───────────────────────────────────────────────────────────────────
+// LSP client
+// ───────────────────────────────────────────────────────────────────
+
+export interface LspClientOptions {
+  baseUrl: string
+  timeoutMs?: number
+  fetch?: typeof fetch
+  defaultHeaders?: Record<string, string>
+  allowHttp?: boolean
+  maxRetries?: number
+}
+
+export interface LnurlPayDiscovery {
+  tag: 'payRequest'
+  callback: string
+  minSendable: number | string
+  maxSendable: number | string
+  metadata: string
+  commentAllowed?: number | string
+}
+
+export interface LspBridgeResult {
+  lnInvoice: string
+  rgbInvoice: string
+  mappingId: string
+}
+
+export class LspClient {
+  constructor(opts: LspClientOptions)
+  health(opts?: { timeoutMs?: number }): Promise<object>
+  getInfo(opts?: { timeoutMs?: number }): Promise<object>
+  lnurlDiscovery(username: string, opts?: { timeoutMs?: number }): Promise<LnurlPayDiscovery>
+  lnurlCallback(username: string, amountMsat: bigint | number, opts?: { assetId?: string; assetAmount?: number; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[] }>
+  onchainSend(params: {
+    rgbInvoice: string
+    ln: { amtMsat: bigint | number; expirySec: number; assetId?: string; assetAmount?: number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+    timeoutMs?: number
+  }): Promise<LspBridgeResult>
+  lightningReceive(params: {
+    lnInvoice: string
+    rgb: { assetId: string; assignment?: unknown; durationSeconds?: number; minConfirmations?: number; witness?: boolean }
+    timeoutMs?: number
+  }): Promise<LspBridgeResult>
+}
+
+export class LspError extends Error {
+  endpoint: string
+  status: number
+  body: string
+  errorBody: object | null
+  errorCode: number | string | null
+  errorTag: string | null
+}
+
+// ───────────────────────────────────────────────────────────────────
+// LNURL-pay (LUD-06 / LUD-16)
+// ───────────────────────────────────────────────────────────────────
+
+export function parseLightningAddress(addr: string, opts?: { allowHttp?: boolean }): { username: string; host: string; discoveryUrl: string }
+export function fetchDiscovery(addr: string, opts?: { fetch?: typeof fetch; timeoutMs?: number; allowHttp?: boolean }): Promise<LnurlPayDiscovery>
+export function resolveAddressToInvoice(addr: string, amountMsat: bigint | number, opts?: { fetch?: typeof fetch; timeoutMs?: number; allowHttp?: boolean; comment?: string }): Promise<{ pr: string; routes?: unknown[]; discovery: LnurlPayDiscovery; callbackUrl: string }>
+
+export class LnurlPayError extends Error {
+  status?: number
+  body?: string
+}
+
+// ───────────────────────────────────────────────────────────────────
+// LSP helpers (account + LSP combined flows)
+// ───────────────────────────────────────────────────────────────────
+
+export interface PayLightningAddressOptions {
+  fetch?: typeof fetch
+  timeoutMs?: number
+  allowHttp?: boolean
+  comment?: string
+  skipAmount?: boolean
+  beforePay?: (invoice: string, ctx: { discovery: LnurlPayDiscovery; callbackUrl: string }) => void | Promise<void>
+}
+
+export interface PayLightningAddressResult {
+  invoice: string
+  sendResult: object
+  discovery: LnurlPayDiscovery
+  callbackUrl: string
+}
+
+export interface RequestLspRgbDepositArgs {
+  lsp: string | LspClient
+  lnInvoice?: string
+  lnInvoiceRequest?: object
+  rgb: { assetId: string; assignment?: unknown; durationSeconds?: number; minConfirmations?: number; witness?: boolean }
+  lspOpts?: { timeoutMs?: number }
+}
+
+export type LspRgbDepositResult = LspBridgeResult
+
+export interface PayRgbViaLspArgs {
+  lsp: string | LspClient
+  rgbInvoice: string
+  ln: { amtMsat: bigint | number; expirySec: number; assetId?: string; assetAmount?: number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+  lspOpts?: { timeoutMs?: number }
+}
+
+export interface PayRgbViaLspResult extends LspBridgeResult {
+  sendResult: object
+}
+
+export function payLightningAddress(account: WalletAccountRgbLightning, addr: string, amountMsat: bigint | number, opts?: PayLightningAddressOptions): Promise<PayLightningAddressResult>
+export function requestLspRgbDeposit(account: WalletAccountRgbLightning, args: RequestLspRgbDepositArgs): Promise<LspRgbDepositResult>
+export function payRgbViaLsp(account: WalletAccountRgbLightning, args: PayRgbViaLspArgs): Promise<PayRgbViaLspResult>

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,16 @@ export interface CreateLightningInvoiceRequest {
   minFinalCltvExpiryDelta?: number
 }
 
+export interface CreateHodlInvoiceParams {
+  /** 32-byte payment hash (hex). The preimage is released later via claimHodlInvoice. */
+  paymentHash: string
+  amtMsat?: number
+  expirySec: number
+  assetId?: string
+  assetAmount?: number
+  minFinalCltvExpiryDelta?: number
+}
+
 /**
  * Channel-open request forwarded verbatim to RLN. Only the fields most
  * relevant to APay are typed here; any other RLN openchannel field may
@@ -238,6 +248,13 @@ export class WalletAccountRgbLightning {
     waitForPeerMs?: number
     pollIntervalMs?: number
   }): Promise<BootstrapLspResult>
+  /** The lspBaseUrl / lspBearerToken this node was constructed with. */
+  getLspConfig(): { baseUrl: string | null; bearerToken: string | null }
+  /**
+   * Build the composed {@link UtexoLsp} flow object. No-arg form
+   * auto-discovers the peer from the wallet's lspBaseUrl.
+   */
+  createLsp(peer?: LspPeer, peerPort?: number): Promise<UtexoLsp>
 
   // Node info / network / sync
   getNodeInfo(): Promise<object>
@@ -262,6 +279,8 @@ export class WalletAccountRgbLightning {
   createLightningInvoice(request: CreateLightningInvoiceRequest | object): Promise<object>
   decodeInvoice(invoice: string): Promise<object>
   getInvoiceStatus(invoice: string): Promise<object>
+  /** Create a HODL invoice bound to a caller-supplied payment hash. */
+  createHodlInvoice(params: CreateHodlInvoiceParams): Promise<{ bolt11: string; paymentHash: string }>
   cancelHodlInvoice(request: object): Promise<{ ok: true }>
   claimHodlInvoice(request: object): Promise<object>
 
@@ -397,6 +416,10 @@ export class LspClient {
   getInfo(opts?: { timeoutMs?: number }): Promise<object>
   lnurlDiscovery(username: string, opts?: { timeoutMs?: number }): Promise<LnurlPayDiscovery>
   lnurlCallback(username: string, amountMsat: bigint | number, opts?: { assetId?: string; assetAmount?: number; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[] }>
+  /** Full LUD-06 resolution routed through this LSP's baseUrl (discovery + callback). */
+  resolveAddress(username: string, amountMsat: bigint | number, opts?: { assetId?: string; assetAmount?: bigint | number; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[]; status?: string; reason?: string }>
+  /** Resolve the auto-assigned Lightning Address for a node pubkey (post-apayNew). */
+  getLightningAddressByPubkey(peerPubkey: string, opts?: { timeoutMs?: number }): Promise<{ username: string; domain: string }>
   onchainSend(params: {
     rgbInvoice: string
     ln: { amtMsat: bigint | number; expirySec: number; assetId?: string; assetAmount?: number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
@@ -475,3 +498,108 @@ export interface PayRgbViaLspResult extends LspBridgeResult {
 export function payLightningAddress(account: WalletAccountRgbLightning, addr: string, amountMsat: bigint | number, opts?: PayLightningAddressOptions): Promise<PayLightningAddressResult>
 export function requestLspRgbDeposit(account: WalletAccountRgbLightning, args: RequestLspRgbDepositArgs): Promise<LspRgbDepositResult>
 export function payRgbViaLsp(account: WalletAccountRgbLightning, args: PayRgbViaLspArgs): Promise<PayRgbViaLspResult>
+
+// ───────────────────────────────────────────────────────────────────
+// UtexoLsp — composed LSP flows (parity with @utexo/rgb-sdk-rn)
+// ───────────────────────────────────────────────────────────────────
+
+/** Canonical receive state (4 terminal-or-pending values). */
+export type ReceiveStatus = 'Pending' | 'Succeeded' | 'Failed' | 'Expired'
+
+/** Single config object describing the LSP peer for composed flows. */
+export interface LspPeer {
+  baseUrl: string
+  peerPubkey: string
+  peerHost: string
+  peerPort: number
+  bearerToken?: string
+  timeoutMs?: number
+  allowHttp?: boolean
+}
+
+/** Shared polling options for the wait/await flows. */
+export interface WaitOptions {
+  timeoutMs?: number
+  pollIntervalMs?: number
+  signal?: AbortSignal
+  onProgress?: (msg: string) => void
+  /** Run at the start of each poll iteration — e.g. mine a regtest block. */
+  onEachPoll?: () => Promise<void>
+}
+
+export interface ChannelReadyInfo {
+  channelId: string
+  peerPubkey: string
+  capacitySat: number
+  outboundBalanceMsat: number
+  inboundBalanceMsat: number
+}
+
+export interface ReceiveAssetOptions {
+  assetId: string
+  amountSats?: number
+  amountRgb?: number
+  expirySeconds?: number
+}
+
+export interface ReceiveAssetResult {
+  lnInvoice: string
+  rgbInvoice: string
+  mappingId: string
+}
+
+export interface SendAssetOptions {
+  rgbInvoice: string
+  ln?: { amtMsat?: bigint | number; expirySec?: number; assetId?: string; assetAmount?: bigint | number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+}
+
+export interface SendAssetResult extends LspBridgeResult {
+  sendResult: object
+}
+
+export interface PayAddressOptions {
+  address: string
+  amtMsat: bigint | number
+  asset?: { assetId: string; assetAmount: number }
+}
+
+export interface LightningAddressInfo {
+  username: string
+  domain: string
+  /** Convenience: `username@domain`. */
+  address: string
+}
+
+export interface ClaimResult {
+  paymentHash: string
+  claimed: boolean
+  error?: string
+}
+
+export class UtexoLsp {
+  constructor(account: WalletAccountRgbLightning, peer: LspPeer)
+  readonly http: LspClient
+  readonly peer: LspPeer
+  connect(): Promise<{ ok: true }>
+  waitForChannel(assetId: string, opts?: WaitOptions): Promise<ChannelReadyInfo>
+  receiveAsset(opts: ReceiveAssetOptions): Promise<ReceiveAssetResult>
+  awaitReceiveSettlement(lnInvoice: string, opts?: WaitOptions): Promise<'settled' | 'timed_out'>
+  waitForOutboundLiquidity(minMsat: number, opts?: WaitOptions): Promise<void>
+  sendAsset(opts: SendAssetOptions): Promise<SendAssetResult>
+  payAddress(opts: PayAddressOptions): Promise<{ invoice: string; sendResult: object }>
+  enableLightningAddress(): Promise<LightningAddressInfo>
+  claimPendingPayments(): Promise<ClaimResult[]>
+}
+
+export function peerUri(peer: LspPeer): string
+export function normalizeReceiveStatus(raw: string | { status?: string } | null | undefined): ReceiveStatus
+
+export class LspChannelTimeoutError extends Error {
+  assetId: string
+  elapsedMs: number
+}
+
+export class LspSettlementError extends Error {
+  step: 'ln_invoice'
+  status: ReceiveStatus
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/UTEXO-Protocol/wdk-rgb-lightning.git"
   },
   "main": "index.js",
+  "types": "./index.d.ts",
   "type": "module",
   "scripts": {
     "lint": "standard",
@@ -44,6 +45,7 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "bare": "./bare.js",
       "node": "./index-node.js",
       "default": "./index.js"

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -78,6 +78,15 @@ export class BareRgbLightningBinding {
       max_media_upload_size_mb: config.maxMediaUploadSizeMb ?? 5,
       enable_virtual_channels_v0: config.enableVirtualChannelsV0 ?? false
     }
+    // Virtual-channels-v0 trust list. When the LSP opens (or the device
+    // opens against the LSP) a `trusted_no_broadcast` virtual channel,
+    // the device must list the LSP's node_id here or RLN's `allows_peer`
+    // rejects the channel. Production APay requires this — see Yurii's
+    // Signet LSP setup: every mobile client sets enableVirtualChannelsV0
+    // + virtualPeerPubkeys=[LSP node_id]. Forwarded only when non-empty.
+    if (Array.isArray(config.virtualPeerPubkeys) && config.virtualPeerPubkeys.length > 0) {
+      this._initRequest.virtual_peer_pubkeys = config.virtualPeerPubkeys
+    }
     // VSS fields are only forwarded when the host opts in. Omitting them
     // lets the RLN-side `#[serde(default)]` keep VSS fully disabled.
     if (config.vssUrl) this._initRequest.vss_url = config.vssUrl

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -95,6 +95,8 @@ export class BareRgbLightningBinding {
     this._signer = null
     /** @type {boolean} */
     this._sdkInitDone = false
+    /** @type {number | null} Snapshot version returned by the most recent vssBackup(). */
+    this._lastVssVersion = null
   }
 
   /**
@@ -207,34 +209,41 @@ export class BareRgbLightningBinding {
    * @returns {{version: number}}
    */
   vssBackup () {
-    return this.node.vssBackup()
+    const r = this.node.vssBackup()
+    if (r && typeof r.version === 'number') this._lastVssVersion = r.version
+    return r
+  }
+
+  /**
+   * Local-view VSS status. RLN's C-FFI exposes no read-only
+   * server-side backup-info query (unlike rgb-lib's `vssBackupInfo`),
+   * so this reports what the host can know without a round-trip:
+   * whether VSS was configured at construction, the configured URL +
+   * allow-http flag, and the snapshot version from the most recent
+   * `vssBackup()` call this session (`null` if none yet). For a live
+   * server version, call `vssBackup()` (it flushes and returns the
+   * fresh `{ version }`).
+   *
+   * @returns {{ configured: boolean, url: string|null, allowHttp: boolean, lastBackupVersion: number|null }}
+   */
+  vssStatus () {
+    return {
+      configured: !!this._config.vssUrl,
+      url: this._config.vssUrl ?? null,
+      allowHttp: !!this._config.vssAllowHttp,
+      lastBackupVersion: this._lastVssVersion
+    }
   }
 
   /**
    * Register this node with an LSP as an async-payments (APay) recipient.
    * Used for offline-receive over Lightning Address — the wallet uploads
    * a batch of pre-allocated payment hashes to the LSP, which then
-   * accepts payments addressed to those hashes on the wallet's behalf
-   * while the wallet is offline.
+   * accepts Lightning payments addressed to those hashes on the wallet's
+   * behalf, even while the wallet is offline.
    *
    * @param {string} hostNodeId  - LSP's node_id (hex, 33-byte compressed secp256k1)
    * @returns {object}  AsyncOrderNewResponse — request_id, host_node_id,
-   *   protocol_version, order_id, status, accepted_through_index,
-   *   next_index_expected, unused_hashes, refill_batch_size, first_hash_index
-   */
-  apayNew (hostNodeId) {
-    const node = this.node
-    return node.apayNew(hostNodeId)
-  }
-
-  /**
-   * Register with an LSP as an APay (async-payments) recipient. The
-   * wallet uploads a batch of pre-allocated payment hashes to the LSP;
-   * the LSP then accepts Lightning payments addressed to those hashes
-   * on the wallet's behalf, even while the wallet is offline.
-   *
-   * @param {string} hostNodeId - the LSP's node_id (hex, compressed secp256k1)
-   * @returns {object} AsyncOrderNewResponse — request_id, host_node_id,
    *   protocol_version, order_id, status, accepted_through_index,
    *   next_index_expected, unused_hashes, refill_batch_size, first_hash_index
    */

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -74,6 +74,12 @@
  *   rather than relying on the implicit on-write flush. Throws if
  *   VSS isn't configured (no `vssUrl` at construction) or the flush
  *   fails (server unreachable, auth rejected, etc.).
+ * @property {() => { configured: boolean, url: string|null, allowHttp: boolean, lastBackupVersion: number|null }} vssStatus
+ *   Local-view VSS status (no server round-trip): whether VSS was
+ *   configured at construction, the URL + allow-http flag, and the
+ *   version from the most recent `vssBackup()` this session. RLN's
+ *   C-FFI exposes no read-only server-side backup-info query, so for
+ *   a live server version call `vssBackup()`.
  * @property {(hostNodeId: string) => object}           apayNew
  *   Register this node with an LSP as an async-payments (APay) recipient.
  *   Used for offline-receive over Lightning Address: the wallet uploads

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -19,6 +19,18 @@
  * @property {number}  [ldkPeerListeningPort=0]
  * @property {number}  [maxMediaUploadSizeMb=5]
  * @property {boolean} [enableVirtualChannelsV0=false]
+ *   Enable virtual-channels-v0. REQUIRED (together with
+ *   `virtualPeerPubkeys`) for async-payments (APay) against a
+ *   production LSP — mobile clients reject standard channels and must
+ *   open `trusted_no_broadcast` virtual channels.
+ * @property {string[]} [virtualPeerPubkeys]
+ *   Trust list of peer node_ids (hex, 33-byte compressed secp256k1)
+ *   allowed to open / receive `trusted_no_broadcast` virtual channels
+ *   with this node. For APay this is the LSP's node_id:
+ *   `virtualPeerPubkeys: [lspNodeId]`. RLN's `allows_peer` rejects a
+ *   virtual channel whose counterparty isn't in this list. Omit (or
+ *   empty) to disable virtual peering. Forwarded as
+ *   `virtual_peer_pubkeys` in the init request.
  * @property {boolean} [permissiveSignerPolicy=true]
  * @property {string}  [vssUrl]
  *   Enables VSS cloud backup. Setting it points the node at a remote

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,137 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Typed error hierarchy for @utexo/wdk-rgb-lightning.
+//
+// Most of the wallet surface forwards directly to rgb-lightning-node
+// (RLN) via the C-FFI, and RLN reports failures as `Rln(<Variant>):
+// <message>` strings. Without a typed wrapper, callers are forced to
+// substring-match those strings to branch on failure mode — brittle
+// and version-coupled. These classes give callers a stable `name` +
+// `code` to switch on while preserving the original RLN message
+// verbatim (so any existing substring checks keep working) and the
+// underlying error as `cause`.
+//
+// Mirrors the shape of `LspError` (see lsp-client.js): a base class
+// with `name`/`code`/`cause` + `toJSON()` for structured logging, and
+// purpose-specific subclasses for the boundaries we wrap.
+
+/**
+ * Base class for all errors raised by this SDK. Carries a stable
+ * machine-readable `code`, the optional originating `cause`, and a
+ * `toJSON()` for structured logging.
+ */
+export class RgbLightningError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ code?: string, cause?: unknown }} [opts]
+   */
+  constructor (message, opts = {}) {
+    super(message)
+    this.name = 'RgbLightningError'
+    /** Stable, machine-readable error code. */
+    this.code = opts.code ?? 'RGB_LIGHTNING_ERROR'
+    if (opts.cause !== undefined) this.cause = opts.cause
+  }
+
+  toJSON () {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      cause: this.cause instanceof Error
+        ? { name: this.cause.name, message: this.cause.message }
+        : (this.cause ?? null)
+    }
+  }
+}
+
+/**
+ * Raised when bringing the node online (`unlock`) fails — bad
+ * bitcoind/indexer/proxy credentials, an unreachable backend, or a
+ * VSS init/restore failure surfaced during unlock.
+ */
+export class UnlockError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, { code: opts.code ?? 'UNLOCK_FAILED', cause: opts.cause })
+    this.name = 'UnlockError'
+  }
+}
+
+/**
+ * Raised for VSS (cloud backup) operations: a flush that fails, a
+ * fence takeover that's rejected, or any other VSS-server interaction
+ * error. See {@link VssNotConfiguredError} for the specific case where
+ * VSS was never configured at construction.
+ */
+export class VssError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, { code: opts.code ?? 'VSS_ERROR', cause: opts.cause })
+    this.name = 'VssError'
+  }
+}
+
+/**
+ * Raised when a VSS operation is attempted on a wallet that was
+ * constructed without a `vssUrl`. Distinct from {@link VssError} so
+ * callers can tell "you forgot to enable VSS" apart from "the VSS
+ * server rejected the request".
+ */
+export class VssNotConfiguredError extends VssError {
+  constructor (message = 'VSS is not configured — construct the wallet with a vssUrl to enable cloud backup.', opts = {}) {
+    super(message, { code: 'VSS_NOT_CONFIGURED', cause: opts.cause })
+    this.name = 'VssNotConfiguredError'
+  }
+}
+
+/**
+ * Raised for async-payments (APay) operations: `apayNew` /
+ * `bootstrapLsp` failures, including the LSP being unreachable, the
+ * host peer not being visible in time, or the LSP rejecting the
+ * async_order registration.
+ */
+export class ApayError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, { code: opts.code ?? 'APAY_ERROR', cause: opts.cause })
+    this.name = 'ApayError'
+  }
+}
+
+/**
+ * Raised by surface that is intentionally not implemented in this
+ * module (e.g. `verify`, `signTransaction`) because the underlying
+ * C-FFI doesn't expose it or the operation is out of scope. The
+ * message documents the supported alternative.
+ */
+export class NotImplementedError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, { code: 'NOT_IMPLEMENTED', cause: opts.cause })
+    this.name = 'NotImplementedError'
+  }
+}
+
+/**
+ * Wrap an arbitrary thrown value in a typed SDK error, preserving the
+ * original message verbatim (so existing substring checks against the
+ * RLN message — e.g. `.includes('Conflict')` — keep working) and
+ * attaching the original as `cause`.
+ *
+ * If `err` is already an instance of the target class it's returned
+ * unchanged, so wrapping is idempotent across nested call sites.
+ *
+ * @template {RgbLightningError} T
+ * @param {unknown} err              The caught value.
+ * @param {new (msg: string, opts?: object) => T} ErrorClass  Target class.
+ * @param {{ code?: string }} [opts]
+ * @returns {T}
+ */
+export function wrapError (err, ErrorClass, opts = {}) {
+  if (err instanceof ErrorClass) return err
+  const message = err && typeof err === 'object' && 'message' in err && err.message
+    ? String(err.message)
+    : String(err)
+  return new ErrorClass(message, { code: opts.code, cause: err })
+}

--- a/src/lsp-client.js
+++ b/src/lsp-client.js
@@ -187,6 +187,79 @@ export class LspClient {
   }
 
   /**
+   * Full LUD-06 resolution against *this* LSP: discover the callback
+   * URL from the Lightning-Address metadata, then fetch the BOLT11
+   * invoice in one call. Unlike {@link resolveAddressToInvoice} in
+   * `lnurl-pay.js` (which is host-agnostic and dials the address's own
+   * domain), this method always routes through the LSP's `baseUrl`: the
+   * callback URL the LSP returns is rewritten onto `baseUrl`'s origin so
+   * the second hop also benefits from this client's retry/timeout rails
+   * and works when the LSP advertises an internal/emulator host
+   * (e.g. `10.0.2.2`) the device can't otherwise reach.
+   *
+   * Mirrors `@utexo/rgb-sdk-rn`'s `UtexoLSPClient.resolveAddress`.
+   *
+   * @param {string} username                       Local-part of `user@host`.
+   * @param {bigint|number|string} amountMsat
+   * @param {object} [opts]
+   * @param {string} [opts.assetId]
+   * @param {bigint|number|string} [opts.assetAmount]
+   * @param {number} [opts.timeoutMs]
+   * @returns {Promise<{ pr:string, routes:unknown[], status?:string, reason?:string }>}
+   */
+  async resolveAddress (username, amountMsat, opts = {}) {
+    if (!isNonEmptyString(username)) throw new TypeError('LspClient.resolveAddress: username required')
+    const meta = await this.lnurlDiscovery(username, opts)
+    if (!meta || typeof meta.callback !== 'string' || meta.callback.length === 0) {
+      throw new LspError(`/.well-known/lnurlp/${username}`, 200, 'missing callback in LNURL response')
+    }
+    const cbPath = this._rewriteCallbackToPath(meta.callback)
+    const params = new URLSearchParams()
+    params.set('amount', toIntString(amountMsat, 'amountMsat'))
+    if (opts.assetId !== undefined) params.set('asset_id', String(opts.assetId))
+    if (opts.assetAmount !== undefined) params.set('asset_amount', toIntString(opts.assetAmount, 'assetAmount'))
+    const sep = cbPath.includes('?') ? '&' : '?'
+    return this._req('GET', `${cbPath}${sep}${params.toString()}`, undefined, opts)
+  }
+
+  /**
+   * Resolve the auto-assigned Lightning Address (`{ username, domain }`)
+   * the LSP minted for a node pubkey — i.e. the offline-receive address
+   * created as a side effect of `apayNew` / `async_order/new`. Give the
+   * resulting `username@domain` to senders.
+   *
+   * Mirrors `@utexo/rgb-sdk-rn`'s
+   * `UtexoLSPClient.getLightningAddressByPubkey`.
+   *
+   * @param {string} peerPubkey  33-byte compressed node pubkey (hex).
+   * @param {object} [opts]
+   * @param {number} [opts.timeoutMs]
+   * @returns {Promise<{ username:string, domain:string }>}
+   */
+  getLightningAddressByPubkey (peerPubkey, opts = {}) {
+    const pk = typeof peerPubkey === 'string' ? peerPubkey.trim() : ''
+    if (pk.length === 0) throw new TypeError('LspClient.getLightningAddressByPubkey: peerPubkey required')
+    return this._req('GET', `/lightning_address/by_pubkey/${encodeURIComponent(pk)}`, undefined, opts)
+  }
+
+  /**
+   * Reduce an LSP-advertised callback URL to a path (+query+hash) rooted
+   * at this client's `baseUrl`. Keeps the second LUD-06 hop on the same
+   * origin so it inherits the client's retry/timeout config and dodges
+   * unreachable internal hosts. Falls back to the raw string if it can't
+   * be parsed.
+   * @private
+   */
+  _rewriteCallbackToPath (callbackUrl) {
+    try {
+      const cb = new URL(callbackUrl, this._base)
+      return `${cb.pathname}${cb.search}${cb.hash}`
+    } catch {
+      return callbackUrl.startsWith('/') ? callbackUrl : `/${callbackUrl}`
+    }
+  }
+
+  /**
    * Bridge: caller hands the LSP an RGB invoice + LN-side parameters;
    * the LSP returns a BOLT11 invoice for the caller to pay. Once paid,
    * the LSP runs `sendrgb` to the recipient embedded in the RGB

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -50,6 +50,8 @@ export class NodeRgbLightningBinding {
     this._signer = null
     /** @type {boolean} */
     this._sdkInitDone = false
+    /** @type {number | null} Snapshot version returned by the most recent vssBackup(). */
+    this._lastVssVersion = null
   }
 
   ensureNode () {
@@ -128,18 +130,30 @@ export class NodeRgbLightningBinding {
    * @returns {{version: number}}
    */
   vssBackup () {
-    return this.node.vssBackup()
+    const r = this.node.vssBackup()
+    if (r && typeof r.version === 'number') this._lastVssVersion = r.version
+    return r
   }
 
   /**
-   * Register this node with an LSP as an async-payments (APay) recipient.
+   * Local-view VSS status. RLN's C-FFI exposes no read-only
+   * server-side backup-info query (unlike rgb-lib's `vssBackupInfo`),
+   * so this reports what the host can know without a round-trip:
+   * whether VSS was configured at construction, the configured URL +
+   * allow-http flag, and the snapshot version from the most recent
+   * `vssBackup()` call this session (`null` if none yet). For a live
+   * server version, call `vssBackup()` (it flushes and returns the
+   * fresh `{ version }`).
    *
-   * @param {string} hostNodeId  - LSP's node_id (hex)
-   * @returns {object}  AsyncOrderNewResponse from upstream PR #51
+   * @returns {{ configured: boolean, url: string|null, allowHttp: boolean, lastBackupVersion: number|null }}
    */
-  apayNew (hostNodeId) {
-    const node = this.node
-    return node.apayNew(hostNodeId)
+  vssStatus () {
+    return {
+      configured: !!this._config.vssUrl,
+      url: this._config.vssUrl ?? null,
+      allowHttp: !!this._config.vssAllowHttp,
+      lastBackupVersion: this._lastVssVersion
+    }
   }
 
   /**

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -36,6 +36,15 @@ export class NodeRgbLightningBinding {
       max_media_upload_size_mb: config.maxMediaUploadSizeMb ?? 5,
       enable_virtual_channels_v0: config.enableVirtualChannelsV0 ?? false
     }
+    // Virtual-channels-v0 trust list. When the LSP opens (or the device
+    // opens against the LSP) a `trusted_no_broadcast` virtual channel,
+    // the device must list the LSP's node_id here or RLN's `allows_peer`
+    // rejects the channel. Production APay requires this — see Yurii's
+    // Signet LSP setup: every mobile client sets enableVirtualChannelsV0
+    // + virtualPeerPubkeys=[LSP node_id]. Forwarded only when non-empty.
+    if (Array.isArray(config.virtualPeerPubkeys) && config.virtualPeerPubkeys.length > 0) {
+      this._initRequest.virtual_peer_pubkeys = config.virtualPeerPubkeys
+    }
     // VSS fields are only forwarded when the host opts in. Omitting them
     // lets the RLN-side `#[serde(default)]` keep VSS fully disabled.
     if (config.vssUrl) this._initRequest.vss_url = config.vssUrl

--- a/src/utexo-lsp.js
+++ b/src/utexo-lsp.js
@@ -1,0 +1,435 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Composed, stateful LSP flows on top of a WalletAccountRgbLightning +
+// an LspClient. Where `lsp-helpers.js` exposes single-shot functions,
+// this class bundles the connect → wait-for-channel → receive/send →
+// settle lifecycle that a wallet app actually drives, with built-in
+// polling, abort support, and per-iteration hooks (e.g. mine a regtest
+// block each poll).
+//
+// API parity with `@utexo/rgb-sdk-rn`'s `UtexoLsp` (src/lsp/UtexoLsp.ts),
+// adapted to this module's account surface: our account exposes
+// `sync()` (not `syncWallet()`), `createLightningInvoice()` returns
+// RLN's `{ invoice }` (not `{ lnInvoice }`), and `getInvoiceStatus()`
+// returns `{ status }` (not a bare string). Those shape differences are
+// absorbed here so the public method names + semantics match.
+
+import { LspClient } from './lsp-client.js'
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/** No usable RGB channel for the asset materialised before `timeoutMs`. */
+export class LspChannelTimeoutError extends Error {
+  constructor (assetId, elapsedMs) {
+    super(`No usable RGB channel for ${assetId} after ${Math.round(elapsedMs / 1000)}s`)
+    this.name = 'LspChannelTimeoutError'
+    this.assetId = assetId
+    this.elapsedMs = elapsedMs
+  }
+}
+
+/** Settlement reached a terminal non-success state (Failed / Expired). */
+export class LspSettlementError extends Error {
+  constructor (step, status) {
+    super(`Settlement ended with status "${status}" at step ${step}`)
+    this.name = 'LspSettlementError'
+    this.step = step
+    this.status = status
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build the `pubkey@host:port` string `connectPeer` accepts. */
+export function peerUri (peer) {
+  return `${peer.peerPubkey}@${peer.peerHost}:${peer.peerPort}`
+}
+
+/**
+ * Canonicalise the many status shapes RLN / the LSP emit into the four
+ * receive states. Accepts a bare string (`'Succeeded'`) or an object
+ * (`{ status }` from `getInvoiceStatus`).
+ * @param {string|{status?:string}|null|undefined} raw
+ * @returns {'Pending'|'Succeeded'|'Failed'|'Expired'}
+ */
+export function normalizeReceiveStatus (raw) {
+  const s = (typeof raw === 'object' && raw !== null ? raw.status : raw) ?? ''
+  const up = String(s).toUpperCase()
+  if (up === 'SUCCEEDED' || up === 'SETTLED') return 'Succeeded'
+  if (up === 'FAILED') return 'Failed'
+  if (up === 'EXPIRED') return 'Expired'
+  return 'Pending'
+}
+
+const DEFAULT_CHANNEL_TIMEOUT_MS = 120_000
+const DEFAULT_SETTLEMENT_TIMEOUT_MS = 60_000
+const DEFAULT_POLL_INTERVAL_MS = 2_000
+
+// ── UtexoLsp ─────────────────────────────────────────────────────────────────
+
+export class UtexoLsp {
+  /**
+   * @param {object} account  A WalletAccountRgbLightning (or compatible)
+   *   exposing connectPeer, sync, listChannels, createLightningInvoice,
+   *   getInvoiceStatus, sendPayment, getNodeInfo, apayNew, listPayments,
+   *   claimHodlInvoice.
+   * @param {object} peer      LspPeer: `{ baseUrl, peerPubkey, peerHost,
+   *   peerPort, bearerToken?, timeoutMs?, allowHttp? }`.
+   */
+  constructor (account, peer) {
+    if (account == null) throw new TypeError('UtexoLsp: account required')
+    if (peer == null || typeof peer.baseUrl !== 'string') {
+      throw new TypeError('UtexoLsp: peer.baseUrl required')
+    }
+    this.account = account
+    this.peer = peer
+    /** Raw HTTP client for one-off LSP calls. @type {LspClient} */
+    this.http = new LspClient({
+      baseUrl: peer.baseUrl,
+      defaultHeaders: peer.bearerToken ? { Authorization: `Bearer ${peer.bearerToken}` } : undefined,
+      allowHttp: peer.allowHttp === true,
+      timeoutMs: peer.timeoutMs
+    })
+  }
+
+  // ── 1. Connection ────────────────────────────────────────────────────────────
+
+  /**
+   * Connect to the LSP's Lightning node. Idempotent — the account's
+   * `connectPeer` already swallows RLN's `Conflict` on a known peer.
+   */
+  async connect () {
+    return this.account.connectPeer(peerUri(this.peer))
+  }
+
+  // ── 2. Channel readiness ──────────────────────────────────────────────────────
+
+  /**
+   * Poll `listChannels` until a usable RGB channel for `assetId` exists.
+   * @param {string} assetId
+   * @param {object} [opts]  WaitOptions (timeoutMs, pollIntervalMs, signal, onProgress, onEachPoll).
+   * @returns {Promise<object>}  ChannelReadyInfo.
+   * @throws {LspChannelTimeoutError}
+   */
+  async waitForChannel (assetId, opts = {}) {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_CHANNEL_TIMEOUT_MS
+    const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    const deadline = Date.now() + timeoutMs
+
+    while (Date.now() < deadline) {
+      this._checkAbort(opts.signal)
+      if (opts.onEachPoll) await opts.onEachPoll()
+      await this.account.sync()
+      const channels = await this._listChannels()
+      const match = channels.find((c) => this._isUsableRgbChannel(c, assetId))
+      opts.onProgress?.(`channels: ${channels.length} — RGB usable: ${match ? 'yes' : 'no'}`)
+      if (match) return this._toChannelReadyInfo(match)
+      await this._sleep(pollIntervalMs, opts.signal)
+    }
+    throw new LspChannelTimeoutError(assetId, timeoutMs)
+  }
+
+  // ── 3. Receive RGB over Lightning (POST /lightning_receive) ───────────────────
+
+  /**
+   * Lightning → RGB bridge. Mints a LN invoice on this wallet, registers
+   * it with the LSP, and returns both invoices. Share `rgbInvoice` with
+   * the on-chain sender; the LSP pays `lnInvoice` once the RGB transfer
+   * settles.
+   *
+   * @param {object} opts
+   * @param {string} opts.assetId
+   * @param {number} [opts.amountSats]      LN amount (sats) for the BOLT11. Omit for amountless.
+   * @param {number} [opts.amountRgb]       RGB units bound to the invoice.
+   * @param {number} [opts.expirySeconds=3600]
+   * @returns {Promise<{ lnInvoice:string, rgbInvoice:string, mappingId:string }>}
+   */
+  async receiveAsset (opts = {}) {
+    if (typeof opts.assetId !== 'string' || opts.assetId.length === 0) {
+      throw new TypeError('UtexoLsp.receiveAsset: assetId required')
+    }
+    const expirySeconds = opts.expirySeconds ?? 3600
+
+    const createdAtMs = Date.now()
+    const created = await this.account.createLightningInvoice({
+      amountMsat: opts.amountSats != null ? Number(opts.amountSats) * 1000 : undefined,
+      expirySec: expirySeconds,
+      assetId: opts.assetId,
+      assetAmount: opts.amountRgb
+    })
+    const lnInvoice = created?.invoice ?? created?.lnInvoice
+    if (typeof lnInvoice !== 'string' || lnInvoice.length === 0) {
+      throw new Error('UtexoLsp.receiveAsset: createLightningInvoice returned no invoice')
+    }
+
+    // The LSP validates durationSeconds against the LN invoice's
+    // *remaining* lifetime (utexo-lsp EXPIRY_MATCH_TOLERANCE_SEC, ~5s).
+    // Invoice creation on a mobile node can take seconds, so send the
+    // remaining lifetime — sending the full expiry 400s once creation
+    // outlasts the tolerance.
+    const elapsedSeconds = Math.round((Date.now() - createdAtMs) / 1000)
+    const durationSeconds = Math.max(1, expirySeconds - elapsedSeconds)
+
+    const lr = await this.http.lightningReceive({
+      lnInvoice,
+      rgb: { assetId: opts.assetId, durationSeconds }
+    })
+    return { lnInvoice, rgbInvoice: lr.rgbInvoice, mappingId: String(lr.mappingId) }
+  }
+
+  // ── 4. Settlement polling ─────────────────────────────────────────────────────
+
+  /**
+   * Poll `getInvoiceStatus(lnInvoice)` until terminal.
+   * @param {string} lnInvoice
+   * @param {object} [opts]  WaitOptions.
+   * @returns {Promise<'settled'|'timed_out'>}
+   * @throws {LspSettlementError} on Failed / Expired.
+   */
+  async awaitReceiveSettlement (lnInvoice, opts = {}) {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_SETTLEMENT_TIMEOUT_MS
+    const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    const deadline = Date.now() + timeoutMs
+
+    while (Date.now() < deadline) {
+      this._checkAbort(opts.signal)
+      await this.account.sync()
+      const raw = await this.account.getInvoiceStatus(lnInvoice)
+      const status = normalizeReceiveStatus(raw)
+      opts.onProgress?.(status)
+      if (status === 'Succeeded') return 'settled'
+      if (status === 'Failed' || status === 'Expired') {
+        throw new LspSettlementError('ln_invoice', status)
+      }
+      await this._sleep(pollIntervalMs, opts.signal)
+    }
+    opts.onProgress?.('timeout')
+    return 'timed_out'
+  }
+
+  // ── 5. Outbound liquidity wait ────────────────────────────────────────────────
+
+  /**
+   * Poll until outbound balance on the LSP channel ≥ `minMsat`.
+   * @param {number} minMsat
+   * @param {object} [opts]  WaitOptions.
+   */
+  async waitForOutboundLiquidity (minMsat, opts = {}) {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_CHANNEL_TIMEOUT_MS
+    const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    const deadline = Date.now() + timeoutMs
+
+    while (Date.now() < deadline) {
+      this._checkAbort(opts.signal)
+      await this.account.sync()
+      const channels = await this._listChannels()
+      const lspChan = channels.find((c) =>
+        this._raw(c, 'peerPubkey', 'peer_pubkey') === this.peer.peerPubkey &&
+        Boolean(this._raw(c, 'isUsable', 'is_usable'))
+      )
+      const outbound = Number(this._outboundMsat(lspChan))
+      opts.onProgress?.(`outbound: ${outbound} msat (need ${minMsat})`)
+      if (outbound >= minMsat) return
+      await this._sleep(pollIntervalMs, opts.signal)
+    }
+  }
+
+  // ── 6. Send RGB via LSP (POST /onchain_send) ──────────────────────────────────
+
+  /**
+   * RGB → Lightning bridge. Submits the recipient's on-chain RGB invoice
+   * to the LSP, then pays the LN invoice the LSP returns. The LSP runs
+   * `sendrgb` to the recipient once the LN payment settles.
+   *
+   * @param {object} opts
+   * @param {string} opts.rgbInvoice
+   * @param {object} [opts.ln]  LN params (`{ amtMsat, expirySec, assetId?, assetAmount? }`).
+   * @returns {Promise<{ lnInvoice:string, rgbInvoice:string, mappingId:string, sendResult:any }>}
+   */
+  async sendAsset (opts = {}) {
+    if (typeof opts.rgbInvoice !== 'string' || opts.rgbInvoice.length === 0) {
+      throw new TypeError('UtexoLsp.sendAsset: rgbInvoice required')
+    }
+    const issued = await this.http.onchainSend({ rgbInvoice: opts.rgbInvoice, ln: opts.ln })
+    const sendResult = await this.account.sendPayment({ invoice: issued.lnInvoice })
+    return {
+      lnInvoice: issued.lnInvoice,
+      rgbInvoice: issued.rgbInvoice,
+      mappingId: String(issued.mappingId),
+      sendResult
+    }
+  }
+
+  // ── 7. Pay a Lightning Address ────────────────────────────────────────────────
+
+  /**
+   * Resolve a Lightning Address and pay it. Tries this LSP's
+   * `resolveAddress` first (handles internal/emulator host rewriting),
+   * then falls back to host-agnostic LUD-06 discovery on the address's
+   * own domain.
+   *
+   * @param {object} opts
+   * @param {string} opts.address          `user@host`.
+   * @param {bigint|number} opts.amtMsat
+   * @param {object} [opts.asset]          `{ assetId, assetAmount }`.
+   * @returns {Promise<{ invoice:string, sendResult:any }>}
+   */
+  async payAddress (opts = {}) {
+    const address = opts.address
+    if (typeof address !== 'string' || !address.includes('@')) {
+      throw new TypeError(`UtexoLsp.payAddress: invalid Lightning Address "${address}"`)
+    }
+    const [username, domain] = address.split('@')
+    if (!username || !domain) throw new TypeError(`UtexoLsp.payAddress: invalid Lightning Address "${address}"`)
+
+    let invoice
+    try {
+      const cb = await this.http.resolveAddress(
+        username, opts.amtMsat, { assetId: opts.asset?.assetId, assetAmount: opts.asset?.assetAmount }
+      )
+      invoice = cb?.pr
+    } catch {
+      // Fall back to standard LNURL discovery on the address's own host.
+      const fetcher = globalThis.fetch
+      if (typeof fetcher !== 'function') throw new Error('UtexoLsp.payAddress: no global fetch for LNURL fallback')
+      const meta = await fetcher(`https://${domain}/.well-known/lnurlp/${encodeURIComponent(username)}`).then((r) => r.json())
+      if (!meta?.callback) throw new Error('UtexoLsp.payAddress: missing callback in LNURL response')
+      let url = `${meta.callback}${meta.callback.includes('?') ? '&' : '?'}amount=${opts.amtMsat}`
+      if (opts.asset?.assetId) url += `&asset_id=${encodeURIComponent(opts.asset.assetId)}`
+      if (opts.asset?.assetAmount !== undefined) url += `&asset_amount=${opts.asset.assetAmount}`
+      const cb = await fetcher(url).then((r) => r.json())
+      invoice = cb?.pr
+    }
+
+    if (typeof invoice !== 'string' || invoice.length === 0) {
+      throw new Error('UtexoLsp.payAddress: no invoice returned for Lightning Address')
+    }
+    const sendResult = await this.account.sendPayment({ invoice })
+    return { invoice, sendResult }
+  }
+
+  // ── 8. Async / offline receive (APay) ─────────────────────────────────────────
+
+  /**
+   * Register the async-payment hash pool with this LSP, then read back
+   * the auto-assigned Lightning Address for this wallet's pubkey. Call
+   * once after first unlock to enable offline receive.
+   *
+   * @returns {Promise<{ username:string, domain:string, address:string }>}
+   */
+  async enableLightningAddress () {
+    const nodeInfo = await this.account.getNodeInfo()
+    const pubkey = String(nodeInfo?.pubkey ?? '')
+    if (!pubkey) throw new Error('UtexoLsp.enableLightningAddress: wallet not unlocked (no pubkey)')
+
+    const lspInfo = await this.http.getInfo()
+    const lspPubkey = lspInfo?.pubkey
+    if (typeof lspPubkey !== 'string' || lspPubkey.length === 0) {
+      throw new Error('UtexoLsp.enableLightningAddress: LSP /get_info returned no pubkey')
+    }
+    await this.account.apayNew(lspPubkey)
+
+    const addr = await this.http.getLightningAddressByPubkey(pubkey)
+    return { username: addr.username, domain: addr.domain, address: `${addr.username}@${addr.domain}` }
+  }
+
+  // ── 9. Claim pending HODL payments ────────────────────────────────────────────
+
+  /**
+   * Find inbound CLAIMABLE/CLAIMING payments and claim each via
+   * `claimHodlInvoice`. Use after unlock to settle invoices that arrived
+   * while offline.
+   *
+   * @returns {Promise<Array<{ paymentHash:string, claimed:boolean, error?:string }>>}
+   */
+  async claimPendingPayments () {
+    const payments = await this._listPayments()
+    const claimable = payments.filter((p) => {
+      const s = String(this._raw(p, 'status', 'status') ?? '').toUpperCase()
+      return s === 'CLAIMABLE' || s === 'CLAIMING'
+    })
+
+    const results = []
+    for (const p of claimable) {
+      const paymentHash = String(this._raw(p, 'paymentHash', 'payment_hash') ?? '')
+      const preimage = String(
+        this._raw(p, 'paymentPreimage', 'payment_preimage') ??
+        this._raw(p, 'paymentImage', 'payment_image') ?? ''
+      )
+      try {
+        // RLN's claim request is passed through verbatim by the account;
+        // include both the hash and preimage under the common key names.
+        await this.account.claimHodlInvoice({ payment_hash: paymentHash, payment_preimage: preimage })
+        results.push({ paymentHash, claimed: true })
+      } catch (err) {
+        results.push({ paymentHash, claimed: false, error: err?.message })
+      }
+    }
+    return results
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────────
+
+  async _listChannels () {
+    const resp = await this.account.listChannels()
+    if (Array.isArray(resp)) return resp
+    if (resp && Array.isArray(resp.channels)) return resp.channels
+    return []
+  }
+
+  async _listPayments () {
+    const resp = await this.account.listPayments()
+    if (Array.isArray(resp)) return resp
+    if (resp && Array.isArray(resp.payments)) return resp.payments
+    return []
+  }
+
+  _isUsableRgbChannel (c, assetId) {
+    return (
+      this._raw(c, 'assetId', 'asset_id') === assetId &&
+      Boolean(this._raw(c, 'isUsable', 'is_usable') ?? this._raw(c, 'ready', 'ready'))
+    )
+  }
+
+  _toChannelReadyInfo (c) {
+    return {
+      channelId: String(this._raw(c, 'channelId', 'channel_id') ?? ''),
+      peerPubkey: this.peer.peerPubkey,
+      capacitySat: Number(this._raw(c, 'capacitySat', 'capacity_sat') ?? 0),
+      outboundBalanceMsat: Number(this._outboundMsat(c)),
+      inboundBalanceMsat: Number(this._raw(c, 'inboundBalanceMsat', 'inbound_balance_msat') ?? 0)
+    }
+  }
+
+  // RLN channel JSON has shifted field names across versions
+  // (`outbound_balance_msat` vs `local_balance_msat`); read either.
+  _outboundMsat (c) {
+    return (
+      this._raw(c, 'outboundBalanceMsat', 'outbound_balance_msat') ??
+      this._raw(c, 'localBalanceMsat', 'local_balance_msat') ??
+      0
+    )
+  }
+
+  _raw (obj, camel, snake) {
+    if (obj == null) return undefined
+    return obj[camel] ?? obj[snake]
+  }
+
+  _checkAbort (signal) {
+    if (signal?.aborted) throw new Error('UtexoLsp: operation aborted')
+  }
+
+  _sleep (ms, signal) {
+    // NB: do NOT unref() — this is a deliberate poll-interval wait and
+    // must keep the event loop alive until it resolves or aborts.
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(resolve, ms)
+      signal?.addEventListener('abort', () => { clearTimeout(t); reject(new Error('UtexoLsp: aborted')) }, { once: true })
+    })
+  }
+}

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -17,6 +17,8 @@ import {
   requestLspRgbDeposit as _requestLspRgbDeposit,
   payRgbViaLsp as _payRgbViaLsp
 } from './lsp-helpers.js'
+import { LspClient } from './lsp-client.js'
+import { UtexoLsp } from './utexo-lsp.js'
 import {
   UnlockError,
   VssError,
@@ -342,6 +344,63 @@ export default class WalletAccountRgbLightning {
     return result
   }
 
+  /**
+   * Returns the `lspBaseUrl` / `lspBearerToken` this account's node was
+   * constructed with (from the wallet-manager config). Useful to confirm
+   * APay config matches the {@link createLsp} peer config. Mirrors
+   * `@utexo/rgb-sdk-rn`'s `getLspConfig`.
+   *
+   * @returns {{ baseUrl: string|null, bearerToken: string|null }}
+   */
+  getLspConfig () {
+    const cfg = (this._binding && this._binding._config) || {}
+    return {
+      baseUrl: cfg.lspBaseUrl ?? null,
+      bearerToken: cfg.lspBearerToken ?? null
+    }
+  }
+
+  /**
+   * Build a {@link UtexoLsp} — the composed LSP flow object (connect,
+   * wait-for-channel, receive/send asset, pay address, enable Lightning
+   * Address, claim pending). Mirrors `@utexo/rgb-sdk-rn`'s
+   * `wallet.createLsp(peer?)`.
+   *
+   * No-arg form auto-discovers the peer from the wallet's `lspBaseUrl`:
+   * pubkey via `GET /get_info`, host from the base URL, port from
+   * `peerPort` (default 9735).
+   *
+   * Explicit form takes a full LspPeer
+   * (`{ baseUrl, peerPubkey, peerHost, peerPort, bearerToken?, timeoutMs?, allowHttp? }`).
+   *
+   * @param {object} [peer]
+   * @param {number} [peerPort=9735]  Used only by the auto-discover form.
+   * @returns {Promise<UtexoLsp>}
+   */
+  async createLsp (peer, peerPort = 9735) {
+    if (peer) return new UtexoLsp(this, peer)
+
+    const { baseUrl, bearerToken } = this.getLspConfig()
+    if (!baseUrl) {
+      throw new Error('createLsp: lspBaseUrl not set — pass a peer explicitly or construct the wallet with lspBaseUrl')
+    }
+    const http = new LspClient({
+      baseUrl,
+      defaultHeaders: bearerToken ? { Authorization: `Bearer ${bearerToken}` } : undefined
+    })
+    const info = await http.getInfo()
+    if (!info || typeof info.pubkey !== 'string' || info.pubkey.length === 0) {
+      throw new Error('createLsp: LSP /get_info returned no pubkey')
+    }
+    return new UtexoLsp(this, {
+      baseUrl,
+      peerPubkey: info.pubkey,
+      peerHost: new URL(baseUrl).hostname,
+      peerPort,
+      bearerToken: bearerToken ?? undefined
+    })
+  }
+
   // ==========================================================================
   // Node info / network / sync — ✅ wired
   // ==========================================================================
@@ -528,6 +587,40 @@ export default class WalletAccountRgbLightning {
 
   /** @param {string} invoice */
   async getInvoiceStatus (invoice) { return this._node.invoiceStatus(invoice) }
+
+  /**
+   * Create a HODL (hold) invoice — a BOLT11 bound to a caller-supplied
+   * `paymentHash` whose preimage the receiver releases later via
+   * {@link claimHodlInvoice}. Convenience wrapper over
+   * {@link createInvoice} (which already accepts `payment_hash`); named
+   * for parity with `@utexo/rgb-sdk-rn`'s `createHodlInvoice`.
+   *
+   * @param {object} params
+   * @param {string}  params.paymentHash             32-byte payment hash (hex).
+   * @param {number} [params.amtMsat]
+   * @param {number}  params.expirySec
+   * @param {string} [params.assetId]
+   * @param {number} [params.assetAmount]
+   * @param {number} [params.minFinalCltvExpiryDelta]
+   * @returns {Promise<{ bolt11:string, paymentHash:string }>}
+   */
+  async createHodlInvoice (params = {}) {
+    if (!params || typeof params.paymentHash !== 'string' || params.paymentHash.length === 0) {
+      throw new TypeError('createHodlInvoice: params.paymentHash (hex) is required')
+    }
+    const res = await this.createLightningInvoice({
+      paymentHash: params.paymentHash,
+      amountMsat: params.amtMsat ?? undefined,
+      expirySec: params.expirySec,
+      assetId: params.assetId ?? undefined,
+      assetAmount: params.assetAmount ?? undefined,
+      minFinalCltvExpiryDelta: params.minFinalCltvExpiryDelta ?? undefined
+    })
+    return {
+      bolt11: res?.invoice ?? res?.bolt11 ?? '',
+      paymentHash: res?.payment_hash ?? params.paymentHash
+    }
+  }
 
   // Hodl invoices — 🚧 (request shape is upstream-defined; passthrough kept simple)
   /** @param {Object} request */

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -17,6 +17,14 @@ import {
   requestLspRgbDeposit as _requestLspRgbDeposit,
   payRgbViaLsp as _payRgbViaLsp
 } from './lsp-helpers.js'
+import {
+  UnlockError,
+  VssError,
+  VssNotConfiguredError,
+  ApayError,
+  NotImplementedError,
+  wrapError
+} from './errors.js'
 
 /**
  * Sentinel placeholder address returned by `getAddress()` before the
@@ -92,7 +100,15 @@ export default class WalletAccountRgbLightning {
    * @param {Object} unlockRequest
    */
   async unlock (unlockRequest) {
-    this._binding.unlock(unlockRequest)
+    try {
+      this._binding.unlock(unlockRequest)
+    } catch (e) {
+      // Wrap into a typed UnlockError so callers can branch on
+      // `err.name === 'UnlockError'` / `err.code` instead of
+      // substring-matching the RLN message. The original message is
+      // preserved verbatim and attached as `cause`.
+      throw wrapError(e, UnlockError)
+    }
     // Return something non-undefined so the worklet's `safeStringify`
     // produces a real string. The RN-side response schema rejects
     // null/undefined results (see wdk-react-native-core schemas).
@@ -124,10 +140,46 @@ export default class WalletAccountRgbLightning {
    * docs section "Single-writer ownership" for the contract.
    *
    * @param {string} password
+   * @throws {VssNotConfiguredError} if the wallet was built without a vssUrl.
+   * @throws {VssError} if the takeover is rejected by the VSS server.
    */
   async clearVssFence (password) {
-    this._binding.clearVssFence(password)
+    this._assertVssConfigured()
+    try {
+      this._binding.clearVssFence(password)
+    } catch (e) {
+      throw wrapError(e, VssError)
+    }
     return { ok: true }
+  }
+
+  /**
+   * @private
+   * @throws {VssNotConfiguredError} if no vssUrl was set at construction.
+   */
+  _assertVssConfigured () {
+    const status = this._binding.vssStatus()
+    if (!status || !status.configured) {
+      throw new VssNotConfiguredError()
+    }
+  }
+
+  /**
+   * Local-view VSS status — does not hit the server. Reports whether
+   * VSS was configured at construction (`vssUrl`), the configured URL +
+   * allow-http flag, and `lastBackupVersion`: the snapshot version from
+   * the most recent `vssBackup()` call this session (`null` if none).
+   *
+   * RLN's C-FFI exposes no read-only server-side backup-info query
+   * (unlike rgb-lib's `vssBackupInfo`), so a live server version is only
+   * available by calling `vssBackup()` (which flushes and returns the
+   * fresh `{ version }`). Use this method for cheap "is VSS on / what
+   * was my last checkpoint" reads without a network round-trip.
+   *
+   * @returns {Promise<{ configured: boolean, url: string|null, allowHttp: boolean, lastBackupVersion: number|null }>}
+   */
+  async vssStatus () {
+    return this._binding.vssStatus()
   }
 
   /**
@@ -151,9 +203,16 @@ export default class WalletAccountRgbLightning {
    * round-trip with the cloud before potentially being killed.
    *
    * @returns {Promise<{version: number}>}
+   * @throws {VssNotConfiguredError} if the wallet was built without a vssUrl.
+   * @throws {VssError} if the flush fails (server unreachable, auth rejected).
    */
   async vssBackup () {
-    return this._binding.vssBackup()
+    this._assertVssConfigured()
+    try {
+      return this._binding.vssBackup()
+    } catch (e) {
+      throw wrapError(e, VssError)
+    }
   }
 
   /**
@@ -174,7 +233,11 @@ export default class WalletAccountRgbLightning {
    *      refill_batch_size, first_hash_index }`
    */
   async apayNew (hostNodeId) {
-    return this._binding.apayNew(hostNodeId)
+    try {
+      return this._binding.apayNew(hostNodeId)
+    } catch (e) {
+      throw wrapError(e, ApayError)
+    }
   }
 
   /**
@@ -266,11 +329,12 @@ export default class WalletAccountRgbLightning {
     const result = { connect, peerVisible }
     if (typeof hostNodeId === 'string' && hostNodeId.length > 0) {
       if (!peerVisible) {
-        throw new Error(
+        throw new ApayError(
           'bootstrapLsp: peer did not appear in listPeers within ' +
           `${waitForPeerMs}ms — refusing to call apayNew because RLN ` +
           'will time out waiting for host response. Retry later or ' +
-          'call apayNew directly once the peer is visible.'
+          'call apayNew directly once the peer is visible.',
+          { code: 'APAY_PEER_NOT_VISIBLE' }
         )
       }
       result.apay = await this.apayNew(hostNodeId)
@@ -395,6 +459,54 @@ export default class WalletAccountRgbLightning {
    *   applies when omitted.
    */
   async createInvoice (request) { return this._node.lnInvoice(request) }
+
+  /**
+   * Cross-SDK alias for {@link createInvoice}. The reference on-chain
+   * SDK (`@utexo/rgb-sdk-rn`) names the receive-side entry
+   * `createLightningInvoice`; we expose the same name here for
+   * discoverability, accepting either the native RLN snake_case request
+   * (forwarded verbatim) or a camelCase convenience shape
+   * `{ amountMsat?, expirySec, assetId?, assetAmount?, paymentHash?,
+   *    descriptionHash?, minFinalCltvExpiryDelta? }`.
+   *
+   * Unlike the reference SDK's stub (which throws "not implemented"),
+   * this is fully backed by a local LDK node.
+   *
+   * @param {Object} request
+   * @returns {Promise<object>}  RLN's lnInvoice response (invoice, payment_hash, ...).
+   */
+  async createLightningInvoice (request) {
+    return this.createInvoice(WalletAccountRgbLightning._toLnInvoiceRequest(request))
+  }
+
+  /**
+   * Normalise a camelCase convenience invoice request to RLN's
+   * snake_case shape. Passes through snake_case keys untouched so a
+   * native request object still works verbatim.
+   * @private
+   * @param {Object} [req]
+   * @returns {Object}
+   */
+  static _toLnInvoiceRequest (req) {
+    if (!req || typeof req !== 'object') return req
+    const out = { ...req }
+    const map = {
+      amountMsat: 'amt_msat',
+      expirySec: 'expiry_sec',
+      assetId: 'asset_id',
+      assetAmount: 'asset_amount',
+      paymentHash: 'payment_hash',
+      descriptionHash: 'description_hash',
+      minFinalCltvExpiryDelta: 'min_final_cltv_expiry_delta'
+    }
+    for (const [camel, snake] of Object.entries(map)) {
+      if (camel in out && !(snake in out)) {
+        out[snake] = out[camel]
+        delete out[camel]
+      }
+    }
+    return out
+  }
 
   /** @param {string} invoice */
   async decodeInvoice (invoice) { return this._node.decodeLnInvoice(invoice) }
@@ -622,7 +734,7 @@ export default class WalletAccountRgbLightning {
    * @returns {Promise<boolean>}
    */
   async verify (_message, _signature) {
-    throw new Error(
+    throw new NotImplementedError(
       'verify() requires upstream c-ffi support for rln_verify_message — ' +
       'pending: expose lightning::util::message_signing::verify in rgb-lightning-node/bindings/c-ffi.'
     )
@@ -639,7 +751,7 @@ export default class WalletAccountRgbLightning {
    * @returns {Promise<never>}
    */
   async signTransaction (_tx) {
-    throw new Error(
+    throw new NotImplementedError(
       'signTransaction() is not exposed on RGB Lightning accounts — ' +
       'use sendTransaction(request) for on-chain spends (VLS signs in-process), ' +
       'sendPayment/keysend for LN, or sendRgbAsset for RGB transfers.'

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -391,7 +391,22 @@ export default class WalletAccountRgbLightning {
   // Channels — ✅ all wired
   // ==========================================================================
 
-  /** @param {Object} request - JsonOpenChannelRequest */
+  /**
+   * Open a Lightning channel. Request is forwarded verbatim to RLN.
+   *
+   * For async-payments (APay) against a production LSP, open a virtual
+   * channel by passing `virtual_open_mode: 'trusted_no_broadcast'` and
+   * constructing the wallet with `enableVirtualChannelsV0: true` +
+   * `virtualPeerPubkeys: [lspNodeId]`. Standard (broadcast) channels are
+   * rejected by APay mobile clients.
+   *
+   * Note: RGB-routed HTLCs have a hard minimum of 3_000_000 msat (the
+   * LSP's `MIN_AMT_MSAT`); size asset channels accordingly.
+   *
+   * @param {Object} request - JsonOpenChannelRequest (`peer_pubkey_and_opt_addr`,
+   *   `capacity_sat`, `push_msat?`, `asset_id?`, `asset_amount?`, `public?`,
+   *   `with_anchors?`, `virtual_open_mode?`).
+   */
   async openChannel (request) { return this._node.openChannel(request) }
 
   /** @param {Object} request - JsonCloseChannelRequest */

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -125,6 +125,7 @@ export default class WalletManagerRgbLightning extends WalletManager {
         ldkPeerListeningPort: this._config.ldkPeerListeningPort,
         maxMediaUploadSizeMb: this._config.maxMediaUploadSizeMb,
         enableVirtualChannelsV0: this._config.enableVirtualChannelsV0,
+        virtualPeerPubkeys: this._config.virtualPeerPubkeys,
         permissiveSignerPolicy: this._config.permissiveSignerPolicy,
         vssUrl: this._config.vssUrl,
         vssAllowHttp: this._config.vssAllowHttp,


### PR DESCRIPTION
Draft. SDK-polish pass from the gap analysis vs the reference `@utexo/rgb-sdk-rn`. No behavioural change to the happy path — additive surface + typed errors that preserve the original RLN message.

## What

1. **TypeScript declarations** — hand-authored `index.d.ts` for the full public surface (manager, account, bindings, errors, `LspClient`, LNURL + LSP helpers), wired via the `types` field + a `types` condition in `exports`. The package previously shipped **no** types. Verified with `tsc --strict` both internally and consumer-side under `nodenext`.
2. **Typed error hierarchy** (`src/errors.js`) — `RgbLightningError` base (`code` + `cause` + `toJSON()`) with `UnlockError` / `VssError` / `VssNotConfiguredError` / `ApayError` / `NotImplementedError`. `unlock`, `clearVssFence`, `vssBackup`, `apayNew`, `bootstrapLsp`, `verify`, `signTransaction` throw these so callers branch on `err.name`/`err.code` instead of substring-matching `Rln(...)`. **Original message preserved verbatim + attached as `cause`** so existing substring checks keep working.
3. **`account.vssStatus()`** — honest local-view status (`configured`/`url`/`allowHttp`/`lastBackupVersion`), no faked server call. RLN's c-ffi has no read-only backup-info query (unlike rgb-lib); bindings now track the version from the last `vssBackup()`.
4. **`account.createLightningInvoice()`** — cross-SDK alias for `createInvoice` matching `rgb-sdk-rn`'s naming (which is itself a stub there); accepts native snake_case or a camelCase convenience shape.

Also removes a duplicate `apayNew` method in both bindings (the shadowed copy used `this.node`, which throws pre-unlock).

## Verification
- `standard` lint clean; `tsc --strict` clean (internal + `nodenext` consumer check); error-module instanceof/toJSON/message-preservation smoke test passes.