### PR TITLE
fix: align binding peerDependencies with README install versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "bip39": "3.1.0"
   },
   "peerDependencies": {
-    "@utexo/rgb-lightning-node-bare": "^0.6.0-beta.1",
-    "@utexo/rgb-lightning-node-nodejs": "^0.6.0-beta.1"
+    "@utexo/rgb-lightning-node-bare": ">=0.1.0-beta.12",
+    "@utexo/rgb-lightning-node-nodejs": ">=0.1.0-beta.8"
   },
   "peerDependenciesMeta": {
     "@utexo/rgb-lightning-node-bare": {


### PR DESCRIPTION
### What
The README's Installation section still installs the native bindings at:

- `rgb-lightning-node-nodejs#v0.1.0-beta.8`
- `rgb-lightning-node-bare#v0.1.0-beta.12`

but `peerDependencies` now declares a floor of `^0.6.0-beta.1` for both.
Those documented versions fall below that range, so following the README as written produces an `EBADPEER` warning on install.

### Why `>=` and not `^`
npm caret ranges do not match prereleases across a different base version. In particular, `^0.6.0-beta.1` will not accept `0.1.0-beta.8`, and switching to another caret-based prerelease floor would still keep prerelease matching brittle. A plain `>=0.1.0-beta.X` floor keeps the documented install path valid without reintroducing prerelease range surprises.

### Scope
Manifest-only. No code paths change. The bindings remain optional peer deps (`peerDependenciesMeta` untouched).

### Note for maintainers
This patch assumes the README install commands are still the source of truth. If `^0.6.0-beta.1` is the intended minimum instead, the fix belongs in the README instead.