### PR TITLE
test: jest unit suite + bump @tetherto/wdk-wallet to beta.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build and Test
 
-# Mirrors UTEXO-Protocol/wdk-wallet-rgb/.github/workflows/build.yml. This
-# package is pure JS (the native bindings are optional peer deps), so the
-# PR check is lint only — there is no `test` script in package.json.
+# Mirrors UTEXO-Protocol/wdk-wallet-rgb/.github/workflows/build.yml. The
+# native bindings are optional peer deps, so CI runs without them: the
+# check is lint plus the jest unit suite, which exercises the host-side
+# JS logic (recipient routing, error wrapping, binding config mapping)
+# with the native addon mocked — no live node required.
 
 on:
   push:
@@ -32,3 +34,6 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Run tests
+        run: npm test

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,14 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Several methods on the wallet account return fees/amounts as BigInt
+// (e.g. `transfer` / `quoteTransfer`). Register a serializer so BigInt
+// values render readably in assertion diffs and snapshots instead of
+// throwing "Do not know how to serialize a BigInt".
+expect.addSnapshotSerializer({
+  test: (value) => typeof value === 'bigint',
+  print: (value) => `${String(value)}n`
+})

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "types": "./index.d.ts",
   "type": "module",
   "scripts": {
-    "lint": "standard",
-    "lint:fix": "standard --fix"
+    "lint": "standard --env jest",
+    "lint:fix": "standard --fix --env jest",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "dependencies": {
-    "@tetherto/wdk-wallet": "^1.0.0-beta.7",
+    "@tetherto/wdk-wallet": "^1.0.0-beta.10",
     "bare-node-runtime": "1.2.0",
     "bip39": "3.1.0"
   },
@@ -41,7 +43,17 @@
     }
   },
   "devDependencies": {
+    "cross-env": "7.0.3",
+    "jest": "29.7.0",
     "standard": "17.1.2"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ],
+    "moduleNameMapper": {
+      "^@utexo/rgb-lightning-node-nodejs$": "<rootDir>/tests/__mocks__/rgb-lightning-node-nodejs.mjs"
+    }
   },
   "exports": {
     ".": {

--- a/tests/__mocks__/rgb-lightning-node-nodejs.mjs
+++ b/tests/__mocks__/rgb-lightning-node-nodejs.mjs
@@ -1,0 +1,37 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Jest mock for the native napi addon `@utexo/rgb-lightning-node-nodejs`.
+// Wired in via the `moduleNameMapper` entry in package.json's jest config
+// so that importing `src/node-binding.js` under test does not pull in (or
+// require the install of) the real platform-specific `.node` binary. The
+// shape mirrors the addon's documented surface; methods are inert stubs —
+// `node-binding-config.test.js` only exercises the pure request-mapping
+// logic in the binding constructor, which never calls into these.
+
+const SdkNode = {
+  create: () => ({})
+}
+
+const NativeExternalSigner = {
+  create: () => ({
+    bootstrap: () => ({}),
+    destroy: () => {}
+  })
+}
+
+const uniffiHealthcheck = () => true
+const uniffiIsInitialized = () => false
+const sdkInitialize = () => {}
+const sdkShutdown = () => {}
+
+export default {
+  SdkNode,
+  NativeExternalSigner,
+  uniffiHealthcheck,
+  uniffiIsInitialized,
+  sdkInitialize,
+  sdkShutdown
+}

--- a/tests/classify-recipient.test.js
+++ b/tests/classify-recipient.test.js
@@ -1,0 +1,60 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the static recipient classifier that drives the
+// generic `transfer()` / `quoteTransfer()` router. Pure logic — no node,
+// no binding, no network.
+
+import WalletAccountRgbLightning from '../src/wallet-account-rgb-lightning.js'
+
+const classify = WalletAccountRgbLightning._classifyRecipient
+
+describe('WalletAccountRgbLightning._classifyRecipient', () => {
+  it('classifies BOLT11 invoices across all network prefixes', () => {
+    expect(classify('lnbc10u1pcoffee')).toBe('bolt11') // mainnet
+    expect(classify('lntb10u1pcoffee')).toBe('bolt11') // testnet
+    expect(classify('lnbcrt10u1pcoffee')).toBe('bolt11') // regtest
+    expect(classify('lnsb10u1pcoffee')).toBe('bolt11') // signet
+  })
+
+  it('is case-insensitive for BOLT11 prefixes', () => {
+    expect(classify('LNBC10U1PCOFFEE')).toBe('bolt11')
+    expect(classify('LnTb10u1pcoffee')).toBe('bolt11')
+  })
+
+  it('classifies RGB invoices (rgb: and utxob: schemes)', () => {
+    expect(classify('rgb:2WBcas9-usxg9Hm9d-N6q2Lpf3Z-...')).toBe('rgb-invoice')
+    expect(classify('utxob:abcdef-123456')).toBe('rgb-invoice')
+    expect(classify('RGB:UPPER-case-scheme')).toBe('rgb-invoice')
+  })
+
+  it('classifies a 66-hex-char string as an LN node pubkey', () => {
+    const pubkey = '02' + 'a'.repeat(64)
+    expect(pubkey).toHaveLength(66)
+    expect(classify(pubkey)).toBe('ln-pubkey')
+    expect(classify(pubkey.toUpperCase())).toBe('ln-pubkey')
+  })
+
+  it('falls back to btc-address for anything else', () => {
+    expect(classify('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')).toBe('btc-address')
+    expect(classify('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')).toBe('btc-address')
+    expect(classify('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBe('btc-address')
+    // 64 hex chars is NOT a pubkey (needs 66) -> treated as an address.
+    expect(classify('a'.repeat(64))).toBe('btc-address')
+  })
+
+  it('trims surrounding whitespace before classifying', () => {
+    expect(classify('  lnbc10u1pcoffee  ')).toBe('bolt11')
+    const pubkey = '03' + 'b'.repeat(64)
+    expect(classify(`\t${pubkey}\n`)).toBe('ln-pubkey')
+  })
+
+  it('throws on empty or non-string recipients', () => {
+    expect(() => classify('')).toThrow('recipient must be a non-empty string')
+    expect(() => classify(null)).toThrow('recipient must be a non-empty string')
+    expect(() => classify(undefined)).toThrow('recipient must be a non-empty string')
+    expect(() => classify(42)).toThrow('recipient must be a non-empty string')
+  })
+})

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -1,0 +1,88 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the typed error hierarchy and the `wrapError` helper.
+// Pure module — no node, binding or network.
+
+import {
+  RgbLightningError,
+  UnlockError,
+  VssError,
+  VssNotConfiguredError,
+  ApayError,
+  NotImplementedError,
+  wrapError
+} from '../src/errors.js'
+
+describe('error hierarchy', () => {
+  it('assigns a stable name + code to each subclass', () => {
+    expect(new RgbLightningError('m')).toMatchObject({ name: 'RgbLightningError', code: 'RGB_LIGHTNING_ERROR' })
+    expect(new UnlockError('m')).toMatchObject({ name: 'UnlockError', code: 'UNLOCK_FAILED' })
+    expect(new VssError('m')).toMatchObject({ name: 'VssError', code: 'VSS_ERROR' })
+    expect(new VssNotConfiguredError()).toMatchObject({ name: 'VssNotConfiguredError', code: 'VSS_NOT_CONFIGURED' })
+    expect(new ApayError('m')).toMatchObject({ name: 'ApayError', code: 'APAY_ERROR' })
+    expect(new NotImplementedError('m')).toMatchObject({ name: 'NotImplementedError', code: 'NOT_IMPLEMENTED' })
+  })
+
+  it('keeps every subclass an instanceof the base (and Error)', () => {
+    for (const E of [UnlockError, VssError, ApayError, NotImplementedError]) {
+      const e = new E('x')
+      expect(e).toBeInstanceOf(Error)
+      expect(e).toBeInstanceOf(RgbLightningError)
+    }
+    expect(new VssNotConfiguredError()).toBeInstanceOf(VssError)
+  })
+
+  it('VssNotConfiguredError carries a helpful default message', () => {
+    expect(new VssNotConfiguredError().message).toMatch(/VSS is not configured/)
+  })
+
+  it('serializes to a structured object via toJSON', () => {
+    const cause = new Error('root cause')
+    const err = new UnlockError('bad creds', { cause })
+    expect(err.toJSON()).toEqual({
+      name: 'UnlockError',
+      code: 'UNLOCK_FAILED',
+      message: 'bad creds',
+      cause: { name: 'Error', message: 'root cause' }
+    })
+  })
+
+  it('toJSON reports a null cause when none was provided', () => {
+    expect(new VssError('x').toJSON().cause).toBeNull()
+  })
+})
+
+describe('wrapError', () => {
+  it('preserves the original message verbatim and attaches the cause', () => {
+    const original = new Error('Rln(Conflict): already initialized')
+    const wrapped = wrapError(original, UnlockError)
+    expect(wrapped).toBeInstanceOf(UnlockError)
+    expect(wrapped.message).toBe('Rln(Conflict): already initialized')
+    expect(wrapped.cause).toBe(original)
+    expect(wrapped.code).toBe('UNLOCK_FAILED')
+  })
+
+  it('is idempotent when the value is already the target class', () => {
+    const already = new VssError('boom')
+    expect(wrapError(already, VssError)).toBe(already)
+  })
+
+  it('re-wraps an error of a different typed class', () => {
+    const unlock = new UnlockError('x')
+    const wrapped = wrapError(unlock, VssError)
+    expect(wrapped).toBeInstanceOf(VssError)
+    expect(wrapped.cause).toBe(unlock)
+  })
+
+  it('stringifies non-Error throwables', () => {
+    expect(wrapError('plain string', ApayError).message).toBe('plain string')
+    expect(wrapError({ message: 'objmsg' }, ApayError).message).toBe('objmsg')
+  })
+
+  it('honours an explicit code override', () => {
+    expect(wrapError(new Error('x'), ApayError, { code: 'APAY_PEER_NOT_VISIBLE' }).code).toBe('APAY_PEER_NOT_VISIBLE')
+  })
+})

--- a/tests/node-binding-config.test.js
+++ b/tests/node-binding-config.test.js
@@ -1,0 +1,87 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the NodeRgbLightningBinding request-mapping logic — the
+// pure config -> RLN init-request translation done in the constructor.
+// The native addon `@utexo/rgb-lightning-node-nodejs` is replaced by the
+// jest mock wired in package.json (`moduleNameMapper`), so no `.node`
+// binary is loaded.
+
+import { NodeRgbLightningBinding } from '../src/node-binding.js'
+
+describe('NodeRgbLightningBinding._initRequest', () => {
+  it('applies defaults and omits opt-in fields for a minimal config', () => {
+    const binding = new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/data' })
+    expect(binding._initRequest).toEqual({
+      storage_dir_path: '/data',
+      daemon_listening_port: 0,
+      ldk_peer_listening_port: 0,
+      network: 'regtest',
+      max_media_upload_size_mb: 5,
+      enable_virtual_channels_v0: false
+    })
+    // None of the opt-in keys should be present.
+    expect(binding._initRequest).not.toHaveProperty('virtual_peer_pubkeys')
+    expect(binding._initRequest).not.toHaveProperty('vss_url')
+    expect(binding._initRequest).not.toHaveProperty('lsp_base_url')
+  })
+
+  it('forwards explicit ports, media size and virtual-channels flag', () => {
+    const binding = new NodeRgbLightningBinding({
+      network: 'testnet',
+      dataDir: '/d',
+      daemonListeningPort: 3001,
+      ldkPeerListeningPort: 9735,
+      maxMediaUploadSizeMb: 10,
+      enableVirtualChannelsV0: true
+    })
+    expect(binding._initRequest).toMatchObject({
+      daemon_listening_port: 3001,
+      ldk_peer_listening_port: 9735,
+      max_media_upload_size_mb: 10,
+      enable_virtual_channels_v0: true
+    })
+  })
+
+  it('forwards virtual_peer_pubkeys only when the list is non-empty', () => {
+    const empty = new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d', virtualPeerPubkeys: [] })
+    expect(empty._initRequest).not.toHaveProperty('virtual_peer_pubkeys')
+
+    const withPeers = new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d', virtualPeerPubkeys: ['02abc'] })
+    expect(withPeers._initRequest.virtual_peer_pubkeys).toEqual(['02abc'])
+  })
+
+  it('forwards VSS and LSP fields only when opted in', () => {
+    const binding = new NodeRgbLightningBinding({
+      network: 'regtest',
+      dataDir: '/d',
+      vssUrl: 'https://vss.example',
+      vssAllowHttp: true,
+      vssAllowEmptyRestore: true,
+      lspBaseUrl: 'https://lsp.example',
+      lspBearerToken: 'tok'
+    })
+    expect(binding._initRequest).toMatchObject({
+      vss_url: 'https://vss.example',
+      vss_allow_http: true,
+      vss_allow_empty_restore: true,
+      lsp_base_url: 'https://lsp.example',
+      lsp_bearer_token: 'tok'
+    })
+  })
+
+  it('vssStatus reflects the constructed config without a server round-trip', () => {
+    const off = new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d' })
+    expect(off.vssStatus()).toEqual({ configured: false, url: null, allowHttp: false, lastBackupVersion: null })
+
+    const on = new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d', vssUrl: 'https://vss.example', vssAllowHttp: true })
+    expect(on.vssStatus()).toEqual({
+      configured: true,
+      url: 'https://vss.example',
+      allowHttp: true,
+      lastBackupVersion: null
+    })
+  })
+})

--- a/tests/not-implemented.test.js
+++ b/tests/not-implemented.test.js
@@ -1,0 +1,41 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the intentionally-unimplemented surface. `verify` and
+// `signTransaction` are documented gaps that must throw a typed
+// NotImplementedError (not a bare Error) so callers can branch on it.
+
+import WalletAccountRgbLightning from '../src/wallet-account-rgb-lightning.js'
+import { NotImplementedError } from '../src/errors.js'
+
+function makeAccount () {
+  return new WalletAccountRgbLightning({ binding: { node: {} } })
+}
+
+describe('unimplemented surface', () => {
+  it('verify() rejects with NotImplementedError', async () => {
+    const account = makeAccount()
+    await expect(account.verify('msg', 'sig')).rejects.toBeInstanceOf(NotImplementedError)
+    await expect(account.verify('msg', 'sig')).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' })
+  })
+
+  it('signTransaction() rejects with NotImplementedError', async () => {
+    const account = makeAccount()
+    await expect(account.signTransaction({})).rejects.toBeInstanceOf(NotImplementedError)
+    await expect(account.signTransaction({})).rejects.toMatchObject({ code: 'NOT_IMPLEMENTED' })
+  })
+
+  it('the verify() message points at the supported alternative path', async () => {
+    const account = makeAccount()
+    await expect(account.signTransaction({})).rejects.toThrow(/sendTransaction/)
+  })
+})
+
+describe('constructor guard', () => {
+  it('throws when no binding is supplied', () => {
+    expect(() => new WalletAccountRgbLightning()).toThrow('requires a BareRgbLightningBinding')
+    expect(() => new WalletAccountRgbLightning({})).toThrow('requires a BareRgbLightningBinding')
+  })
+})

--- a/tests/transfer-router.test.js
+++ b/tests/transfer-router.test.js
@@ -1,0 +1,112 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the generic `transfer()` / `quoteTransfer()` routers.
+// They classify the recipient and dispatch to the right backing method;
+// here we stub those backing methods on the instance so no node, binding
+// or network is touched.
+
+import { jest } from '@jest/globals'
+import WalletAccountRgbLightning from '../src/wallet-account-rgb-lightning.js'
+
+// A 66-hex-char compressed pubkey for the keysend (ln-pubkey) path.
+const LN_PUBKEY = '02' + 'f'.repeat(64)
+const BOLT11 = 'lnbcrt10u1pcoffee'
+const BTC_ADDR = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'
+const RGB_INVOICE = 'rgb:2WBcas9-usxg9Hm9d-N6q2Lpf3Z'
+
+function makeAccount () {
+  // The constructor only needs a truthy `binding`; the routed methods are
+  // stubbed below so `_node` is never dereferenced.
+  const account = new WalletAccountRgbLightning({ binding: { node: {} } })
+  account.sendPayment = jest.fn(async () => ({ payment_hash: 'ph', fee_msat: 7 }))
+  account.keysend = jest.fn(async () => ({ payment_hash: 'kh', fee_msat: 11 }))
+  account.sendTransaction = jest.fn(async () => ({ txid: 'btctxid' }))
+  account.sendRgbAsset = jest.fn(async () => ({ txid: 'rgbtxid' }))
+  return account
+}
+
+describe('WalletAccountRgbLightning.transfer', () => {
+  it('rejects a non-object options argument', async () => {
+    const account = makeAccount()
+    await expect(account.transfer(null)).rejects.toThrow('options must be { recipient, amount, token? }')
+    await expect(account.transfer('lnbc...')).rejects.toThrow('options must be { recipient, amount, token? }')
+  })
+
+  it('routes a BOLT11 recipient to sendPayment and returns {hash, fee:BigInt}', async () => {
+    const account = makeAccount()
+    const res = await account.transfer({ recipient: BOLT11, amount: 1000 })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 1000 })
+    expect(res).toEqual({ hash: 'ph', fee: 7n })
+  })
+
+  it('forwards token as asset_id on the BOLT11 path', async () => {
+    const account = makeAccount()
+    await account.transfer({ recipient: BOLT11, amount: 1000, token: 'asset123' })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 1000, asset_id: 'asset123' })
+  })
+
+  it('routes an LN pubkey to keysend', async () => {
+    const account = makeAccount()
+    const res = await account.transfer({ recipient: LN_PUBKEY, amount: 2000 })
+    expect(account.keysend).toHaveBeenCalledWith({ dest_pubkey: LN_PUBKEY, amt_msat: 2000 })
+    expect(res).toEqual({ hash: 'kh', fee: 11n })
+  })
+
+  it('requires an amount for the keysend path', async () => {
+    const account = makeAccount()
+    await expect(account.transfer({ recipient: LN_PUBKEY })).rejects.toThrow('transfer(keysend): amount (msats) is required')
+    expect(account.keysend).not.toHaveBeenCalled()
+  })
+
+  it('routes a BTC address to sendTransaction with the supplied fee rate', async () => {
+    const account = makeAccount()
+    const res = await account.transfer({ recipient: BTC_ADDR, amount: 50000, feeRate: 2 })
+    expect(account.sendTransaction).toHaveBeenCalledWith({
+      address: BTC_ADDR,
+      amount: 50000,
+      fee_rate: 2,
+      skip_sync: false
+    })
+    // fee = round(feeRate * APPROX_BTC_TX_VBYTES) = round(2 * 141) = 282
+    expect(res).toEqual({ hash: 'btctxid', fee: 282n })
+  })
+
+  it('requires an amount for the on-chain path', async () => {
+    const account = makeAccount()
+    await expect(account.transfer({ recipient: BTC_ADDR })).rejects.toThrow('transfer(on-chain): amount (sats) is required')
+    expect(account.sendTransaction).not.toHaveBeenCalled()
+  })
+
+  it('routes an RGB invoice to sendRgbAsset and reports a zero fee', async () => {
+    const account = makeAccount()
+    const res = await account.transfer({ recipient: RGB_INVOICE, amount: 5, token: 'asset123' })
+    expect(account.sendRgbAsset).toHaveBeenCalledWith({ recipient_id: RGB_INVOICE, amount: 5, asset_id: 'asset123' })
+    expect(res).toEqual({ hash: 'rgbtxid', fee: 0n })
+  })
+})
+
+describe('WalletAccountRgbLightning.quoteTransfer', () => {
+  it('rejects a non-object options argument', async () => {
+    const account = makeAccount()
+    await expect(account.quoteTransfer(undefined)).rejects.toThrow('options must be { recipient, amount, token? }')
+  })
+
+  it('quotes LN transfers as a basis-point fraction of the amount', async () => {
+    const account = makeAccount()
+    // ceil(1_000_000 * 50 / 10000) = 5000
+    await expect(account.quoteTransfer({ recipient: BOLT11, amount: 1_000_000 })).resolves.toEqual({ fee: 5000n })
+    // floor at 1 for tiny/zero amounts
+    await expect(account.quoteTransfer({ recipient: LN_PUBKEY, amount: 0 })).resolves.toEqual({ fee: 1n })
+  })
+
+  it('quotes on-chain transfers from the default fee rate and tx size', async () => {
+    const account = makeAccount()
+    account._defaultFeeRate = jest.fn(async () => 3)
+    // round(3 * 141) = 423
+    await expect(account.quoteTransfer({ recipient: BTC_ADDR, amount: 50000 })).resolves.toEqual({ fee: 423n })
+    expect(account._defaultFeeRate).toHaveBeenCalledWith(6)
+  })
+})

--- a/tests/vss-status.test.js
+++ b/tests/vss-status.test.js
@@ -1,0 +1,67 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the local-view VSS surface: `vssStatus` passes the
+// binding's view through untouched, and the mutating ops gate on
+// "VSS configured" before touching the binding.
+
+import { jest } from '@jest/globals'
+import WalletAccountRgbLightning from '../src/wallet-account-rgb-lightning.js'
+import { VssNotConfiguredError, VssError } from '../src/errors.js'
+
+function makeAccount (binding) {
+  return new WalletAccountRgbLightning({ binding })
+}
+
+describe('vssStatus', () => {
+  it('returns the binding local-view status verbatim', async () => {
+    const status = { configured: true, url: 'https://vss.example', allowHttp: false, lastBackupVersion: 4 }
+    const account = makeAccount({ vssStatus: () => status })
+    await expect(account.vssStatus()).resolves.toBe(status)
+  })
+})
+
+describe('clearVssFence', () => {
+  it('throws VssNotConfiguredError when VSS was never configured', async () => {
+    const clearVssFence = jest.fn()
+    const account = makeAccount({ vssStatus: () => ({ configured: false }), clearVssFence })
+    await expect(account.clearVssFence('pw')).rejects.toBeInstanceOf(VssNotConfiguredError)
+    expect(clearVssFence).not.toHaveBeenCalled()
+  })
+
+  it('forwards to the binding when VSS is configured', async () => {
+    const clearVssFence = jest.fn()
+    const account = makeAccount({ vssStatus: () => ({ configured: true }), clearVssFence })
+    await expect(account.clearVssFence('pw')).resolves.toEqual({ ok: true })
+    expect(clearVssFence).toHaveBeenCalledWith('pw')
+  })
+
+  it('wraps a binding failure as a VssError preserving the message', async () => {
+    const account = makeAccount({
+      vssStatus: () => ({ configured: true }),
+      clearVssFence: () => { throw new Error('fence takeover rejected') }
+    })
+    const err = await account.clearVssFence('pw').catch((e) => e)
+    expect(err).toBeInstanceOf(VssError)
+    expect(err.message).toBe('fence takeover rejected')
+  })
+})
+
+describe('vssBackup', () => {
+  it('throws VssNotConfiguredError when VSS was never configured', async () => {
+    const vssBackup = jest.fn()
+    const account = makeAccount({ vssStatus: () => ({ configured: false }), vssBackup })
+    await expect(account.vssBackup()).rejects.toBeInstanceOf(VssNotConfiguredError)
+    expect(vssBackup).not.toHaveBeenCalled()
+  })
+
+  it('returns the binding snapshot version when configured', async () => {
+    const account = makeAccount({
+      vssStatus: () => ({ configured: true }),
+      vssBackup: () => ({ version: 9 })
+    })
+    await expect(account.vssBackup()).resolves.toEqual({ version: 9 })
+  })
+})


### PR DESCRIPTION
Addresses two findings from the WDK partner-module review.

## Builds against latest stable @tetherto/wdk
Bumps `@tetherto/wdk-wallet` `^1.0.0-beta.7` -> `^1.0.0-beta.10` (current npm latest). The beta.7 -> beta.10 delta is additive-only for the consumed `WalletManager` surface (this module value-imports only the default `WalletManager` and extends it; everything else from the package is type-only), so no source change is required.

## Tests exist and pass
Adds a jest unit suite (mirroring `wdk-wallet-rgb`) covering the host-side logic with no live node and no native binding — the addon is mocked via `moduleNameMapper`:

- recipient classification (bolt11 / rgb / ln-pubkey / btc-address)
- `transfer` / `quoteTransfer` dispatch and fee math
- typed error hierarchy + `wrapError` idempotency / `toJSON`
- `verify` / `signTransaction` `NotImplementedError` contract
- VSS local-view gating (`vssStatus` / `clearVssFence` / `vssBackup`)
- `NodeRgbLightningBinding` init-request mapping

43 tests across 6 suites. `build.yml` now runs `npm test` after lint; `lint` uses `--env jest`. Production dependency audit is clean (`npm audit --omit=dev` -> 0 vulnerabilities); the jest advisories are dev-only and match the sibling module.

The companion README "Testing and local development" section (documenting the dockerised integration flow) is a separate PR stacked on the README rewrite (#11).