### PR TITLE
chore(release): v0.1.0-beta.11 + fix npm/GitHub release drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,13 @@ jobs:
           echo "bare=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-bare']")" >> $GITHUB_OUTPUT
           echo "nodejs=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-nodejs']")" >> $GITHUB_OUTPUT
 
+      # Create the GitHub Release for both trigger paths: the auto (RLN
+      # dispatch / workflow_dispatch) path AND the manual tag-push path.
+      # Previously this was gated on `auto == 'true'`, so a `v*` tag push
+      # published to npm but left no matching GitHub Release — the release
+      # had to be created by hand, which let npm and GitHub drift apart.
       - name: Create Release
-        if: steps.rln.outputs.auto == 'true'
+        if: steps.rln.outputs.auto == 'true' || github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.pkg_version.outputs.version }}
@@ -104,8 +109,6 @@ jobs:
             ## wdk-rgb-lightning ${{ steps.pkg_version.outputs.version }}
 
             WDK module for RGB Lightning — channels, invoices, payments, RGB-over-LN.
-
-            Built with RGB Lightning Node v${{ steps.rln.outputs.version }}
 
             ### Installation
             ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
Prepares the first release that carries the partner-review fixes, and fixes the workflow gap that let npm and GitHub releases drift.

## Why
- npm `@utexo/wdk-rgb-lightning@0.1.0-beta.10` and GitHub release `v0.1.0-beta.10` both point at `7383b34` — the **pre-fix** commit.
- `main` carries the merged fixes (wdk-wallet `beta.10`, README/peer-install correction, jest unit suite, "Built with WDK" badge) but is **still labelled `0.1.0-beta.10`**, so the fixes have never been published.

## Changes
1. **Version bump** `0.1.0-beta.10` -> `0.1.0-beta.11` so the current code can publish (beta.10 is taken on npm).
2. **Workflow fix** (`release.yml`): "Create Release" now runs for the **tag-push** path too, not only the RLN-dispatch path. Previously a `v*` tag push published to npm but created no GitHub Release (it was made by hand afterwards), which is how npm and GitHub releases drifted. Also drops the RLN-version line from the release body, which was only populated on the dispatch path.

## Release procedure after merge
Push the tag at the merge commit:
```
git tag v0.1.0-beta.11 <merge-sha> && git push origin v0.1.0-beta.11
```
The workflow then publishes `0.1.0-beta.11` to npm **and** creates GitHub Release `v0.1.0-beta.11` — npm, GitHub, and `main` all aligned.