### PR TITLE
ci(release): keep GitHub Latest in sync with npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,14 @@ jobs:
             "@utexo/rgb-lightning-node-nodejs": "${{ steps.pkg_version.outputs.nodejs }}"
             ```
           draft: false
-          prerelease: ${{ contains(steps.pkg_version.outputs.version, 'beta') || contains(steps.pkg_version.outputs.version, 'alpha') }}
+          # Mark each new release as GitHub's "Latest" so it tracks npm's
+          # `latest` dist-tag. GitHub refuses to flag a *prerelease* as
+          # Latest, so the newest release is published as a non-prerelease
+          # (the version string itself, e.g. 0.1.0-beta.11, still signals
+          # the beta line). Without this, betas were left as prereleases
+          # and the "Latest" badge stuck to an older release, drifting from
+          # npm.
+          prerelease: false
+          make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to the v0.1.0-beta.11 release that keeps GitHub's "Latest" release in sync with npm's `latest` going forward.

## Problem
The Release workflow marked betas as `prerelease: true`. GitHub never assigns the "Latest" badge to a prerelease, so the badge stuck to whichever release was a non-prerelease — recently the old `v0.1.0-beta.10` — while npm's `latest` advanced. That's the npm↔GitHub drift we just had to fix by hand (`gh release edit --latest`).

## Change
In the "Create Release" step: `prerelease: false` + `make_latest: true`, so every new release becomes GitHub's Latest and tracks npm's `latest` automatically. The version string (e.g. `0.1.0-beta.11`) still communicates the beta line; only the GitHub prerelease flag changes.

## Note on convention
This makes the newest release GitHub-"Latest" even though it's a beta — matching the existing precedent (`v0.1.0-beta.10` was already a non-prerelease "Latest") and npm's single `latest` dist-tag. If the team would rather keep betas flagged as prereleases (and accept that GitHub shows no "Latest" until a stable 1.0), close this and we'll instead drop the manual `--latest` step — but then GitHub won't surface a current version.