### PR TITLE
chore(release): v0.1.0-beta.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.11",
+  "version": "0.1.0-beta.12",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
Version bump so the issuance-removal change can be published to npm.

## Why
`main` carries #17 (RGB issuance removed from the README + `index.d.ts`, redirected to `@utexo/wdk-wallet-rgb`) but is still labelled `0.1.0-beta.11` — which is already on npm with the **old** content (issuance still shown). This bumps to `0.1.0-beta.12` so the change can ship.

## Release procedure after merge
Push the tag at the merge commit:
```
git tag v0.1.0-beta.12 <merge-sha> && git push origin v0.1.0-beta.12
```
The Release workflow then publishes `0.1.0-beta.12` to npm, auto-creates GitHub release `v0.1.0-beta.12`, and auto-marks it "Latest" (via the `make_latest` fix from #16) — no manual steps. npm, GitHub, and `main` stay aligned.