### PR TITLE
test: comprehensive + mutation-hardened unit suite; fix getPayment enum bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .DS_Store
 package-lock.json
+coverage/

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -645,7 +645,10 @@ export default class WalletAccountRgbLightning {
   async listPayments () { return this._node.listPayments() }
 
   /** @param {string} paymentHashHex
-   *  @param {'sent'|'received'} paymentType */
+   *  @param {'Outbound'|'InboundAutoClaim'|'InboundHodl'} paymentType
+   *    RLN's payment-type discriminant. The C-FFI deserialises this into
+   *    its `Outbound | InboundAutoClaim | InboundHodl` enum and errors on
+   *    any other value (the pre-1.0 HTTP API's `sent`/`received` are gone). */
   async getPayment (paymentHashHex, paymentType) {
     return this._node.getPayment(paymentHashHex, paymentType)
   }
@@ -997,14 +1000,16 @@ export default class WalletAccountRgbLightning {
       const hit = onchain.find((t) => t?.txid === hash)
       if (hit) return hit
     } catch (_e) { /* fall through to LN lookup */ }
-    try {
-      const sent = await this.getPayment(hash, 'sent')
-      if (sent && sent.payment_hash) return sent
-    } catch (_e) { /* not a sent payment */ }
-    try {
-      const recv = await this.getPayment(hash, 'received')
-      if (recv && recv.payment_hash) return recv
-    } catch (_e) { /* not a received payment either */ }
+    // RLN's get_payment requires a payment-type discriminant — one of
+    // 'Outbound' / 'InboundAutoClaim' / 'InboundHodl'. The C-FFI rejects
+    // any other value (the old HTTP API's 'sent'/'received' no longer
+    // parse), so try each known type until the hash matches a payment.
+    for (const paymentType of ['Outbound', 'InboundAutoClaim', 'InboundHodl']) {
+      try {
+        const p = await this.getPayment(hash, paymentType)
+        if (p && p.payment_hash) return p
+      } catch (_e) { /* not this payment type — try the next */ }
+    }
     return null
   }
 

--- a/tests/lnurl-pay.test.js
+++ b/tests/lnurl-pay.test.js
@@ -1,0 +1,384 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the generic LUD-06 / Lightning-Address client. Pure
+// module — no node or binding. Network access is mocked via an injected
+// `opts.fetch` returning fake Response-like objects.
+
+import { jest } from '@jest/globals'
+import {
+  LnurlPayError,
+  parseLightningAddress,
+  fetchDiscovery,
+  resolveAddressToInvoice
+} from '../src/lnurl-pay.js'
+
+// A minimal Response-like stub. `body` is serialized to JSON unless a raw
+// string is supplied, so we can also exercise the invalid-JSON path.
+function makeResponse ({ ok = true, status = 200, body = {}, raw } = {}) {
+  const text = raw !== undefined ? raw : JSON.stringify(body)
+  return { ok, status, text: async () => text }
+}
+
+// A valid LUD-06 discovery document used as the happy-path baseline.
+function discoveryDoc (overrides = {}) {
+  return {
+    tag: 'payRequest',
+    callback: 'https://pay.example/lnurlp/cb',
+    minSendable: 1000,
+    maxSendable: 100000,
+    metadata: '[["text/plain","pay alice"]]',
+    ...overrides
+  }
+}
+
+describe('LnurlPayError', () => {
+  it('defaults status/body and exposes a stable name', () => {
+    const err = new LnurlPayError('boom')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('LnurlPayError')
+    expect(err.message).toBe('boom')
+    expect(err.status).toBe(0)
+    expect(err.body).toBe('')
+    expect(err.cause).toBeUndefined()
+  })
+
+  it('carries status, body and cause when provided', () => {
+    const cause = new Error('root')
+    const err = new LnurlPayError('http', { status: 502, body: 'bad gateway', cause })
+    expect(err.status).toBe(502)
+    expect(err.body).toBe('bad gateway')
+    expect(err.cause).toBe(cause)
+  })
+})
+
+describe('parseLightningAddress', () => {
+  it('parses a canonical user@host and builds the https discovery URL', () => {
+    const out = parseLightningAddress('Alice@GetAlby.com')
+    expect(out).toEqual({
+      username: 'alice',
+      host: 'getalby.com',
+      discoveryUrl: 'https://getalby.com/.well-known/lnurlp/alice'
+    })
+  })
+
+  it('percent-encodes the local-part in the discovery URL', () => {
+    const out = parseLightningAddress('a.b+c@host.com')
+    expect(out.username).toBe('a.b+c')
+    expect(out.discoveryUrl).toBe('https://host.com/.well-known/lnurlp/a.b%2Bc')
+  })
+
+  it('uses the last @ so the local-part may not contain one', () => {
+    // Only the final @ splits; everything before must still be a valid
+    // local-part, so an embedded @ makes the local-part invalid.
+    expect(() => parseLightningAddress('a@b@host.com')).toThrow(LnurlPayError)
+  })
+
+  it('auto-allows http for localhost / loopback / .local hosts', () => {
+    expect(parseLightningAddress('bob@localhost').discoveryUrl)
+      .toBe('http://localhost/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@127.0.0.1:3000').discoveryUrl)
+      .toBe('http://127.0.0.1:3000/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@[::1]:8080').discoveryUrl)
+      .toBe('http://[::1]:8080/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@node.local').discoveryUrl)
+      .toBe('http://node.local/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@dev.localhost').discoveryUrl)
+      .toBe('http://dev.localhost/.well-known/lnurlp/bob')
+  })
+
+  it('uses http for .onion hosts regardless of allowHttp', () => {
+    expect(parseLightningAddress('bob@abc.onion').discoveryUrl)
+      .toBe('http://abc.onion/.well-known/lnurlp/bob')
+  })
+
+  it('uses http for a normal host only when allowHttp is true', () => {
+    expect(parseLightningAddress('bob@example.com', { allowHttp: true }).discoveryUrl)
+      .toBe('http://example.com/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@example.com', { allowHttp: false }).discoveryUrl)
+      .toBe('https://example.com/.well-known/lnurlp/bob')
+  })
+
+  it('throws when the address is missing or not a string', () => {
+    expect(() => parseLightningAddress('')).toThrow(LnurlPayError)
+    expect(() => parseLightningAddress(undefined)).toThrow(/address required/)
+    expect(() => parseLightningAddress(42)).toThrow(LnurlPayError)
+  })
+
+  it('throws on a missing @, a leading @, or a trailing @', () => {
+    expect(() => parseLightningAddress('nohost')).toThrow(/malformed address/)
+    expect(() => parseLightningAddress('@host.com')).toThrow(/malformed address/)
+    expect(() => parseLightningAddress('user@')).toThrow(/malformed address/)
+  })
+
+  it('throws on an invalid local-part', () => {
+    expect(() => parseLightningAddress('a b@host.com')).toThrow(/invalid local-part/)
+  })
+
+  it('throws on an invalid host', () => {
+    expect(() => parseLightningAddress('user@ho st.com')).toThrow(/invalid host/)
+  })
+})
+
+describe('fetchDiscovery', () => {
+  it('requests the derived well-known URL with an Accept header and returns parsed params', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
+    const out = await fetchDiscovery('alice@getalby.com', { fetch })
+    expect(out).toEqual(discoveryDoc())
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://getalby.com/.well-known/lnurlp/alice')
+    expect(init.headers.Accept).toBe('application/json')
+    expect(init.signal === undefined || typeof init.signal === 'object').toBe(true)
+  })
+
+  it('passes a full http(s) URL straight through without parsing it as an address', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
+    const url = 'https://lsp.example/.well-known/lnurlp/carol'
+    await fetchDiscovery(url, { fetch })
+    expect(fetch.mock.calls[0][0]).toBe(url)
+  })
+
+  it('throws when no usable fetch is available', async () => {
+    // `opts.fetch ?? globalThis.fetch` only falls back on null/undefined,
+    // so a non-function value reaches the typeof guard.
+    await expect(fetchDiscovery('a@b.com', { fetch: 'not-a-fn' }))
+      .rejects.toThrow(/no global fetch/)
+  })
+
+  it('wraps a thrown fetch transport error with a cause', async () => {
+    const cause = new Error('ECONNREFUSED')
+    const fetch = jest.fn(async () => { throw cause })
+    const err = await fetchDiscovery('a@b.com', { fetch }).catch((e) => e)
+    expect(err).toBeInstanceOf(LnurlPayError)
+    expect(err.message).toMatch(/fetch failed/)
+    expect(err.cause).toBe(cause)
+  })
+
+  it('throws with status + body on a non-ok HTTP response', async () => {
+    const fetch = jest.fn(async () => makeResponse({ ok: false, status: 404, raw: '  not found  ' }))
+    const err = await fetchDiscovery('a@b.com', { fetch }).catch((e) => e)
+    expect(err).toBeInstanceOf(LnurlPayError)
+    expect(err.status).toBe(404)
+    expect(err.body).toBe('not found')
+    expect(err.message).toMatch(/HTTP 404/)
+  })
+
+  it('throws when the body is not valid JSON', async () => {
+    const fetch = jest.fn(async () => makeResponse({ raw: 'not-json{' }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/invalid JSON/)
+  })
+
+  it('throws when discovery is not an object', async () => {
+    const fetch = jest.fn(async () => makeResponse({ raw: 'null' }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/is not an object/)
+  })
+
+  it('throws when the server returns status=ERROR', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: { status: 'ERROR', reason: 'blocked' } }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/discovery rejected: blocked/)
+  })
+
+  it('throws when the status=ERROR document omits a reason', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: { status: 'ERROR' } }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/no reason/)
+  })
+
+  it('throws when the tag is not payRequest', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ tag: 'withdrawRequest' }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/expected tag='payRequest'/)
+  })
+
+  it('throws when the callback is not an http(s) URL', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ callback: 'ftp://x' }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/invalid callback/)
+  })
+
+  it('throws when the sendable range is missing, inverted, or non-positive', async () => {
+    const cases = [
+      { minSendable: undefined },
+      { minSendable: 5000, maxSendable: 1000 },
+      { minSendable: 0 }
+    ]
+    for (const overrides of cases) {
+      const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc(overrides) }))
+      await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/invalid sendable range/)
+    }
+  })
+
+  it('accepts numeric sendable bounds passed as strings', async () => {
+    const fetch = jest.fn(async () => makeResponse({
+      body: discoveryDoc({ minSendable: '1000', maxSendable: '5000' })
+    }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).resolves.toMatchObject({ tag: 'payRequest' })
+  })
+
+  it('throws when metadata is not a string', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ metadata: 123 }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/missing metadata string/)
+  })
+})
+
+describe('resolveAddressToInvoice', () => {
+  // Build a two-call fetch: first call -> discovery, second -> callback.
+  function twoStepFetch (discovery, callbackResp) {
+    let n = 0
+    return jest.fn(async () => {
+      n += 1
+      return n === 1 ? makeResponse({ body: discovery }) : makeResponse({ body: callbackResp })
+    })
+  }
+
+  it('resolves an in-range amount to the bolt11 invoice plus context', async () => {
+    const discovery = discoveryDoc()
+    const fetch = twoStepFetch(discovery, { pr: 'lnbc1...', routes: [{ a: 1 }] })
+    const out = await resolveAddressToInvoice('alice@getalby.com', 5000n, { fetch })
+    expect(out.pr).toBe('lnbc1...')
+    expect(out.routes).toEqual([{ a: 1 }])
+    expect(out.discovery).toEqual(discovery)
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000')
+    // discovery + callback = exactly two fetches.
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch.mock.calls[1][0]).toBe('https://pay.example/lnurlp/cb?amount=5000')
+  })
+
+  it('defaults routes to an empty array when the callback omits them', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch })
+    expect(out.routes).toEqual([])
+  })
+
+  it('accepts a numeric amount and truncates it to an integer string', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 4999.9, { fetch })
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=4999')
+  })
+
+  it('accepts an integer string amount', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', '2500', { fetch })
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=2500')
+  })
+
+  it('appends a LUD-12 comment with & when the callback already has a query', async () => {
+    const discovery = discoveryDoc({ callback: 'https://pay.example/cb?token=xyz' })
+    const fetch = twoStepFetch(discovery, { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch, comment: 'hi there' })
+    expect(out.callbackUrl).toBe('https://pay.example/cb?token=xyz&amount=5000&comment=hi+there')
+  })
+
+  it('throws when no usable fetch is available', async () => {
+    await expect(resolveAddressToInvoice('a@b.com', 1000, { fetch: 'not-a-fn' }))
+      .rejects.toThrow(/no global fetch/)
+  })
+
+  it('throws when the amount is below the server minimum', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    await expect(resolveAddressToInvoice('a@b.com', 500, { fetch }))
+      .rejects.toThrow(/outside server range/)
+    // Only discovery is fetched; the out-of-range guard short-circuits.
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when the amount is above the server maximum', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    await expect(resolveAddressToInvoice('a@b.com', 999999, { fetch }))
+      .rejects.toThrow(/outside server range/)
+  })
+
+  it('throws on a negative bigint amount', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
+    await expect(resolveAddressToInvoice('a@b.com', -1n, { fetch }))
+      .rejects.toThrow(/must be ≥ 0/)
+  })
+
+  it('throws on a non-integer / negative amount', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
+    await expect(resolveAddressToInvoice('a@b.com', -5, { fetch }))
+      .rejects.toThrow(/non-negative integer/)
+    await expect(resolveAddressToInvoice('a@b.com', 'abc', { fetch }))
+      .rejects.toThrow(/non-negative integer/)
+    await expect(resolveAddressToInvoice('a@b.com', {}, { fetch }))
+      .rejects.toThrow(/non-negative integer/)
+  })
+
+  it('throws when the callback responds with status=ERROR', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { status: 'ERROR', reason: 'too poor' })
+    const err = await resolveAddressToInvoice('a@b.com', 5000, { fetch }).catch((e) => e)
+    expect(err).toBeInstanceOf(LnurlPayError)
+    expect(err.message).toMatch(/callback rejected: too poor/)
+    expect(err.status).toBe(200)
+  })
+
+  it('reports "no reason" when the callback ERROR omits a reason', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { status: 'ERROR' })
+    await expect(resolveAddressToInvoice('a@b.com', 5000, { fetch }))
+      .rejects.toThrow(/no reason/)
+  })
+
+  it('throws when the callback omits pr', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { routes: [] })
+    await expect(resolveAddressToInvoice('a@b.com', 5000, { fetch }))
+      .rejects.toThrow(/missing 'pr'/)
+  })
+
+  it('throws when pr is an empty string', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: '' })
+    await expect(resolveAddressToInvoice('a@b.com', 5000, { fetch }))
+      .rejects.toThrow(/missing 'pr'/)
+  })
+
+  it('compares large msat amounts as BigInt without 2^53 truncation', async () => {
+    const big = '9007199254740993' // 2^53 + 1
+    const discovery = discoveryDoc({ minSendable: '1000', maxSendable: big })
+    const fetch = twoStepFetch(discovery, { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', BigInt(big), { fetch })
+    expect(out.callbackUrl).toBe(`https://pay.example/lnurlp/cb?amount=${big}`)
+  })
+})
+
+describe('timeout signal selection', () => {
+  // The happy paths above exercise the AbortSignal.timeout branch. Here we
+  // temporarily blank out AbortSignal.timeout to drive the AbortController
+  // fallback, and also blank out AbortController to hit the undefined path.
+  let savedTimeout
+
+  beforeEach(() => {
+    savedTimeout = AbortSignal.timeout
+  })
+
+  afterEach(() => {
+    AbortSignal.timeout = savedTimeout
+  })
+
+  it('falls back to AbortController when AbortSignal.timeout is unavailable', async () => {
+    AbortSignal.timeout = undefined
+    let captured
+    const fetch = jest.fn(async (url, init) => {
+      captured = init.signal
+      return makeResponse({ body: discoveryDoc() })
+    })
+    await fetchDiscovery('a@b.com', { fetch })
+    // The controller's signal is a real AbortSignal instance.
+    expect(captured).toBeInstanceOf(AbortSignal)
+  })
+
+  it('passes undefined when neither AbortSignal.timeout nor AbortController exist', async () => {
+    AbortSignal.timeout = undefined
+    const savedController = globalThis.AbortController
+    globalThis.AbortController = undefined
+    try {
+      let captured = 'unset'
+      const fetch = jest.fn(async (url, init) => {
+        captured = init.signal
+        return makeResponse({ body: discoveryDoc() })
+      })
+      await fetchDiscovery('a@b.com', { fetch })
+      expect(captured).toBeUndefined()
+    } finally {
+      globalThis.AbortController = savedController
+    }
+  })
+})

--- a/tests/lnurl-pay.test.js
+++ b/tests/lnurl-pay.test.js
@@ -130,7 +130,10 @@ describe('fetchDiscovery', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
     const [url, init] = fetch.mock.calls[0]
     expect(url).toBe('https://getalby.com/.well-known/lnurlp/alice')
-    expect(init.headers.Accept).toBe('application/json')
+    // The default headers object is exactly { Accept: 'application/json' };
+    // since no caller headers are merged here, asserting the whole shape
+    // catches a dropped/renamed Accept key.
+    expect(init.headers).toEqual({ Accept: 'application/json' })
     expect(init.signal === undefined || typeof init.signal === 'object').toBe(true)
   })
 
@@ -208,6 +211,22 @@ describe('fetchDiscovery', () => {
     }
   })
 
+  it('rejects minSendable=0 but accepts minSendable=1 (min <= 0 boundary)', async () => {
+    // Isolates the `min <= 0` sub-clause. With min=0, max=100000 every other
+    // clause (min==null, max==null, min>max) is false, so ONLY `min <= 0`
+    // fires the throw. Mutating `<=` to `<` would make `0 < 0` false and
+    // wrongly ACCEPT a zero floor — this asserts the rejection directly.
+    const zeroFetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ minSendable: 0 }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch: zeroFetch }))
+      .rejects.toThrow(/invalid sendable range min=0 max=100000/)
+
+    // And the smallest positive floor (1) must pass the guard, proving the
+    // clause is exactly `<= 0` and not e.g. `<= 1`.
+    const oneFetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ minSendable: 1 }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch: oneFetch }))
+      .resolves.toMatchObject({ minSendable: 1 })
+  })
+
   it('accepts numeric sendable bounds passed as strings', async () => {
     const fetch = jest.fn(async () => makeResponse({
       body: discoveryDoc({ minSendable: '1000', maxSendable: '5000' })
@@ -269,6 +288,25 @@ describe('resolveAddressToInvoice', () => {
     expect(out.callbackUrl).toBe('https://pay.example/cb?token=xyz&amount=5000&comment=hi+there')
   })
 
+  it('uses ? for the first param and & between params when the callback has no query', async () => {
+    // The base callback has NO query string, so appendQuery must start with '?'
+    // and join the comment with '&'. This pins the `?` vs `&` separator choice
+    // for the comment branch independently of the already-has-query test above.
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch, comment: 'hi there' })
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000&comment=hi+there')
+    expect(fetch.mock.calls[1][0]).toBe('https://pay.example/lnurlp/cb?amount=5000&comment=hi+there')
+  })
+
+  it('omits the comment param entirely when no comment is supplied', async () => {
+    // The `...(opts.comment ? { comment } : {})` branch: with no comment the
+    // callback URL carries amount only and NO comment key.
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch })
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000')
+    expect(out.callbackUrl).not.toContain('comment')
+  })
+
   it('throws when no usable fetch is available', async () => {
     await expect(resolveAddressToInvoice('a@b.com', 1000, { fetch: 'not-a-fn' }))
       .rejects.toThrow(/no global fetch/)
@@ -288,6 +326,44 @@ describe('resolveAddressToInvoice', () => {
       .rejects.toThrow(/outside server range/)
   })
 
+  it('accepts an amount exactly equal to minSendable (inclusive lower bound)', async () => {
+    // discoveryDoc() has minSendable=1000. Paying exactly 1000 must succeed:
+    // the guard is `amount < min` (strict). Mutating `<` to `<=` would reject
+    // this boundary and the second (callback) fetch would never happen.
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 1000, { fetch })
+    expect(out.pr).toBe('lnbc1...')
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=1000')
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('accepts an amount exactly equal to maxSendable (inclusive upper bound)', async () => {
+    // discoveryDoc() has maxSendable=100000. Paying exactly 100000 must
+    // succeed: the guard is `amount > max` (strict). Mutating `>` to `>=`
+    // would reject this boundary and skip the callback fetch.
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    const out = await resolveAddressToInvoice('a@b.com', 100000, { fetch })
+    expect(out.pr).toBe('lnbc1...')
+    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=100000')
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects an amount one below minSendable but accepts the boundary', async () => {
+    // Pins the strict-inequality edge: 999 (min-1) rejected, 1000 (min) ok.
+    const below = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    await expect(resolveAddressToInvoice('a@b.com', 999, { fetch: below }))
+      .rejects.toThrow(/outside server range \[1000, 100000\]/)
+    expect(below).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an amount one above maxSendable but accepts the boundary', async () => {
+    // Pins the strict-inequality edge: 100001 (max+1) rejected.
+    const above = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
+    await expect(resolveAddressToInvoice('a@b.com', 100001, { fetch: above }))
+      .rejects.toThrow(/outside server range \[1000, 100000\]/)
+    expect(above).toHaveBeenCalledTimes(1)
+  })
+
   it('throws on a negative bigint amount', async () => {
     const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
     await expect(resolveAddressToInvoice('a@b.com', -1n, { fetch }))
@@ -305,11 +381,16 @@ describe('resolveAddressToInvoice', () => {
   })
 
   it('throws when the callback responds with status=ERROR', async () => {
-    const fetch = twoStepFetch(discoveryDoc(), { status: 'ERROR', reason: 'too poor' })
+    const errorBody = { status: 'ERROR', reason: 'too poor' }
+    const fetch = twoStepFetch(discoveryDoc(), errorBody)
     const err = await resolveAddressToInvoice('a@b.com', 5000, { fetch }).catch((e) => e)
     expect(err).toBeInstanceOf(LnurlPayError)
     expect(err.message).toMatch(/callback rejected: too poor/)
     expect(err.status).toBe(200)
+    // The error must carry the verbatim callback body for diagnostics:
+    // blanking it to '' (or any other value) is a regression.
+    expect(err.body).toBe(JSON.stringify(errorBody))
+    expect(JSON.parse(err.body)).toEqual(errorBody)
   })
 
   it('reports "no reason" when the callback ERROR omits a reason', async () => {
@@ -322,6 +403,43 @@ describe('resolveAddressToInvoice', () => {
     const fetch = twoStepFetch(discoveryDoc(), { routes: [] })
     await expect(resolveAddressToInvoice('a@b.com', 5000, { fetch }))
       .rejects.toThrow(/missing 'pr'/)
+  })
+
+  it('truncates an over-long missing-pr body to 197 chars + an ellipsis', async () => {
+    // A callback response with NO pr whose JSON serialization is far longer
+    // than 200 chars, forcing truncate() to fire. The pad value contains no
+    // double quotes so the serialized JSON shape is predictable.
+    const longBody = { routes: [], note: 'x'.repeat(500) }
+    const serialized = JSON.stringify(longBody)
+    expect(serialized.length).toBeGreaterThan(200)
+    const fetch = twoStepFetch(discoveryDoc(), longBody)
+    const err = await resolveAddressToInvoice('a@b.com', 5000, { fetch }).catch((e) => e)
+    expect(err).toBeInstanceOf(LnurlPayError)
+    // Exact contract: first 197 chars of the serialized body, then '…'.
+    const expectedTruncation = serialized.slice(0, 197) + '…'
+    expect(err.message).toBe(`LUD-06 callback missing 'pr': ${expectedTruncation}`)
+    // Kills slice(0, 150)+'!!!' and any other cap/marker mutation.
+    expect(err.message).toContain('…')
+    expect(err.message).not.toContain('!!!')
+    expect(err.message.endsWith('…')).toBe(true)
+    // The truncated body must include exactly 197 chars of payload after the
+    // fixed prefix, so a 150-char cap (47 fewer chars) would change the length.
+    const payload = err.message.slice("LUD-06 callback missing 'pr': ".length)
+    expect(payload).toHaveLength(198) // 197 chars + the single ellipsis char
+    expect(payload.slice(0, 197)).toBe(serialized.slice(0, 197))
+  })
+
+  it('does NOT truncate a short missing-pr body', async () => {
+    // Guards the s.length > 200 boundary: a sub-200-char body passes through
+    // verbatim with no ellipsis, so flipping > to >= or changing the cap is
+    // observable here too.
+    const shortBody = { routes: [] }
+    const serialized = JSON.stringify(shortBody)
+    expect(serialized.length).toBeLessThanOrEqual(200)
+    const fetch = twoStepFetch(discoveryDoc(), shortBody)
+    const err = await resolveAddressToInvoice('a@b.com', 5000, { fetch }).catch((e) => e)
+    expect(err.message).toBe(`LUD-06 callback missing 'pr': ${serialized}`)
+    expect(err.message).not.toContain('…')
   })
 
   it('throws when pr is an empty string', async () => {

--- a/tests/lsp-client.test.js
+++ b/tests/lsp-client.test.js
@@ -1,0 +1,585 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the thin typed LSP HTTP wrapper. Every request is served
+// by an injected `fetch` stub (opts.fetch) returning Response-like objects
+// so no real network or native code is touched.
+
+import { jest } from '@jest/globals'
+import { LspError, LspClient } from '../src/lsp-client.js'
+
+const BASE = 'https://lsp.utexo.io'
+
+// Build a Response-like object. `text` defaults to a JSON serialization of
+// `json` so callers can pass either.
+function makeRes ({ ok = true, status = 200, json, text, headers } = {}) {
+  const bodyText = text !== undefined
+    ? text
+    : (json !== undefined ? JSON.stringify(json) : '')
+  return {
+    ok,
+    status,
+    headers: headers ?? {},
+    json: async () => (json !== undefined ? json : JSON.parse(bodyText)),
+    text: async () => bodyText
+  }
+}
+
+// A fetch stub that returns the given (single) response for every call.
+function fetchReturning (res) {
+  return jest.fn(async () => res)
+}
+
+function makeClient (overrides = {}) {
+  const fetchImpl = overrides.fetch ?? fetchReturning(makeRes({ json: { ok: true } }))
+  const client = new LspClient({ baseUrl: BASE, fetch: fetchImpl, ...overrides })
+  return { client, fetchImpl }
+}
+
+describe('LspError', () => {
+  it('formats a message with status + body for HTTP errors', () => {
+    const err = new LspError('/health', 503, 'down')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('LspError')
+    expect(err.endpoint).toBe('/health')
+    expect(err.status).toBe(503)
+    expect(err.body).toBe('down')
+    expect(err.message).toBe('LSP /health → HTTP 503: down')
+  })
+
+  it('formats a transport-failure message (status 0) from the cause', () => {
+    const cause = new Error('ECONNREFUSED')
+    const err = new LspError('/get_info', 0, '', cause)
+    expect(err.status).toBe(0)
+    expect(err.message).toBe('LSP /get_info → ECONNREFUSED')
+    expect(err.cause).toBe(cause)
+  })
+
+  it('falls back to "request failed" when the cause has no message', () => {
+    const err = new LspError('/get_info', 0, '')
+    expect(err.message).toBe('LSP /get_info → request failed')
+  })
+
+  it('parses a structured JSON error body into errorBody/errorCode/errorTag', () => {
+    const body = JSON.stringify({ error: 'asset not allowed', code: 42, name: 'AssetDenied' })
+    const err = new LspError('/onchain_send', 400, body)
+    expect(err.errorBody).toEqual({ error: 'asset not allowed', code: 42, name: 'AssetDenied' })
+    expect(err.errorCode).toBe(42)
+    expect(err.errorTag).toBe('AssetDenied')
+    // message is rewritten to the structured `error` string.
+    expect(err.message).toBe('LSP /onchain_send → HTTP 400: asset not allowed')
+  })
+
+  it('accepts a string code in the structured body', () => {
+    const body = JSON.stringify({ error: 'nope', code: 'E_NOPE' })
+    const err = new LspError('/x', 400, body)
+    expect(err.errorCode).toBe('E_NOPE')
+    expect(err.errorTag).toBeNull()
+  })
+
+  it('leaves structured fields null for a non-JSON body', () => {
+    const err = new LspError('/x', 500, 'plain text error')
+    expect(err.errorBody).toBeNull()
+    expect(err.errorCode).toBeNull()
+    expect(err.errorTag).toBeNull()
+  })
+
+  it('tolerates a body that starts with { but is not valid JSON', () => {
+    const err = new LspError('/x', 500, '{not json')
+    expect(err.errorBody).toBeNull()
+    expect(err.message).toBe('LSP /x → HTTP 500: {not json')
+  })
+
+  it('handles a JSON body without recognised fields', () => {
+    const err = new LspError('/x', 400, JSON.stringify({ foo: 'bar' }))
+    expect(err.errorBody).toEqual({ foo: 'bar' })
+    expect(err.errorCode).toBeNull()
+    expect(err.errorTag).toBeNull()
+    // message stays the raw-body form since there was no `error` field.
+    expect(err.message).toBe('LSP /x → HTTP 400: {"foo":"bar"}')
+  })
+})
+
+describe('LspClient constructor', () => {
+  it('throws when baseUrl is missing or empty', () => {
+    expect(() => new LspClient({})).toThrow(/baseUrl is required/)
+    expect(() => new LspClient({ baseUrl: '' })).toThrow(/baseUrl is required/)
+    expect(() => new LspClient()).toThrow(/baseUrl is required/)
+  })
+
+  it('throws when no fetch is available', () => {
+    const orig = globalThis.fetch
+    // Remove global fetch so the fallback also fails.
+    delete globalThis.fetch
+    try {
+      expect(() => new LspClient({ baseUrl: BASE })).toThrow(/no fetch available/)
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+
+  it('uses globalThis.fetch when no override is supplied', () => {
+    const orig = globalThis.fetch
+    const g = jest.fn(async () => makeRes({ json: {} }))
+    globalThis.fetch = g
+    try {
+      const client = new LspClient({ baseUrl: BASE })
+      expect(client.baseUrl).toBe(BASE)
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+
+  it('normalises a trailing slash off the baseUrl', () => {
+    const { client } = makeClient({ baseUrl: 'https://lsp.utexo.io///' })
+    expect(client.baseUrl).toBe('https://lsp.utexo.io')
+  })
+
+  it('rejects a baseUrl that is not a valid URL', () => {
+    expect(() => new LspClient({ baseUrl: 'not a url', fetch: jest.fn() })).toThrow(/not a valid URL/)
+  })
+
+  it('rejects a non-http(s) protocol', () => {
+    expect(() => new LspClient({ baseUrl: 'ftp://lsp.utexo.io', fetch: jest.fn() })).toThrow(/must use http: or https:/)
+  })
+
+  it('rejects plain http on a non-loopback host by default', () => {
+    expect(() => new LspClient({ baseUrl: 'http://example.com', fetch: jest.fn() }))
+      .toThrow(/plain http:\/\/ is only allowed for loopback/)
+  })
+
+  it('allows plain http on a loopback host', () => {
+    const client = new LspClient({ baseUrl: 'http://localhost:3000', fetch: jest.fn() })
+    expect(client.baseUrl).toBe('http://localhost:3000')
+  })
+
+  it('allows plain http on a non-loopback host when allowHttp is set', () => {
+    const client = new LspClient({ baseUrl: 'http://staging.local', fetch: jest.fn(), allowHttp: true })
+    expect(client.baseUrl).toBe('http://staging.local')
+  })
+
+  it('clamps a non-finite maxRetries to the default', () => {
+    const { client } = makeClient({ maxRetries: Number.NaN })
+    expect(client._maxRetries).toBe(3)
+  })
+
+  it('floors a negative maxRetries to 0 and truncates fractions', () => {
+    expect(makeClient({ maxRetries: -5 }).client._maxRetries).toBe(0)
+    expect(makeClient({ maxRetries: 2.9 }).client._maxRetries).toBe(2)
+  })
+
+  it('clamps a bogus timeoutMs to the default', () => {
+    expect(makeClient({ timeoutMs: 0 }).client._timeoutMs).toBe(15000)
+    expect(makeClient({ timeoutMs: 'x' }).client._timeoutMs).toBe(15000)
+  })
+
+  it('copies defaultHeaders defensively', () => {
+    const headers = { Authorization: 'Bearer tok' }
+    const { client } = makeClient({ defaultHeaders: headers })
+    headers.Authorization = 'mutated'
+    expect(client._headers).toEqual({ Authorization: 'Bearer tok' })
+  })
+})
+
+describe('GET endpoint methods', () => {
+  it('health() issues GET /health and returns parsed JSON', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { status: 'ok' } })) })
+    const out = await client.health()
+    expect(out).toEqual({ status: 'ok' })
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://lsp.utexo.io/health')
+    expect(init.method).toBe('GET')
+    expect(init.headers.Accept).toBe('application/json')
+    // No body / Content-Type on a GET.
+    expect(init.body).toBeUndefined()
+    expect(init.headers['Content-Type']).toBeUndefined()
+  })
+
+  it('getInfo() issues GET /get_info', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { pubkey: 'abc' } })) })
+    expect(await client.getInfo()).toEqual({ pubkey: 'abc' })
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://lsp.utexo.io/get_info')
+  })
+
+  it('merges defaultHeaders (e.g. a Bearer token) into every request', async () => {
+    const { client, fetchImpl } = makeClient({ defaultHeaders: { Authorization: 'Bearer tok' } })
+    await client.health()
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('Bearer tok')
+  })
+
+  it('lnurlDiscovery() encodes the username into the well-known path', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { callback: 'x' } })) })
+    await client.lnurlDiscovery('al ice')
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://lsp.utexo.io/.well-known/lnurlp/al%20ice')
+  })
+
+  it('lnurlDiscovery() requires a username', () => {
+    const { client } = makeClient()
+    expect(() => client.lnurlDiscovery('')).toThrow(/username required/)
+    expect(() => client.lnurlDiscovery()).toThrow(/username required/)
+  })
+
+  it('lnurlCallback() builds the amount query and encodes the username', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { pr: 'lnbc' } })) })
+    await client.lnurlCallback('alice', 1000)
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://lsp.utexo.io/pay/callback/alice?amount=1000')
+  })
+
+  it('lnurlCallback() forwards optional asset_id / asset_amount', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })) })
+    await client.lnurlCallback('alice', 5000n, { assetId: 'rgb:asset', assetAmount: 7 })
+    const url = fetchImpl.mock.calls[0][0]
+    expect(url).toContain('amount=5000')
+    expect(url).toContain('asset_id=rgb%3Aasset')
+    expect(url).toContain('asset_amount=7')
+  })
+
+  it('lnurlCallback() requires a username', () => {
+    const { client } = makeClient()
+    expect(() => client.lnurlCallback('', 1)).toThrow(/username required/)
+  })
+
+  it('lnurlCallback() rejects a non-integer amount', () => {
+    const { client } = makeClient()
+    expect(() => client.lnurlCallback('alice', -1)).toThrow(/non-negative integer/)
+    expect(() => client.lnurlCallback('alice', 'abc')).toThrow(/non-negative integer/)
+  })
+
+  it('getLightningAddressByPubkey() trims and encodes the pubkey', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { username: 'u', domain: 'd' } })) })
+    const out = await client.getLightningAddressByPubkey('  02abc  ')
+    expect(out).toEqual({ username: 'u', domain: 'd' })
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://lsp.utexo.io/lightning_address/by_pubkey/02abc')
+  })
+
+  it('getLightningAddressByPubkey() requires a non-empty pubkey', () => {
+    const { client } = makeClient()
+    expect(() => client.getLightningAddressByPubkey('   ')).toThrow(/peerPubkey required/)
+    expect(() => client.getLightningAddressByPubkey(123)).toThrow(/peerPubkey required/)
+  })
+})
+
+describe('resolveAddress', () => {
+  it('requires a username', async () => {
+    const { client } = makeClient()
+    await expect(client.resolveAddress('', 1000)).rejects.toThrow(/username required/)
+  })
+
+  it('discovers the callback then fetches the invoice in one call', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(makeRes({ json: { callback: 'https://lsp.utexo.io/pay/callback/alice' } }))
+      .mockResolvedValueOnce(makeRes({ json: { pr: 'lnbc1', routes: [] } }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    const out = await client.resolveAddress('alice', 2500, { assetId: 'rgb:a', assetAmount: 3 })
+    expect(out).toEqual({ pr: 'lnbc1', routes: [] })
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://lsp.utexo.io/.well-known/lnurlp/alice')
+    const cbUrl = fetchImpl.mock.calls[1][0]
+    expect(cbUrl).toContain('https://lsp.utexo.io/pay/callback/alice?')
+    expect(cbUrl).toContain('amount=2500')
+    expect(cbUrl).toContain('asset_id=rgb%3Aa')
+    expect(cbUrl).toContain('asset_amount=3')
+  })
+
+  it('rewrites an internal/emulator callback host onto the baseUrl origin', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(makeRes({ json: { callback: 'http://10.0.2.2:9000/pay/callback/bob' } }))
+      .mockResolvedValueOnce(makeRes({ json: { pr: 'lnbc2' } }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.resolveAddress('bob', 100)
+    // second hop is rewritten to the client's own origin.
+    expect(fetchImpl.mock.calls[1][0]).toBe('https://lsp.utexo.io/pay/callback/bob?amount=100')
+  })
+
+  it('appends with & when the callback already has a query string', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(makeRes({ json: { callback: 'https://lsp.utexo.io/pay/callback/x?nonce=1' } }))
+      .mockResolvedValueOnce(makeRes({ json: { pr: 'lnbc3' } }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.resolveAddress('x', 100)
+    const url = fetchImpl.mock.calls[1][0]
+    expect(url).toContain('nonce=1&amount=100')
+  })
+
+  it('throws an LspError when the discovery response lacks a callback', async () => {
+    const fetchImpl = fetchReturning(makeRes({ json: { other: true } }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await expect(client.resolveAddress('alice', 100)).rejects.toThrow(/missing callback in LNURL response/)
+  })
+})
+
+describe('POST endpoint methods', () => {
+  it('onchainSend() posts the snake_cased body and camel-cases the response', async () => {
+    const fetchImpl = fetchReturning(makeRes({
+      json: { rgb_invoice: 'rgb:x', ln_invoice: 'lnbc', mapping_id: 9 }
+    }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    const out = await client.onchainSend({
+      rgbInvoice: 'rgb:x',
+      ln: {
+        amtMsat: 1000n,
+        expirySec: 3600,
+        assetId: 'rgb:a',
+        assetAmount: 5,
+        descriptionHash: 'dh',
+        paymentHash: 'ph',
+        minFinalCltvExpiryDelta: 40
+      }
+    })
+    expect(out).toEqual({
+      rgb_invoice: 'rgb:x',
+      ln_invoice: 'lnbc',
+      mapping_id: 9,
+      rgbInvoice: 'rgb:x',
+      lnInvoice: 'lnbc',
+      mappingId: 9
+    })
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://lsp.utexo.io/onchain_send')
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    const body = JSON.parse(init.body)
+    expect(body).toEqual({
+      rgb_invoice: 'rgb:x',
+      lninvoice: {
+        amt_msat: 1000,
+        expiry_sec: 3600,
+        asset_id: 'rgb:a',
+        asset_amount: 5,
+        description_hash: 'dh',
+        payment_hash: 'ph',
+        min_final_cltv_expiry_delta: 40
+      }
+    })
+  })
+
+  it('onchainSend() requires rgbInvoice and ln params', async () => {
+    const { client } = makeClient()
+    await expect(client.onchainSend({})).rejects.toThrow(/rgbInvoice required/)
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x' })).rejects.toThrow(/ln params required/)
+  })
+
+  it('lightningReceive() posts snake_cased rgb params with defaults', async () => {
+    const fetchImpl = fetchReturning(makeRes({
+      json: { ln_invoice: 'lnbc', rgb_invoice: 'rgb:y', mapping_id: 3 }
+    }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    const out = await client.lightningReceive({
+      lnInvoice: 'lnbc',
+      rgb: { assetId: 'rgb:a' }
+    })
+    expect(out).toMatchObject({ lnInvoice: 'lnbc', rgbInvoice: 'rgb:y', mappingId: 3 })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body).toEqual({
+      ln_invoice: 'lnbc',
+      rgb_invoice: { asset_id: 'rgb:a', min_confirmations: 1, witness: false }
+    })
+  })
+
+  it('lightningReceive() forwards optional rgb fields', async () => {
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.lightningReceive({
+      lnInvoice: 'lnbc',
+      rgb: { assetId: 'rgb:a', assignment: 'Any', durationSeconds: 600, minConfirmations: 2, witness: true }
+    })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.rgb_invoice).toEqual({
+      asset_id: 'rgb:a',
+      min_confirmations: 2,
+      witness: true,
+      assignment: 'Any',
+      duration_seconds: 600
+    })
+  })
+
+  it('lightningReceive() validates lnInvoice and rgb params', async () => {
+    const { client } = makeClient()
+    await expect(client.lightningReceive({})).rejects.toThrow(/lnInvoice required/)
+    await expect(client.lightningReceive({ lnInvoice: 'lnbc' })).rejects.toThrow(/rgb params required/)
+    await expect(client.lightningReceive({ lnInvoice: 'lnbc', rgb: {} })).rejects.toThrow(/rgb.assetId required/)
+  })
+})
+
+describe('_req error and edge handling', () => {
+  it('returns null for an empty (204-style) ok body', async () => {
+    const { client } = makeClient({ fetch: fetchReturning(makeRes({ ok: true, status: 204, text: '' })) })
+    expect(await client.health()).toBeNull()
+  })
+
+  it('throws an LspError carrying status + trimmed body on a non-ok response', async () => {
+    const { client } = makeClient({
+      fetch: fetchReturning(makeRes({ ok: false, status: 400, text: '  bad request  ' }))
+    })
+    await expect(client.health()).rejects.toMatchObject({
+      name: 'LspError',
+      status: 400,
+      endpoint: '/health',
+      body: 'bad request'
+    })
+  })
+
+  it('throws an LspError when the ok body is not valid JSON', async () => {
+    const { client } = makeClient({ fetch: fetchReturning(makeRes({ ok: true, status: 200, text: '<html>' })) })
+    await expect(client.health()).rejects.toMatchObject({
+      name: 'LspError',
+      status: 200,
+      body: 'invalid JSON: <html>'
+    })
+  })
+
+  it('rejects a response larger than the 1 MiB cap', async () => {
+    const huge = 'a'.repeat((1 << 20) + 1)
+    const { client } = makeClient({ fetch: fetchReturning(makeRes({ ok: true, status: 200, text: huge })) })
+    await expect(client.health()).rejects.toThrow(/response too large/)
+  })
+
+  it('wraps a transport-level fetch rejection in an LspError with status 0', async () => {
+    const cause = new Error('ECONNRESET')
+    const fetchImpl = jest.fn(async () => { throw cause })
+    // disable retries so it fails fast.
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 0 })
+    await expect(client.health()).rejects.toMatchObject({ name: 'LspError', status: 0 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('honours a per-call timeoutMs override (no throw, request still issued)', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })) })
+    await client.getInfo({ timeoutMs: 2000 })
+    expect(fetchImpl.mock.calls[0][1].signal).toBeDefined()
+  })
+})
+
+describe('_req retry behaviour', () => {
+  it('retries idempotent GETs on a retryable 503 then succeeds', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce(makeRes({ ok: false, status: 503, text: 'unavailable' }))
+      .mockResolvedValueOnce(makeRes({ json: { status: 'ok' } }))
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 3 })
+    const out = await client.health()
+    expect(out).toEqual({ status: 'ok' })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries on a transport error then succeeds', async () => {
+    const fetchImpl = jest.fn()
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce(makeRes({ json: { ok: true } }))
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 2 })
+    await client.health()
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after exhausting the retry budget and throws the last status', async () => {
+    const fetchImpl = jest.fn(async () => makeRes({ ok: false, status: 502, text: 'bad gateway' }))
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 2 })
+    await expect(client.health()).rejects.toMatchObject({ status: 502 })
+    // original + 2 retries = 3 calls.
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry a non-retryable status (e.g. 404)', async () => {
+    const fetchImpl = jest.fn(async () => makeRes({ ok: false, status: 404, text: 'not found' }))
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 3 })
+    await expect(client.health()).rejects.toMatchObject({ status: 404 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry POST methods even on a retryable status', async () => {
+    const fetchImpl = jest.fn(async () => makeRes({ ok: false, status: 503, text: 'unavailable' }))
+    const { client } = makeClient({ fetch: fetchImpl, maxRetries: 3 })
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: 1 } })).rejects.toMatchObject({ status: 503 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('_rewriteCallbackToPath', () => {
+  it('reduces an absolute URL to path+search+hash', () => {
+    const { client } = makeClient()
+    expect(client._rewriteCallbackToPath('https://other.example/pay/cb?x=1#frag')).toBe('/pay/cb?x=1#frag')
+  })
+
+  it('resolves a relative path against the baseUrl', () => {
+    const { client } = makeClient()
+    expect(client._rewriteCallbackToPath('/pay/cb')).toBe('/pay/cb')
+  })
+
+  it('falls back to a leading-slash-prefixed string when parsing throws', () => {
+    const { client } = makeClient()
+    // Force `new URL(...)` to throw by stubbing the base to an unparseable value.
+    client._base = '::::'
+    expect(client._rewriteCallbackToPath('pay/cb')).toBe('/pay/cb')
+    expect(client._rewriteCallbackToPath('/already')).toBe('/already')
+  })
+})
+
+describe('numeric coercion edge cases (via public API)', () => {
+  it('accepts a large bigint amount as a string in the LN body', async () => {
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    const big = BigInt(Number.MAX_SAFE_INTEGER) + 10n
+    await client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: big } })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.lninvoice.amt_msat).toBe(big.toString())
+  })
+
+  it('accepts a numeric-string amount in lnurlCallback', async () => {
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })) })
+    await client.lnurlCallback('alice', '1234')
+    expect(fetchImpl.mock.calls[0][0]).toContain('amount=1234')
+  })
+
+  it('rejects a negative bigint amount', async () => {
+    const { client } = makeClient()
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: -1n } }))
+      .rejects.toThrow(/must be ≥ 0/)
+  })
+
+  it('rejects a uint32 field that overflows', async () => {
+    const { client } = makeClient()
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { expirySec: 0x1ffffffff } }))
+      .rejects.toThrow(/must fit in uint32/)
+  })
+
+  it('passes a numeric-string amtMsat through unchanged (uint64 string path)', async () => {
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: '987654321' } })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.lninvoice.amt_msat).toBe('987654321')
+  })
+
+  it('rejects a non-numeric-string amtMsat', async () => {
+    const { client } = makeClient()
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: 'oops' } }))
+      .rejects.toThrow(/must be a non-negative integer/)
+  })
+})
+
+describe('_timeoutSignal', () => {
+  it('returns an AbortSignal from AbortSignal.timeout when available', () => {
+    const { client } = makeClient()
+    const sig = client._timeoutSignal(1000)
+    expect(sig).toBeInstanceOf(AbortSignal)
+  })
+
+  it('falls back to an AbortController when AbortSignal.timeout is missing', () => {
+    const orig = AbortSignal.timeout
+    // Force the fallback branch.
+    AbortSignal.timeout = undefined
+    try {
+      const { client } = makeClient()
+      const sig = client._timeoutSignal(1000)
+      expect(sig).toBeInstanceOf(AbortSignal)
+    } finally {
+      AbortSignal.timeout = orig
+    }
+  })
+
+  it('uses the constructor timeout when given a non-positive override', () => {
+    const { client } = makeClient({ timeoutMs: 5000 })
+    const sig = client._timeoutSignal(0)
+    expect(sig).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/tests/lsp-client.test.js
+++ b/tests/lsp-client.test.js
@@ -100,6 +100,20 @@ describe('LspError', () => {
     // message stays the raw-body form since there was no `error` field.
     expect(err.message).toBe('LSP /x → HTTP 400: {"foo":"bar"}')
   })
+
+  it('does not rewrite the message when the structured `error` field is non-string', () => {
+    // Guard: `if (typeof parsed.error === 'string')`. A numeric `error`
+    // must leave the message as the raw-body form. Dropping that guard
+    // would interpolate `123` into the message, which this catches.
+    const body = JSON.stringify({ error: 123, code: 7, name: 'Weird' })
+    const err = new LspError('/x', 400, body)
+    expect(err.errorBody).toEqual({ error: 123, code: 7, name: 'Weird' })
+    // code/name are still parsed; only the message-rewrite is suppressed.
+    expect(err.errorCode).toBe(7)
+    expect(err.errorTag).toBe('Weird')
+    expect(err.message).toBe(`LSP /x → HTTP 400: ${body}`)
+    expect(err.message).not.toContain('→ HTTP 400: 123')
+  })
 })
 
 describe('LspClient constructor', () => {
@@ -234,6 +248,26 @@ describe('GET endpoint methods', () => {
     expect(url).toContain('amount=5000')
     expect(url).toContain('asset_id=rgb%3Aasset')
     expect(url).toContain('asset_amount=7')
+  })
+
+  it('lnurlCallback() URL-encodes a username with special characters', async () => {
+    // Source path uses encodeURIComponent(username). A username with a
+    // space must appear percent-encoded in the callback path; dropping
+    // the encoding would leave a raw space, which this assertion catches.
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: { pr: 'lnbc' } })) })
+    await client.lnurlCallback('al ice', 1000)
+    const url = fetchImpl.mock.calls[0][0]
+    expect(url).toBe('https://lsp.utexo.io/pay/callback/al%20ice?amount=1000')
+    expect(url).not.toContain('callback/al ice')
+  })
+
+  it('lnurlCallback() String()-coerces a non-string assetId into the query', async () => {
+    // `params.set('asset_id', String(opts.assetId))` — a numeric assetId
+    // must be stringified, not dropped or passed as-is.
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })) })
+    await client.lnurlCallback('alice', 1000, { assetId: 12345 })
+    const url = fetchImpl.mock.calls[0][0]
+    expect(url).toContain('asset_id=12345')
   })
 
   it('lnurlCallback() requires a username', () => {
@@ -394,6 +428,33 @@ describe('POST endpoint methods', () => {
     })
   })
 
+  it('lightningReceive() coerces a truthy non-boolean witness to true', async () => {
+    // Source uses `witness: !!rgb.witness`. A truthy non-boolean (1) must
+    // become the boolean `true`. A `rgb.witness === true` mutation would
+    // turn 1 into false here, so assert the exact boolean.
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.lightningReceive({
+      lnInvoice: 'lnbc',
+      rgb: { assetId: 'rgb:a', witness: 1 }
+    })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.rgb_invoice.witness).toBe(true)
+  })
+
+  it('lightningReceive() coerces a falsy non-boolean witness to false', async () => {
+    // Symmetric guard: `!!0` is false and `0 === true` is also false, but
+    // pinning the exact boolean keeps the witness contract precise.
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.lightningReceive({
+      lnInvoice: 'lnbc',
+      rgb: { assetId: 'rgb:a', witness: 0 }
+    })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.rgb_invoice.witness).toBe(false)
+  })
+
   it('lightningReceive() validates lnInvoice and rgb params', async () => {
     const { client } = makeClient()
     await expect(client.lightningReceive({})).rejects.toThrow(/lnInvoice required/)
@@ -435,6 +496,21 @@ describe('_req error and edge handling', () => {
     await expect(client.health()).rejects.toThrow(/response too large/)
   })
 
+  it('accepts a response of exactly the 1 MiB cap (boundary is > not >=)', async () => {
+    // Build valid JSON whose total length is EXACTLY MAX_RESPONSE_BYTES.
+    // `text.length > MAX_RESPONSE_BYTES` must be false here, so the body is
+    // parsed and returned. A `>=` mutation would reject this exact-size
+    // body, which this test catches.
+    const MAX = 1 << 20
+    const wrapper = '{"a":"' + '"}' // {"a":"...." }
+    const pad = 'b'.repeat(MAX - wrapper.length)
+    const atLimit = '{"a":"' + pad + '"}'
+    expect(atLimit.length).toBe(MAX)
+    const { client } = makeClient({ fetch: fetchReturning(makeRes({ ok: true, status: 200, text: atLimit })) })
+    const out = await client.health()
+    expect(out).toEqual({ a: pad })
+  })
+
   it('wraps a transport-level fetch rejection in an LspError with status 0', async () => {
     const cause = new Error('ECONNRESET')
     const fetchImpl = jest.fn(async () => { throw cause })
@@ -444,10 +520,29 @@ describe('_req error and edge handling', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 
-  it('honours a per-call timeoutMs override (no throw, request still issued)', async () => {
-    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })) })
+  it('honours a per-call timeoutMs override (resolves the override, not the constructor default)', async () => {
+    // Constructor default is 15000; the per-call override is 2000. Assert
+    // the resolved call timeout is exactly 2000 so a mutation that ignores
+    // the override (callTimeoutMs = this._timeoutMs) is caught.
+    const { client, fetchImpl } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })), timeoutMs: 15000 })
+    const sigSpy = jest.spyOn(client, '_timeoutSignal')
     await client.getInfo({ timeoutMs: 2000 })
     expect(fetchImpl.mock.calls[0][1].signal).toBeDefined()
+    // _req computes callTimeoutMs then passes it to _timeoutSignal.
+    expect(sigSpy).toHaveBeenCalledWith(2000)
+    expect(sigSpy).not.toHaveBeenCalledWith(15000)
+    sigSpy.mockRestore()
+  })
+
+  it('falls back to the constructor timeout when no per-call override is given', async () => {
+    // The other arm of the ternary: with no opts.timeoutMs, _timeoutSignal
+    // must receive the constructor value (5000), proving the override
+    // branch is genuinely conditional and not hard-wired.
+    const { client } = makeClient({ fetch: fetchReturning(makeRes({ json: {} })), timeoutMs: 5000 })
+    const sigSpy = jest.spyOn(client, '_timeoutSignal')
+    await client.getInfo()
+    expect(sigSpy).toHaveBeenCalledWith(5000)
+    sigSpy.mockRestore()
   })
 })
 
@@ -477,6 +572,37 @@ describe('_req retry behaviour', () => {
     await expect(client.health()).rejects.toMatchObject({ status: 502 })
     // original + 2 retries = 3 calls.
     expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  it('waits the exact exponential backoff (250ms, 500ms) between retryable 503s', async () => {
+    // AbortSignal.timeout (used by _timeoutSignal) does not schedule a JS
+    // setTimeout, so every setTimeout we observe here is a backoff wait.
+    // We assert the precise delays so a constant-backoff mutation
+    // (RETRY_BASE_MS * 2^attempt -> RETRY_BASE_MS) is caught: attempt 0
+    // must wait 250ms and attempt 1 must wait 500ms, not 250/250.
+    expect(typeof AbortSignal.timeout).toBe('function')
+    const delays = []
+    const realSetTimeout = global.setTimeout
+    const stSpy = jest.spyOn(global, 'setTimeout').mockImplementation((cb, ms, ...rest) => {
+      delays.push(ms)
+      // Fire the backoff callback immediately so the test does not actually
+      // sleep; we only care about the requested delay value.
+      return realSetTimeout(cb, 0, ...rest)
+    })
+    try {
+      const fetchImpl = jest.fn()
+        .mockResolvedValueOnce(makeRes({ ok: false, status: 503, text: 'unavailable' }))
+        .mockResolvedValueOnce(makeRes({ ok: false, status: 503, text: 'unavailable' }))
+        .mockResolvedValueOnce(makeRes({ json: { status: 'ok' } }))
+      const { client } = makeClient({ fetch: fetchImpl, maxRetries: 3 })
+      const out = await client.health()
+      expect(out).toEqual({ status: 'ok' })
+      expect(fetchImpl).toHaveBeenCalledTimes(3)
+      // Exactly two backoff waits, doubling each time.
+      expect(delays).toEqual([250, 500])
+    } finally {
+      stSpy.mockRestore()
+    }
   })
 
   it('does not retry a non-retryable status (e.g. 404)', async () => {
@@ -522,6 +648,24 @@ describe('numeric coercion edge cases (via public API)', () => {
     await client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: big } })
     const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
     expect(body.lninvoice.amt_msat).toBe(big.toString())
+  })
+
+  it('emits a bigint of exactly MAX_SAFE_INTEGER as a JSON number, not a string', async () => {
+    // The boundary is `v <= MAX_SAFE_INTEGER ? Number(v) : v.toString()`.
+    // At exactly MAX_SAFE_INTEGER the `<=` keeps it on the number path.
+    // A `<` mutation would push it onto the string path, so assert the
+    // serialized value is the bare number (no quotes) AND a JS number.
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    const boundary = BigInt(Number.MAX_SAFE_INTEGER) // 9007199254740991n
+    await client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: boundary } })
+    const rawBody = fetchImpl.mock.calls[0][1].body
+    // Number path -> unquoted in the serialized JSON.
+    expect(rawBody).toContain('"amt_msat":9007199254740991')
+    expect(rawBody).not.toContain('"amt_msat":"9007199254740991"')
+    const body = JSON.parse(rawBody)
+    expect(body.lninvoice.amt_msat).toBe(Number.MAX_SAFE_INTEGER)
+    expect(typeof body.lninvoice.amt_msat).toBe('number')
   })
 
   it('accepts a numeric-string amount in lnurlCallback', async () => {

--- a/tests/lsp-helpers.test.js
+++ b/tests/lsp-helpers.test.js
@@ -53,6 +53,19 @@ function makeLspClient (body) {
   return { client, fetch }
 }
 
+// A *real* LspClient (so it survives `asLspClient`'s `instanceof LspClient`
+// gate) whose bridge method is stubbed to return an EXACT raw response
+// object. This is the only way to feed the helper a shape the real
+// `camelCaseLspResponse` would never emit — e.g. snake_case-ONLY (no
+// camelCase synthesized alongside it), or a dual-keyed object whose
+// snake/camel values intentionally DIFFER — which is what actually
+// exercises the `res.lnInvoice ?? res.ln_invoice` fallback/precedence.
+function makeStubbedLspClient (method, raw) {
+  const client = new LspClient({ baseUrl: 'https://lsp.example', fetch: jest.fn() })
+  const spy = jest.spyOn(client, method).mockResolvedValue(raw)
+  return { client, spy }
+}
+
 describe('payLightningAddress', () => {
   it('throws when account is null or lacks sendPayment', async () => {
     await expect(payLightningAddress(null, 'a@host', 1000)).rejects.toThrow(TypeError)
@@ -117,6 +130,20 @@ describe('payLightningAddress', () => {
     expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: huge.toString() })
   })
 
+  it('coerces a bigint EXACTLY equal to MAX_SAFE_INTEGER to a Number (inclusive boundary)', async () => {
+    // toUint64 uses `v <= MAX_SAFE_INTEGER ? Number(v) : String(v)`. The
+    // boundary value itself must still become a Number. If the comparison
+    // were `<` (exclusive), MAX_SAFE_INTEGER would fall to the string arm
+    // and amt_msat would be '9007199254740991' instead of the number.
+    const boundary = BigInt(Number.MAX_SAFE_INTEGER)
+    const fetch = makeLnurlFetch({ maxSendable: (boundary + 1n).toString() })
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    await payLightningAddress(account, 'maxsafe@host.example', boundary, { fetch })
+    const req = account.sendPayment.mock.calls[0][0]
+    expect(req.amt_msat).toBe(Number.MAX_SAFE_INTEGER)
+    expect(typeof req.amt_msat).toBe('number')
+  })
+
   it('passes through a numeric-string amount unchanged for amt_msat', async () => {
     const fetch = makeLnurlFetch()
     const account = { sendPayment: jest.fn(async () => ({})) }
@@ -152,8 +179,12 @@ describe('requestLspRgbDeposit', () => {
       .rejects.toThrow('rgb params required')
   })
 
-  it('uses a supplied lnInvoice and forwards it to lightningReceive (camelCase result)', async () => {
-    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:zzz', mappingId: 42 })
+  it('uses a supplied lnInvoice and forwards it to lightningReceive', async () => {
+    // Wire shape is snake_case in BOTH directions (the real utexo-lsp
+    // returns { ln_invoice, rgb_invoice, mapping_id }); the real LspClient
+    // synthesizes the camelCase the helper consumes. Body is asserted
+    // snake_case too.
+    const { client, fetch } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:zzz', mapping_id: 42 })
     const account = {}
     const out = await requestLspRgbDeposit(account, { lsp: client, lnInvoice: BOLT11, rgb })
 
@@ -163,14 +194,43 @@ describe('requestLspRgbDeposit', () => {
     expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:zzz', mappingId: 42 })
   })
 
-  it('falls back to snake_case fields from the LSP response', async () => {
-    const { client } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:snake', mapping_id: 7 })
+  it('falls back to snake_case fields when the response is snake_case-ONLY', async () => {
+    // The REAL utexo-lsp returns snake_case JSON; the helper must read it
+    // even if (hypothetically) no camelCase alias is present. Feeding a
+    // snake-ONLY raw object forces the `?? res.ln_invoice` fallback arm to
+    // be the one taken — dropping those fallbacks makes every field
+    // undefined and this assertion fails.
+    const { client, spy } = makeStubbedLspClient('lightningReceive', {
+      ln_invoice: BOLT11,
+      rgb_invoice: 'rgb:snake',
+      mapping_id: 7
+    })
     const out = await requestLspRgbDeposit({}, { lsp: client, lnInvoice: BOLT11, rgb })
     expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:snake', mappingId: 7 })
+    spy.mockRestore()
+  })
+
+  it('prefers camelCase over snake_case on a realistic dual-keyed response', async () => {
+    // The real LspClient.camelCaseLspResponse spreads the raw snake_case
+    // body AND adds camelCase aliases, so the helper sees BOTH keys. Pin
+    // the precedence: when they DIFFER, camelCase wins. Reordering the
+    // operands to `res.ln_invoice ?? res.lnInvoice` would pick the WRONG_*
+    // snake values and fail every assertion below.
+    const { client, spy } = makeStubbedLspClient('lightningReceive', {
+      ln_invoice: 'WRONG_LN',
+      rgb_invoice: 'WRONG_RGB',
+      mapping_id: -1,
+      lnInvoice: BOLT11,
+      rgbInvoice: 'rgb:right',
+      mappingId: 77
+    })
+    const out = await requestLspRgbDeposit({}, { lsp: client, lnInvoice: BOLT11, rgb })
+    expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:right', mappingId: 77 })
+    spy.mockRestore()
   })
 
   it('mints an invoice via account.createInvoice when lnInvoice is omitted (string return)', async () => {
-    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:abc', mappingId: 1 })
+    const { client, fetch } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:abc', mapping_id: 1 })
     const account = { createInvoice: jest.fn(async () => BOLT11) }
     const lnInvoiceRequest = { amtMsat: 1000 }
 
@@ -181,12 +241,32 @@ describe('requestLspRgbDeposit', () => {
   })
 
   it('mints via account.lnInvoice when createInvoice is absent (object return with .invoice)', async () => {
-    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:abc', mappingId: 1 })
+    const { client, fetch } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:abc', mapping_id: 1 })
     const account = { lnInvoice: jest.fn(async () => ({ invoice: BOLT11 })) }
 
     await requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb })
 
     expect(account.lnInvoice).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetch.mock.calls[0][1].body).ln_invoice).toBe(BOLT11)
+  })
+
+  it('prefers account.createInvoice over account.lnInvoice when both exist', async () => {
+    // pickInvoiceMinter must try createInvoice FIRST. With both present,
+    // swapping the precedence (checking lnInvoice first) would call the
+    // wrong minter — so we assert createInvoice ran and lnInvoice did not.
+    const { client, fetch } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:abc', mapping_id: 1 })
+    const account = {
+      createInvoice: jest.fn(async () => BOLT11),
+      lnInvoice: jest.fn(async () => ({ invoice: 'lnbcrt-from-lnInvoice' }))
+    }
+    const lnInvoiceRequest = { amtMsat: 1000 }
+
+    await requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest, rgb })
+
+    expect(account.createInvoice).toHaveBeenCalledWith(lnInvoiceRequest)
+    expect(account.lnInvoice).not.toHaveBeenCalled()
+    // The BOLT11 actually forwarded to the LSP must be createInvoice's,
+    // not lnInvoice's — guards against the wrong minter winning silently.
     expect(JSON.parse(fetch.mock.calls[0][1].body).ln_invoice).toBe(BOLT11)
   })
 
@@ -200,6 +280,28 @@ describe('requestLspRgbDeposit', () => {
   it('throws when the account minter returns no usable invoice', async () => {
     const { client } = makeLspClient({})
     const account = { createInvoice: jest.fn(async () => ({ noInvoiceHere: true })) }
+    await expect(requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb }))
+      .rejects.toThrow('account invoice mint returned no invoice')
+  })
+
+  it('throws the clean mint error (not a TypeError) when the minter returns null', async () => {
+    // `invoice = typeof minted === 'string' ? minted : minted?.invoice`.
+    // The optional chain matters: if the guard were `minted.invoice`,
+    // a null return would throw "Cannot read properties of null". The
+    // helper must instead surface its own descriptive mint error. Pin
+    // that the optional-chaining branch produces undefined -> clean throw.
+    const { client } = makeLspClient({})
+    const account = { createInvoice: jest.fn(async () => null) }
+    await expect(requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb }))
+      .rejects.toThrow('account invoice mint returned no invoice')
+  })
+
+  it('throws the clean mint error when the minter returns a number', async () => {
+    // A non-string, non-object primitive (number) also hits `minted?.invoice`
+    // -> undefined -> the descriptive throw. Differentiates a number from
+    // the `{ noInvoiceHere: true }` object case so both branches are pinned.
+    const { client } = makeLspClient({})
+    const account = { createInvoice: jest.fn(async () => 42) }
     await expect(requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb }))
       .rejects.toThrow('account invoice mint returned no invoice')
   })
@@ -268,8 +370,9 @@ describe('payRgbViaLsp', () => {
       .rejects.toThrow('ln params required')
   })
 
-  it('issues the BOLT11 via onchainSend then pays it, returning the DTO (camelCase)', async () => {
-    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:out', mappingId: 11 })
+  it('issues the BOLT11 via onchainSend then pays it, returning the DTO', async () => {
+    // Real wire shape: snake_case response; client normalizes to camelCase.
+    const { client, fetch } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:out', mapping_id: 11 })
     const account = { sendPayment: jest.fn(async () => ({ payment_hash: 'ph2' })) }
 
     const out = await payRgbViaLsp(account, { lsp: client, rgbInvoice: 'rgb:in', ln })
@@ -286,18 +389,56 @@ describe('payRgbViaLsp', () => {
     })
   })
 
-  it('falls back to snake_case fields from the onchainSend response', async () => {
-    const { client } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:snk', mapping_id: 3 })
+  it('falls back to snake_case fields when onchainSend returns snake-ONLY', async () => {
+    // Snake-ONLY raw forces the `issued.ln_invoice` / `issued.rgb_invoice`
+    // / `issued.mapping_id` fallback arms to be the ones taken. Dropping
+    // them leaves lnInvoice undefined (so sendPayment gets undefined and
+    // the DTO mismatches), which this assertion catches.
+    const { client, spy } = makeStubbedLspClient('onchainSend', {
+      ln_invoice: BOLT11,
+      rgb_invoice: 'rgb:snk',
+      mapping_id: 3
+    })
     const account = { sendPayment: jest.fn(async () => ({ ok: true })) }
 
     const out = await payRgbViaLsp(account, { lsp: client, rgbInvoice: 'rgb:in', ln })
 
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11 })
     expect(out).toEqual({
       lnInvoice: BOLT11,
       rgbInvoice: 'rgb:snk',
       mappingId: 3,
       sendResult: { ok: true }
     })
+    spy.mockRestore()
+  })
+
+  it('prefers camelCase over snake_case on a dual-keyed onchainSend response', async () => {
+    // Realistic post-normalization response carries BOTH keys. Pin the
+    // precedence in `issued.lnInvoice ?? issued.ln_invoice`: reordering to
+    // `ln_invoice ?? lnInvoice` would pay WRONG_LN instead of BOLT11 and
+    // emit the WRONG_* fields in the DTO. Differing values prove which arm
+    // is taken; the sendPayment arg pins the exact invoice handed onward.
+    const { client, spy } = makeStubbedLspClient('onchainSend', {
+      ln_invoice: 'WRONG_LN',
+      rgb_invoice: 'WRONG_RGB',
+      mapping_id: -1,
+      lnInvoice: BOLT11,
+      rgbInvoice: 'rgb:right',
+      mappingId: 55
+    })
+    const account = { sendPayment: jest.fn(async () => ({ ok: true })) }
+
+    const out = await payRgbViaLsp(account, { lsp: client, rgbInvoice: 'rgb:in', ln })
+
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11 })
+    expect(out).toEqual({
+      lnInvoice: BOLT11,
+      rgbInvoice: 'rgb:right',
+      mappingId: 55,
+      sendResult: { ok: true }
+    })
+    spy.mockRestore()
   })
 
   it('drives a base-URL string + injected fetch through to sendPayment', async () => {

--- a/tests/lsp-helpers.test.js
+++ b/tests/lsp-helpers.test.js
@@ -1,0 +1,321 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the higher-level LSP orchestration helpers. These
+// compose an "account-like" object with LspClient + the generic LUD-06
+// resolver. We never hit the network: `payLightningAddress` is driven
+// through the real `resolveAddressToInvoice` with an injected fake
+// `fetch`, and the LSP-mediated helpers are exercised both with a real
+// `LspClient` (also fetch-injected) and a hand-rolled fake client.
+
+import { jest } from '@jest/globals'
+import {
+  payLightningAddress,
+  requestLspRgbDeposit,
+  payRgbViaLsp
+} from '../src/lsp-helpers.js'
+import { LspClient } from '../src/lsp-client.js'
+
+const BOLT11 = 'lnbcrt10u1pcoffee'
+
+// A Response-like object for the injected fetch.
+function jsonResponse (obj, { ok = true, status = 200 } = {}) {
+  const text = JSON.stringify(obj)
+  return { ok, status, text: async () => text, json: async () => obj }
+}
+
+// Build a fake fetch that resolves the LUD-06 two-step (discovery then
+// callback) for `resolveAddressToInvoice`. The first call returns the
+// payRequest metadata; the second returns the BOLT11 invoice.
+function makeLnurlFetch ({ pr = BOLT11, callback = 'https://host.example/cb', routes, maxSendable = 1_000_000_000 } = {}) {
+  const discovery = {
+    tag: 'payRequest',
+    callback,
+    minSendable: 1,
+    maxSendable,
+    metadata: '[["text/plain","tip"]]'
+  }
+  return jest.fn(async (url) => {
+    if (String(url).includes('/.well-known/lnurlp/')) return jsonResponse(discovery)
+    return jsonResponse(routes ? { pr, routes } : { pr })
+  })
+}
+
+// `asLspClient` only accepts a real LspClient instance or a base-URL
+// string, so we build a genuine client wired to a fetch that returns
+// `body` for the single POST the helper makes. Exposing the underlying
+// fetch lets callers assert the URL/method/body.
+function makeLspClient (body) {
+  const fetch = jest.fn(async () => jsonResponse(body))
+  const client = new LspClient({ baseUrl: 'https://lsp.example', fetch })
+  return { client, fetch }
+}
+
+describe('payLightningAddress', () => {
+  it('throws when account is null or lacks sendPayment', async () => {
+    await expect(payLightningAddress(null, 'a@host', 1000)).rejects.toThrow(TypeError)
+    await expect(payLightningAddress(null, 'a@host', 1000)).rejects.toThrow('account.sendPayment')
+    await expect(payLightningAddress({}, 'a@host', 1000)).rejects.toThrow('account.sendPayment')
+  })
+
+  it('resolves the address and pays via sendPayment, returning the DTO', async () => {
+    const fetch = makeLnurlFetch({ routes: [{ a: 1 }] })
+    const account = { sendPayment: jest.fn(async () => ({ payment_hash: 'ph' })) }
+
+    const out = await payLightningAddress(account, 'alice@host.example', 5000, { fetch, allowHttp: true })
+
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 5000 })
+    expect(out).toEqual({
+      invoice: BOLT11,
+      sendResult: { payment_hash: 'ph' },
+      discovery: expect.objectContaining({ tag: 'payRequest' }),
+      callbackUrl: expect.stringContaining('amount=5000')
+    })
+    // discovery + callback = two fetches.
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('omits amt_msat when opts.skipAmount is set', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({ ok: true })) }
+
+    await payLightningAddress(account, 'bob@host.example', 5000, { fetch, skipAmount: true })
+
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11 })
+  })
+
+  it('invokes the beforePay hook with (invoice, discovery) before paying', async () => {
+    const fetch = makeLnurlFetch()
+    const order = []
+    const account = { sendPayment: jest.fn(async () => { order.push('pay'); return {} }) }
+    const beforePay = jest.fn(async (pr, discovery) => {
+      order.push('before')
+      expect(pr).toBe(BOLT11)
+      expect(discovery.tag).toBe('payRequest')
+    })
+
+    await payLightningAddress(account, 'carol@host.example', 2000, { fetch, beforePay })
+
+    expect(beforePay).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['before', 'pay'])
+  })
+
+  it('coerces a small bigint amount to a Number for amt_msat', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    await payLightningAddress(account, 'd@host.example', 1234n, { fetch })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 1234 })
+  })
+
+  it('keeps a huge bigint amount as a string for amt_msat', async () => {
+    const huge = BigInt(Number.MAX_SAFE_INTEGER) + 10n
+    const fetch = makeLnurlFetch({ maxSendable: (huge + 1n).toString() })
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    await payLightningAddress(account, 'e@host.example', huge, { fetch })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: huge.toString() })
+  })
+
+  it('passes through a numeric-string amount unchanged for amt_msat', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    await payLightningAddress(account, 'f@host.example', '4096', { fetch })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: '4096' })
+  })
+
+  it('rejects an amount that is not a non-negative integer', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    // The bad amount only trips toUint64 after a successful resolve, so
+    // sendPayment must never be reached.
+    await expect(
+      payLightningAddress(account, 'g@host.example', {}, { fetch })
+    ).rejects.toThrow('amountMsat must be a non-negative integer')
+    expect(account.sendPayment).not.toHaveBeenCalled()
+  })
+})
+
+describe('requestLspRgbDeposit', () => {
+  const rgb = { assetId: 'asset123', assignment: 'Any', witness: false }
+
+  it('throws when account is null', async () => {
+    await expect(requestLspRgbDeposit(null, { lsp: 'https://lsp.example', rgb }))
+      .rejects.toThrow('account required')
+  })
+
+  it('throws when rgb params are missing or not an object', async () => {
+    const account = { createInvoice: jest.fn() }
+    await expect(requestLspRgbDeposit(account, { lsp: 'https://lsp.example' }))
+      .rejects.toThrow('rgb params required')
+    await expect(requestLspRgbDeposit(account, { lsp: 'https://lsp.example', rgb: 'nope' }))
+      .rejects.toThrow('rgb params required')
+  })
+
+  it('uses a supplied lnInvoice and forwards it to lightningReceive (camelCase result)', async () => {
+    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:zzz', mappingId: 42 })
+    const account = {}
+    const out = await requestLspRgbDeposit(account, { lsp: client, lnInvoice: BOLT11, rgb })
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://lsp.example/lightning_receive')
+    expect(JSON.parse(init.body)).toMatchObject({ ln_invoice: BOLT11, rgb_invoice: { asset_id: 'asset123' } })
+    expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:zzz', mappingId: 42 })
+  })
+
+  it('falls back to snake_case fields from the LSP response', async () => {
+    const { client } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:snake', mapping_id: 7 })
+    const out = await requestLspRgbDeposit({}, { lsp: client, lnInvoice: BOLT11, rgb })
+    expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:snake', mappingId: 7 })
+  })
+
+  it('mints an invoice via account.createInvoice when lnInvoice is omitted (string return)', async () => {
+    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:abc', mappingId: 1 })
+    const account = { createInvoice: jest.fn(async () => BOLT11) }
+    const lnInvoiceRequest = { amtMsat: 1000 }
+
+    await requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest, rgb })
+
+    expect(account.createInvoice).toHaveBeenCalledWith(lnInvoiceRequest)
+    expect(JSON.parse(fetch.mock.calls[0][1].body).ln_invoice).toBe(BOLT11)
+  })
+
+  it('mints via account.lnInvoice when createInvoice is absent (object return with .invoice)', async () => {
+    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:abc', mappingId: 1 })
+    const account = { lnInvoice: jest.fn(async () => ({ invoice: BOLT11 })) }
+
+    await requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb })
+
+    expect(account.lnInvoice).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetch.mock.calls[0][1].body).ln_invoice).toBe(BOLT11)
+  })
+
+  it('throws when neither lnInvoice nor lnInvoiceRequest is provided', async () => {
+    const { client } = makeLspClient({})
+    const account = { createInvoice: jest.fn() }
+    await expect(requestLspRgbDeposit(account, { lsp: client, rgb }))
+      .rejects.toThrow('provide either args.lnInvoice or args.lnInvoiceRequest')
+  })
+
+  it('throws when the account minter returns no usable invoice', async () => {
+    const { client } = makeLspClient({})
+    const account = { createInvoice: jest.fn(async () => ({ noInvoiceHere: true })) }
+    await expect(requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb }))
+      .rejects.toThrow('account invoice mint returned no invoice')
+  })
+
+  it('throws when the account exposes neither createInvoice nor lnInvoice', async () => {
+    const { client } = makeLspClient({})
+    const account = {}
+    await expect(requestLspRgbDeposit(account, { lsp: client, lnInvoiceRequest: {}, rgb }))
+      .rejects.toThrow('account must expose createInvoice or lnInvoice')
+  })
+
+  it('accepts a base-URL string and builds an LspClient driven by injected fetch', async () => {
+    const fetch = jest.fn(async () => jsonResponse({ ln_invoice: BOLT11, rgb_invoice: 'rgb:built', mapping_id: 99 }))
+    const account = {}
+    const out = await requestLspRgbDeposit(account, {
+      lsp: 'https://lsp.example',
+      lnInvoice: BOLT11,
+      rgb,
+      lspOpts: { fetch }
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = fetch.mock.calls[0]
+    expect(calledUrl).toBe('https://lsp.example/lightning_receive')
+    expect(init.method).toBe('POST')
+    expect(out).toEqual({ lnInvoice: BOLT11, rgbInvoice: 'rgb:built', mappingId: 99 })
+  })
+
+  it('accepts a pre-built LspClient instance', async () => {
+    const fetch = jest.fn(async () => jsonResponse({ ln_invoice: BOLT11, rgb_invoice: 'rgb:inst', mapping_id: 5 }))
+    const client = new LspClient({ baseUrl: 'https://lsp.example', fetch })
+    const out = await requestLspRgbDeposit({}, { lsp: client, lnInvoice: BOLT11, rgb })
+    expect(out.rgbInvoice).toBe('rgb:inst')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when lsp is neither a client nor a non-empty base URL', async () => {
+    await expect(requestLspRgbDeposit({}, { lsp: '', lnInvoice: BOLT11, rgb }))
+      .rejects.toThrow('lsp must be an LspClient or a base URL string')
+    await expect(requestLspRgbDeposit({}, { lsp: 123, lnInvoice: BOLT11, rgb }))
+      .rejects.toThrow('lsp must be an LspClient or a base URL string')
+  })
+})
+
+describe('payRgbViaLsp', () => {
+  const ln = { amtMsat: 1000, expirySec: 3600 }
+
+  it('throws when account is null or lacks sendPayment', async () => {
+    await expect(payRgbViaLsp(null, { lsp: 'https://lsp.example', rgbInvoice: 'rgb:x', ln }))
+      .rejects.toThrow('account.sendPayment required')
+    await expect(payRgbViaLsp({}, { lsp: 'https://lsp.example', rgbInvoice: 'rgb:x', ln }))
+      .rejects.toThrow('account.sendPayment required')
+  })
+
+  it('throws when rgbInvoice is missing or empty', async () => {
+    const account = { sendPayment: jest.fn() }
+    await expect(payRgbViaLsp(account, { lsp: 'https://lsp.example', rgbInvoice: '', ln }))
+      .rejects.toThrow('rgbInvoice required')
+    await expect(payRgbViaLsp(account, { lsp: 'https://lsp.example', rgbInvoice: 123, ln }))
+      .rejects.toThrow('rgbInvoice required')
+  })
+
+  it('throws when ln params are missing', async () => {
+    const account = { sendPayment: jest.fn() }
+    await expect(payRgbViaLsp(account, { lsp: 'https://lsp.example', rgbInvoice: 'rgb:x' }))
+      .rejects.toThrow('ln params required')
+  })
+
+  it('issues the BOLT11 via onchainSend then pays it, returning the DTO (camelCase)', async () => {
+    const { client, fetch } = makeLspClient({ lnInvoice: BOLT11, rgbInvoice: 'rgb:out', mappingId: 11 })
+    const account = { sendPayment: jest.fn(async () => ({ payment_hash: 'ph2' })) }
+
+    const out = await payRgbViaLsp(account, { lsp: client, rgbInvoice: 'rgb:in', ln })
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://lsp.example/onchain_send')
+    expect(JSON.parse(init.body)).toMatchObject({ rgb_invoice: 'rgb:in' })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11 })
+    expect(out).toEqual({
+      lnInvoice: BOLT11,
+      rgbInvoice: 'rgb:out',
+      mappingId: 11,
+      sendResult: { payment_hash: 'ph2' }
+    })
+  })
+
+  it('falls back to snake_case fields from the onchainSend response', async () => {
+    const { client } = makeLspClient({ ln_invoice: BOLT11, rgb_invoice: 'rgb:snk', mapping_id: 3 })
+    const account = { sendPayment: jest.fn(async () => ({ ok: true })) }
+
+    const out = await payRgbViaLsp(account, { lsp: client, rgbInvoice: 'rgb:in', ln })
+
+    expect(out).toEqual({
+      lnInvoice: BOLT11,
+      rgbInvoice: 'rgb:snk',
+      mappingId: 3,
+      sendResult: { ok: true }
+    })
+  })
+
+  it('drives a base-URL string + injected fetch through to sendPayment', async () => {
+    const fetch = jest.fn(async () => jsonResponse({ ln_invoice: BOLT11, rgb_invoice: 'rgb:url', mapping_id: 8 }))
+    const account = { sendPayment: jest.fn(async () => ({ done: true })) }
+
+    const out = await payRgbViaLsp(account, {
+      lsp: 'https://lsp.example',
+      rgbInvoice: 'rgb:in',
+      ln,
+      lspOpts: { fetch }
+    })
+
+    const [calledUrl, init] = fetch.mock.calls[0]
+    expect(calledUrl).toBe('https://lsp.example/onchain_send')
+    expect(init.method).toBe('POST')
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11 })
+    expect(out.rgbInvoice).toBe('rgb:url')
+    expect(out.sendResult).toEqual({ done: true })
+  })
+})

--- a/tests/node-binding-methods.test.js
+++ b/tests/node-binding-methods.test.js
@@ -1,0 +1,266 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the NodeRgbLightningBinding instance + static methods.
+// The native addon `@utexo/rgb-lightning-node-nodejs` is replaced by the
+// jest mock wired in package.json (`moduleNameMapper`); we drive node /
+// signer behaviour by assigning fake objects onto the binding internals
+// after construction so no `.node` binary is loaded. The pure
+// constructor request-mapping + vssStatus are covered separately in
+// node-binding-config.test.js and are not re-tested here.
+
+import { jest } from '@jest/globals'
+import { NodeRgbLightningBinding } from '../src/node-binding.js'
+
+function makeBinding (overrides = {}) {
+  return new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d', ...overrides })
+}
+
+function fakeNode () {
+  return {
+    initWithNativeExternalSigner: jest.fn(),
+    unlockWithNativeExternalSigner: jest.fn(),
+    vssClearFence: jest.fn(),
+    vssBackup: jest.fn(() => ({ version: 7 })),
+    apayNew: jest.fn(() => ({ order: 'x' })),
+    shutdown: jest.fn()
+  }
+}
+
+function fakeSigner () {
+  return {
+    bootstrap: jest.fn(() => ({ booted: true })),
+    destroy: jest.fn()
+  }
+}
+
+describe('ensureNode', () => {
+  it('creates the node via SdkNode.create on first call and caches it', () => {
+    const b = makeBinding()
+    expect(b._node).toBeNull()
+    const node = b.ensureNode()
+    expect(node).toBeTruthy()
+    expect(b._node).toBe(node)
+  })
+
+  it('returns the same cached node on a second call', () => {
+    const b = makeBinding()
+    const first = b.ensureNode()
+    const second = b.ensureNode()
+    expect(second).toBe(first)
+  })
+})
+
+describe('node getter', () => {
+  it("throws 'SdkNode not created' when no node exists", () => {
+    const b = makeBinding()
+    expect(() => b.node).toThrow('SdkNode not created')
+  })
+
+  it('returns the node when one is present', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    b._node = node
+    expect(b.node).toBe(node)
+  })
+})
+
+describe('attachExternalSigner', () => {
+  it('creates a signer via NativeExternalSigner.create when none attached', () => {
+    const b = makeBinding()
+    expect(b._signer).toBeNull()
+    b.attachExternalSigner('seed-a')
+    expect(b._signer).toBeTruthy()
+    expect(b._seedHex).toBe('seed-a')
+  })
+
+  it('is an idempotent no-op when the same seed is already attached', () => {
+    const b = makeBinding()
+    b.attachExternalSigner('seed-a')
+    const signer = b._signer
+    b.attachExternalSigner('seed-a')
+    expect(b._signer).toBe(signer)
+  })
+
+  it('throws when a different seed is already attached', () => {
+    const b = makeBinding()
+    b.attachExternalSigner('seed-a')
+    expect(() => b.attachExternalSigner('seed-b')).toThrow('a different signer is already attached')
+  })
+})
+
+describe('unlock', () => {
+  it('throws when no signer has been attached', () => {
+    const b = makeBinding()
+    b._node = fakeNode()
+    expect(() => b.unlock({})).toThrow('attachExternalSigner')
+  })
+
+  it('runs init then unlock on the first call and sets _sdkInitDone', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    b._node = node
+    b._signer = signer
+    const req = { mnemonic: 'm' }
+    b.unlock(req)
+    expect(node.initWithNativeExternalSigner).toHaveBeenCalledWith(signer)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledWith(signer, req)
+    expect(b._sdkInitDone).toBe(true)
+  })
+
+  it('swallows a Conflict init error and still proceeds to unlock', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    node.initWithNativeExternalSigner.mockImplementation(() => { throw new Error('Conflict: already initialized') })
+    b._node = node
+    b._signer = fakeSigner()
+    expect(() => b.unlock({})).not.toThrow()
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalled()
+    expect(b._sdkInitDone).toBe(true)
+  })
+
+  it('rethrows a non-Conflict init error and does not unlock', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    node.initWithNativeExternalSigner.mockImplementation(() => { throw new Error('boom') })
+    b._node = node
+    b._signer = fakeSigner()
+    expect(() => b.unlock({})).toThrow('boom')
+    expect(node.unlockWithNativeExternalSigner).not.toHaveBeenCalled()
+    expect(b._sdkInitDone).toBe(false)
+  })
+
+  it('skips init on a second unlock once _sdkInitDone is set', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    b._node = node
+    b._signer = fakeSigner()
+    b.unlock({})
+    b.unlock({})
+    expect(node.initWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('bootstrap', () => {
+  it('throws when no signer is attached', () => {
+    const b = makeBinding()
+    expect(() => b.bootstrap()).toThrow('attachExternalSigner')
+  })
+
+  it('delegates to signer.bootstrap and returns its result', () => {
+    const b = makeBinding()
+    const signer = fakeSigner()
+    b._signer = signer
+    expect(b.bootstrap()).toEqual({ booted: true })
+    expect(signer.bootstrap).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('clearVssFence', () => {
+  it('ensures the node then calls vssClearFence with the password', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    b._node = node
+    b.clearVssFence('pw')
+    expect(node.vssClearFence).toHaveBeenCalledWith({ password: 'pw' })
+  })
+
+  it('lazily creates the node when none exists before clearing the fence', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const ensureSpy = jest.spyOn(b, 'ensureNode').mockReturnValue(node)
+    b.clearVssFence('pw')
+    expect(ensureSpy).toHaveBeenCalledTimes(1)
+    expect(node.vssClearFence).toHaveBeenCalledWith({ password: 'pw' })
+  })
+})
+
+describe('vssBackup', () => {
+  it('returns the node result and records a numeric version', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    b._node = node
+    const r = b.vssBackup()
+    expect(r).toEqual({ version: 7 })
+    expect(b._lastVssVersion).toBe(7)
+  })
+
+  it('does not record _lastVssVersion when version is not numeric', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    node.vssBackup.mockReturnValue({ version: 'nope' })
+    b._node = node
+    b.vssBackup()
+    expect(b._lastVssVersion).toBeNull()
+  })
+
+  it('throws via the node getter when no node has been created', () => {
+    const b = makeBinding()
+    expect(() => b.vssBackup()).toThrow('SdkNode not created')
+  })
+})
+
+describe('apayNew', () => {
+  it('ensures the node then forwards the host node id', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    b._node = node
+    expect(b.apayNew('02hostid')).toEqual({ order: 'x' })
+    expect(node.apayNew).toHaveBeenCalledWith('02hostid')
+  })
+
+  it('lazily creates the node through ensureNode when none exists', () => {
+    const b = makeBinding({ virtualPeerPubkeys: ['02lsp'] })
+    const node = fakeNode()
+    const ensureSpy = jest.spyOn(b, 'ensureNode').mockReturnValue(node)
+    b.apayNew('02hostid')
+    expect(ensureSpy).toHaveBeenCalledTimes(1)
+    expect(node.apayNew).toHaveBeenCalledWith('02hostid')
+  })
+})
+
+describe('shutdown', () => {
+  it('shuts down node + signer, nulls them and resets _sdkInitDone', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    b._node = node
+    b._signer = signer
+    b._sdkInitDone = true
+    b.shutdown()
+    expect(node.shutdown).toHaveBeenCalledTimes(1)
+    expect(signer.destroy).toHaveBeenCalledTimes(1)
+    expect(b._node).toBeNull()
+    expect(b._signer).toBeNull()
+    expect(b._sdkInitDone).toBe(false)
+  })
+
+  it('is idempotent when nothing is attached', () => {
+    const b = makeBinding()
+    expect(() => b.shutdown()).not.toThrow()
+    expect(b._node).toBeNull()
+    expect(b._signer).toBeNull()
+  })
+})
+
+describe('static module passthroughs', () => {
+  it('healthcheck calls the addon uniffiHealthcheck', () => {
+    expect(NodeRgbLightningBinding.healthcheck()).toBe(true)
+  })
+
+  it('isInitialized calls the addon uniffiIsInitialized', () => {
+    expect(NodeRgbLightningBinding.isInitialized()).toBe(false)
+  })
+
+  it('initialize calls the addon sdkInitialize', () => {
+    expect(() => NodeRgbLightningBinding.initialize({})).not.toThrow()
+  })
+
+  it('shutdownGlobal calls the addon sdkShutdown', () => {
+    expect(() => NodeRgbLightningBinding.shutdownGlobal()).not.toThrow()
+  })
+})

--- a/tests/node-binding-methods.test.js
+++ b/tests/node-binding-methods.test.js
@@ -12,10 +12,39 @@
 // node-binding-config.test.js and are not re-tested here.
 
 import { jest } from '@jest/globals'
+import rln from '@utexo/rgb-lightning-node-nodejs'
 import { NodeRgbLightningBinding } from '../src/node-binding.js'
 
 function makeBinding (overrides = {}) {
   return new NodeRgbLightningBinding({ network: 'regtest', dataDir: '/d', ...overrides })
+}
+
+// Real RLN AsyncOrderNewResponse shape (snake_case) — see
+// utexo-rgb-wdk-demo node-demo LnExt.ts getApayNew + testCases t113.
+// `apayNew` must passthrough this exact object reference unchanged.
+function realAsyncOrderNewResponse () {
+  return {
+    request_id: 'req-7f3a',
+    host_node_id: '02hostid',
+    accepted_through_index: 4,
+    order_id: 'order-9c21',
+    status: 'pending',
+    next_index_expected: 5,
+    unused_hashes: ['aa11', 'bb22'],
+    refill_batch_size: 16,
+    first_hash_index: 0
+  }
+}
+
+// Real signer bootstrap payload — see LnExt.ts getBootstrap /
+// binding-interface.js ('node_id, xpubs, master_fp'). NOT `{ booted }`.
+function realBootstrapPayload () {
+  return {
+    node_id: '03beef',
+    account_xpub_vanilla: 'tpubVanilla',
+    account_xpub_colored: 'tpubColored',
+    master_fingerprint: 'a1b2c3d4'
+  }
 }
 
 function fakeNode () {
@@ -24,14 +53,14 @@ function fakeNode () {
     unlockWithNativeExternalSigner: jest.fn(),
     vssClearFence: jest.fn(),
     vssBackup: jest.fn(() => ({ version: 7 })),
-    apayNew: jest.fn(() => ({ order: 'x' })),
+    apayNew: jest.fn(() => realAsyncOrderNewResponse()),
     shutdown: jest.fn()
   }
 }
 
 function fakeSigner () {
   return {
-    bootstrap: jest.fn(() => ({ booted: true })),
+    bootstrap: jest.fn(() => realBootstrapPayload()),
     destroy: jest.fn()
   }
 }
@@ -76,6 +105,37 @@ describe('attachExternalSigner', () => {
     expect(b._seedHex).toBe('seed-a')
   })
 
+  // Kills the mutant that hardcodes NativeExternalSigner.create(seedHex,
+  // 'mainnet', false): asserts the seed, the CONFIGURED network ('regtest')
+  // and the permissive-policy `?? true` DEFAULT are passed through verbatim.
+  it('passes the seed, configured network and permissive-policy default to NativeExternalSigner.create', () => {
+    const created = { bootstrap: jest.fn(), destroy: jest.fn() }
+    const spy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(created)
+    try {
+      const b = makeBinding()
+      b.attachExternalSigner('seed-a')
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('seed-a', 'regtest', true)
+      expect(b._signer).toBe(created)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  // Differentiates the `permissiveSignerPolicy ?? true` default from an
+  // explicit override: an explicit `false` must reach create as the 3rd arg.
+  it('forwards an explicit permissiveSignerPolicy=false instead of the default', () => {
+    const spy = jest.spyOn(rln.NativeExternalSigner, 'create')
+      .mockReturnValue({ bootstrap: jest.fn(), destroy: jest.fn() })
+    try {
+      const b = makeBinding({ permissiveSignerPolicy: false })
+      b.attachExternalSigner('seed-a')
+      expect(spy).toHaveBeenCalledWith('seed-a', 'regtest', false)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
   it('is an idempotent no-op when the same seed is already attached', () => {
     const b = makeBinding()
     b.attachExternalSigner('seed-a')
@@ -88,6 +148,22 @@ describe('attachExternalSigner', () => {
     const b = makeBinding()
     b.attachExternalSigner('seed-a')
     expect(() => b.attachExternalSigner('seed-b')).toThrow('a different signer is already attached')
+  })
+
+  // Kills the mutant that drops the `this._seedHex &&` short-circuit
+  // (`if (this._seedHex !== seedHex)`). When a signer is attached
+  // out-of-band with NO _seedHex recorded, re-attaching must return
+  // silently (the falsy guard wins). Dropping the short-circuit would
+  // make `undefined !== 'seed-x'` true and wrongly throw.
+  it('returns silently when a signer is attached but _seedHex is falsy', () => {
+    const b = makeBinding()
+    const preexisting = fakeSigner()
+    b._signer = preexisting
+    expect(b._seedHex).toBeUndefined()
+    expect(() => b.attachExternalSigner('seed-x')).not.toThrow()
+    // No new signer created and the seed is NOT recorded by the no-op path.
+    expect(b._signer).toBe(preexisting)
+    expect(b._seedHex).toBeUndefined()
   })
 })
 
@@ -143,6 +219,35 @@ describe('unlock', () => {
     expect(node.initWithNativeExternalSigner).toHaveBeenCalledTimes(1)
     expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(2)
   })
+
+  // Exercises the false arm of `e && e.message ? e.message : e`: a thrown
+  // string has no `.message`, so the message is `String(e)` itself. A
+  // thrown 'Conflict' string must still be swallowed via includes('Conflict').
+  it('swallows a thrown string containing Conflict (no .message) and proceeds', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    // eslint-disable-next-line no-throw-literal
+    node.initWithNativeExternalSigner.mockImplementation(() => { throw 'Conflict: already initialized' })
+    b._node = node
+    b._signer = fakeSigner()
+    expect(() => b.unlock({})).not.toThrow()
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+    expect(b._sdkInitDone).toBe(true)
+  })
+
+  // Counterpart: a thrown string WITHOUT 'Conflict' (still no .message)
+  // must be rethrown and must not reach unlock.
+  it('rethrows a thrown string without Conflict (no .message) and does not unlock', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    // eslint-disable-next-line no-throw-literal
+    node.initWithNativeExternalSigner.mockImplementation(() => { throw 'plain boom' })
+    b._node = node
+    b._signer = fakeSigner()
+    expect(() => b.unlock({})).toThrow('plain boom')
+    expect(node.unlockWithNativeExternalSigner).not.toHaveBeenCalled()
+    expect(b._sdkInitDone).toBe(false)
+  })
 })
 
 describe('bootstrap', () => {
@@ -151,11 +256,23 @@ describe('bootstrap', () => {
     expect(() => b.bootstrap()).toThrow('attachExternalSigner')
   })
 
-  it('delegates to signer.bootstrap and returns its result', () => {
+  // Kills the mutant that discards the signer's payload and returns a
+  // hardcoded object: asserts the EXACT real bootstrap payload reference
+  // (node_id / xpubs / master_fingerprint) is returned unchanged.
+  it('returns the signer bootstrap payload unchanged (same reference)', () => {
     const b = makeBinding()
     const signer = fakeSigner()
+    const payload = realBootstrapPayload()
+    signer.bootstrap.mockReturnValue(payload)
     b._signer = signer
-    expect(b.bootstrap()).toEqual({ booted: true })
+    const result = b.bootstrap()
+    expect(result).toBe(payload)
+    expect(result).toEqual({
+      node_id: '03beef',
+      account_xpub_vanilla: 'tpubVanilla',
+      account_xpub_colored: 'tpubColored',
+      master_fingerprint: 'a1b2c3d4'
+    })
     expect(signer.bootstrap).toHaveBeenCalledTimes(1)
   })
 })
@@ -198,6 +315,18 @@ describe('vssBackup', () => {
     expect(b._lastVssVersion).toBeNull()
   })
 
+  // Covers the falsy-`r` arm of `if (r && typeof r.version === 'number')`:
+  // a null node result must short-circuit on `r &&` (no version read), leave
+  // _lastVssVersion untouched, and be returned verbatim.
+  it('returns null and leaves _lastVssVersion untouched when the node returns null', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    node.vssBackup.mockReturnValue(null)
+    b._node = node
+    expect(b.vssBackup()).toBeNull()
+    expect(b._lastVssVersion).toBeNull()
+  })
+
   it('throws via the node getter when no node has been created', () => {
     const b = makeBinding()
     expect(() => b.vssBackup()).toThrow('SdkNode not created')
@@ -205,11 +334,29 @@ describe('vssBackup', () => {
 })
 
 describe('apayNew', () => {
-  it('ensures the node then forwards the host node id', () => {
+  // Kills the mutant that ignores the node result and returns a hardcoded
+  // object: asserts the EXACT real AsyncOrderNewResponse reference (with
+  // request_id / order_id / status / unused_hashes ...) is passed through
+  // unchanged, plus the host node id is forwarded.
+  it('forwards the host node id and returns the node AsyncOrderNewResponse unchanged', () => {
     const b = makeBinding()
     const node = fakeNode()
+    const resp = realAsyncOrderNewResponse()
+    node.apayNew.mockReturnValue(resp)
     b._node = node
-    expect(b.apayNew('02hostid')).toEqual({ order: 'x' })
+    const result = b.apayNew('02hostid')
+    expect(result).toBe(resp)
+    expect(result).toEqual({
+      request_id: 'req-7f3a',
+      host_node_id: '02hostid',
+      accepted_through_index: 4,
+      order_id: 'order-9c21',
+      status: 'pending',
+      next_index_expected: 5,
+      unused_hashes: ['aa11', 'bb22'],
+      refill_batch_size: 16,
+      first_hash_index: 0
+    })
     expect(node.apayNew).toHaveBeenCalledWith('02hostid')
   })
 

--- a/tests/utexo-lsp.test.js
+++ b/tests/utexo-lsp.test.js
@@ -1,0 +1,593 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Unit tests for the composed UtexoLsp flow class plus its pure helpers
+// (peerUri, normalizeReceiveStatus) and the typed error subclasses.
+// The class wraps a WalletAccountRgbLightning + an LspClient; here we
+// pass a fake account (jest.fn methods) and stub the instance's `http`
+// (LspClient) so no node, binding or network is touched. globalThis.fetch
+// is set so the internal LspClient constructs and so the payAddress LNURL
+// fallback path can be exercised.
+
+import { jest } from '@jest/globals'
+import {
+  LspChannelTimeoutError,
+  LspSettlementError,
+  peerUri,
+  normalizeReceiveStatus,
+  UtexoLsp
+} from '../src/utexo-lsp.js'
+
+const PEER = {
+  baseUrl: 'https://lsp.example.io',
+  peerPubkey: '02' + 'a'.repeat(64),
+  peerHost: 'lsp.example.io',
+  peerPort: 9735
+}
+
+// A fake account exposing every method UtexoLsp may call. Each is a
+// jest.fn so callers can assert/override per test.
+function makeAccount (overrides = {}) {
+  return {
+    connectPeer: jest.fn(async () => ({ ok: true })),
+    sync: jest.fn(async () => {}),
+    listChannels: jest.fn(async () => []),
+    createLightningInvoice: jest.fn(async () => ({ invoice: 'lnbcrt-default' })),
+    getInvoiceStatus: jest.fn(async () => ({ status: 'Pending' })),
+    sendPayment: jest.fn(async () => ({ payment_hash: 'ph' })),
+    getNodeInfo: jest.fn(async () => ({ pubkey: 'mynodepubkey' })),
+    apayNew: jest.fn(async () => ({ ok: true })),
+    listPayments: jest.fn(async () => []),
+    claimHodlInvoice: jest.fn(async () => ({ ok: true })),
+    ...overrides
+  }
+}
+
+// Build a UtexoLsp whose internal http (LspClient) methods are all
+// jest.fn stubs, so no fetch is performed for the LSP HTTP surface.
+function makeLsp (account, peer = PEER) {
+  const lsp = new UtexoLsp(account, peer)
+  lsp.http = {
+    lightningReceive: jest.fn(async () => ({ rgbInvoice: 'rgb:abc', mappingId: 1 })),
+    onchainSend: jest.fn(async () => ({ lnInvoice: 'lnbcrt-issued', rgbInvoice: 'rgb:xyz', mappingId: 2 })),
+    resolveAddress: jest.fn(async () => ({ pr: 'lnbcrt-resolved' })),
+    getInfo: jest.fn(async () => ({ pubkey: 'lsppubkey' })),
+    getLightningAddressByPubkey: jest.fn(async () => ({ username: 'alice', domain: 'lsp.example.io' }))
+  }
+  return lsp
+}
+
+beforeEach(() => {
+  globalThis.fetch = jest.fn()
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+  delete globalThis.fetch
+})
+
+// ── pure helpers ───────────────────────────────────────────────────────────
+
+describe('peerUri', () => {
+  it('builds the pubkey@host:port string connectPeer accepts', () => {
+    expect(peerUri(PEER)).toBe(`${PEER.peerPubkey}@lsp.example.io:9735`)
+  })
+
+  it('interpolates each field verbatim', () => {
+    expect(peerUri({ peerPubkey: 'PK', peerHost: 'h.test', peerPort: 1234 })).toBe('PK@h.test:1234')
+  })
+})
+
+describe('normalizeReceiveStatus', () => {
+  it('maps SUCCEEDED / SETTLED (any case) to Succeeded', () => {
+    expect(normalizeReceiveStatus('Succeeded')).toBe('Succeeded')
+    expect(normalizeReceiveStatus('succeeded')).toBe('Succeeded')
+    expect(normalizeReceiveStatus('SETTLED')).toBe('Succeeded')
+    expect(normalizeReceiveStatus({ status: 'settled' })).toBe('Succeeded')
+  })
+
+  it('maps FAILED to Failed and EXPIRED to Expired', () => {
+    expect(normalizeReceiveStatus('Failed')).toBe('Failed')
+    expect(normalizeReceiveStatus({ status: 'EXPIRED' })).toBe('Expired')
+  })
+
+  it('treats unknown / pending / empty / nullish as Pending', () => {
+    expect(normalizeReceiveStatus('Pending')).toBe('Pending')
+    expect(normalizeReceiveStatus('something-else')).toBe('Pending')
+    expect(normalizeReceiveStatus('')).toBe('Pending')
+    expect(normalizeReceiveStatus(null)).toBe('Pending')
+    expect(normalizeReceiveStatus(undefined)).toBe('Pending')
+    expect(normalizeReceiveStatus({})).toBe('Pending')
+    expect(normalizeReceiveStatus({ status: null })).toBe('Pending')
+  })
+})
+
+// ── error subclasses ───────────────────────────────────────────────────────
+
+describe('LspChannelTimeoutError', () => {
+  it('formats a seconds message and carries assetId/elapsedMs', () => {
+    const e = new LspChannelTimeoutError('assetX', 120000)
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('LspChannelTimeoutError')
+    expect(e.assetId).toBe('assetX')
+    expect(e.elapsedMs).toBe(120000)
+    expect(e.message).toBe('No usable RGB channel for assetX after 120s')
+  })
+})
+
+describe('LspSettlementError', () => {
+  it('formats a terminal-status message and carries step/status', () => {
+    const e = new LspSettlementError('ln_invoice', 'Failed')
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('LspSettlementError')
+    expect(e.step).toBe('ln_invoice')
+    expect(e.status).toBe('Failed')
+    expect(e.message).toBe('Settlement ended with status "Failed" at step ln_invoice')
+  })
+})
+
+// ── constructor ────────────────────────────────────────────────────────────
+
+describe('UtexoLsp constructor', () => {
+  it('throws when account is null', () => {
+    expect(() => new UtexoLsp(null, PEER)).toThrow('account required')
+  })
+
+  it('throws when peer is missing or peer.baseUrl is not a string', () => {
+    expect(() => new UtexoLsp(makeAccount(), null)).toThrow('peer.baseUrl required')
+    expect(() => new UtexoLsp(makeAccount(), { baseUrl: 123 })).toThrow('peer.baseUrl required')
+  })
+
+  it('constructs an http LspClient pointed at peer.baseUrl', () => {
+    const lsp = new UtexoLsp(makeAccount(), PEER)
+    expect(lsp.account).toBeTruthy()
+    expect(lsp.peer).toBe(PEER)
+    expect(lsp.http.baseUrl).toBe('https://lsp.example.io')
+  })
+
+  it('passes a bearer token through as an Authorization header (allowHttp/timeout knobs)', () => {
+    const peer = { ...PEER, baseUrl: 'http://127.0.0.1:8080', bearerToken: 'tok', allowHttp: true, timeoutMs: 5000 }
+    const lsp = new UtexoLsp(makeAccount(), peer)
+    expect(lsp.http.baseUrl).toBe('http://127.0.0.1:8080')
+  })
+})
+
+// ── connect ────────────────────────────────────────────────────────────────
+
+describe('connect', () => {
+  it('forwards the peerUri to account.connectPeer', async () => {
+    const account = makeAccount()
+    const lsp = makeLsp(account)
+    await lsp.connect()
+    expect(account.connectPeer).toHaveBeenCalledWith(peerUri(PEER))
+  })
+})
+
+// ── waitForChannel ─────────────────────────────────────────────────────────
+
+describe('waitForChannel', () => {
+  it('returns ChannelReadyInfo for a usable RGB channel (camelCase fields)', async () => {
+    const channel = {
+      assetId: 'assetX',
+      isUsable: true,
+      channelId: 'chan-1',
+      capacitySat: 100000,
+      outboundBalanceMsat: 50000,
+      inboundBalanceMsat: 25000
+    }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    const info = await lsp.waitForChannel('assetX', { timeoutMs: 1000, onProgress })
+    expect(info).toEqual({
+      channelId: 'chan-1',
+      peerPubkey: PEER.peerPubkey,
+      capacitySat: 100000,
+      outboundBalanceMsat: 50000,
+      inboundBalanceMsat: 25000
+    })
+    expect(account.sync).toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledWith('channels: 1 — RGB usable: yes')
+  })
+
+  it('reads snake_case channel fields and the ready/localBalance fallbacks', async () => {
+    const channel = {
+      asset_id: 'assetSnake',
+      ready: true,
+      channel_id: 'chan-2',
+      capacity_sat: 7,
+      local_balance_msat: 999
+    }
+    const account = makeAccount({ listChannels: jest.fn(async () => ({ channels: [channel] })) })
+    const lsp = makeLsp(account)
+    const info = await lsp.waitForChannel('assetSnake', { timeoutMs: 1000 })
+    expect(info.channelId).toBe('chan-2')
+    expect(info.capacitySat).toBe(7)
+    expect(info.outboundBalanceMsat).toBe(999)
+    expect(info.inboundBalanceMsat).toBe(0)
+  })
+
+  it('runs onEachPoll before checking channels', async () => {
+    const onEachPoll = jest.fn(async () => {})
+    const channel = { assetId: 'a', isUsable: true }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    await lsp.waitForChannel('a', { timeoutMs: 1000, onEachPoll })
+    expect(onEachPoll).toHaveBeenCalled()
+  })
+
+  it('throws LspChannelTimeoutError when no usable channel appears before the deadline', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForChannel('missing', { timeoutMs: 5, pollIntervalMs: 1 }))
+      .rejects.toBeInstanceOf(LspChannelTimeoutError)
+  })
+
+  it('aborts immediately when the signal is already aborted', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(lsp.waitForChannel('a', { timeoutMs: 1000, signal: controller.signal }))
+      .rejects.toThrow('operation aborted')
+  })
+
+  it('does not treat a non-matching-asset usable channel as ready', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => [{ assetId: 'other', isUsable: true }]) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForChannel('wanted', { timeoutMs: 5, pollIntervalMs: 1 }))
+      .rejects.toBeInstanceOf(LspChannelTimeoutError)
+  })
+})
+
+// ── receiveAsset ───────────────────────────────────────────────────────────
+
+describe('receiveAsset', () => {
+  it('throws when assetId is missing or empty', async () => {
+    const lsp = makeLsp(makeAccount())
+    await expect(lsp.receiveAsset({})).rejects.toThrow('assetId required')
+    await expect(lsp.receiveAsset({ assetId: '' })).rejects.toThrow('assetId required')
+  })
+
+  it('mints a LN invoice, registers it with the LSP, and returns both invoices', async () => {
+    const account = makeAccount({
+      createLightningInvoice: jest.fn(async () => ({ invoice: 'lnbcrt-mine' }))
+    })
+    const lsp = makeLsp(account)
+    const out = await lsp.receiveAsset({ assetId: 'assetX', amountSats: 100, amountRgb: 5, expirySeconds: 600 })
+    expect(account.createLightningInvoice).toHaveBeenCalledWith({
+      amountMsat: 100000,
+      expirySec: 600,
+      assetId: 'assetX',
+      assetAmount: 5
+    })
+    expect(lsp.http.lightningReceive).toHaveBeenCalledWith({
+      lnInvoice: 'lnbcrt-mine',
+      rgb: { assetId: 'assetX', durationSeconds: expect.any(Number) }
+    })
+    expect(out).toEqual({ lnInvoice: 'lnbcrt-mine', rgbInvoice: 'rgb:abc', mappingId: '1' })
+  })
+
+  it('omits amountMsat for an amountless invoice and defaults expiry to 3600', async () => {
+    const account = makeAccount()
+    const lsp = makeLsp(account)
+    await lsp.receiveAsset({ assetId: 'assetX' })
+    expect(account.createLightningInvoice).toHaveBeenCalledWith({
+      amountMsat: undefined,
+      expirySec: 3600,
+      assetId: 'assetX',
+      assetAmount: undefined
+    })
+  })
+
+  it('accepts the lnInvoice fallback field name', async () => {
+    const account = makeAccount({ createLightningInvoice: jest.fn(async () => ({ lnInvoice: 'lnbcrt-alt' })) })
+    const lsp = makeLsp(account)
+    const out = await lsp.receiveAsset({ assetId: 'assetX' })
+    expect(out.lnInvoice).toBe('lnbcrt-alt')
+  })
+
+  it('throws when createLightningInvoice returns no invoice', async () => {
+    const account = makeAccount({ createLightningInvoice: jest.fn(async () => ({})) })
+    const lsp = makeLsp(account)
+    await expect(lsp.receiveAsset({ assetId: 'assetX' })).rejects.toThrow('returned no invoice')
+  })
+})
+
+// ── awaitReceiveSettlement ─────────────────────────────────────────────────
+
+describe('awaitReceiveSettlement', () => {
+  it("returns 'settled' once status normalizes to Succeeded", async () => {
+    const account = makeAccount({ getInvoiceStatus: jest.fn(async () => ({ status: 'Succeeded' })) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await expect(lsp.awaitReceiveSettlement('ln', { timeoutMs: 1000, onProgress })).resolves.toBe('settled')
+    expect(onProgress).toHaveBeenCalledWith('Succeeded')
+  })
+
+  it('throws LspSettlementError on a Failed status', async () => {
+    const account = makeAccount({ getInvoiceStatus: jest.fn(async () => 'Failed') })
+    const lsp = makeLsp(account)
+    const err = await lsp.awaitReceiveSettlement('ln', { timeoutMs: 1000 }).catch((e) => e)
+    expect(err).toBeInstanceOf(LspSettlementError)
+    expect(err.status).toBe('Failed')
+    expect(err.step).toBe('ln_invoice')
+  })
+
+  it('throws LspSettlementError on an Expired status', async () => {
+    const account = makeAccount({ getInvoiceStatus: jest.fn(async () => ({ status: 'Expired' })) })
+    const lsp = makeLsp(account)
+    await expect(lsp.awaitReceiveSettlement('ln', { timeoutMs: 1000 }))
+      .rejects.toBeInstanceOf(LspSettlementError)
+  })
+
+  it("returns 'timed_out' (and reports it) when status never settles", async () => {
+    const account = makeAccount({ getInvoiceStatus: jest.fn(async () => ({ status: 'Pending' })) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await expect(lsp.awaitReceiveSettlement('ln', { timeoutMs: 5, pollIntervalMs: 1, onProgress }))
+      .resolves.toBe('timed_out')
+    expect(onProgress).toHaveBeenCalledWith('timeout')
+  })
+
+  it('throws on an already-aborted signal', async () => {
+    const account = makeAccount({ getInvoiceStatus: jest.fn(async () => ({ status: 'Pending' })) })
+    const lsp = makeLsp(account)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(lsp.awaitReceiveSettlement('ln', { timeoutMs: 1000, signal: controller.signal }))
+      .rejects.toThrow('operation aborted')
+  })
+})
+
+// ── waitForOutboundLiquidity ───────────────────────────────────────────────
+
+describe('waitForOutboundLiquidity', () => {
+  it('resolves once outbound balance on the LSP channel meets the minimum', async () => {
+    const channel = { peerPubkey: PEER.peerPubkey, isUsable: true, outboundBalanceMsat: 5000 }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await expect(lsp.waitForOutboundLiquidity(5000, { timeoutMs: 1000, onProgress })).resolves.toBeUndefined()
+    expect(onProgress).toHaveBeenCalledWith('outbound: 5000 msat (need 5000)')
+  })
+
+  it('reads snake_case fields for the LSP channel match', async () => {
+    const channel = { peer_pubkey: PEER.peerPubkey, is_usable: true, outbound_balance_msat: 9000 }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForOutboundLiquidity(1, { timeoutMs: 1000 })).resolves.toBeUndefined()
+  })
+
+  it('keeps polling and returns (without throwing) when liquidity never arrives', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForOutboundLiquidity(10000, { timeoutMs: 5, pollIntervalMs: 1 }))
+      .resolves.toBeUndefined()
+  })
+
+  it('aborts on an already-aborted signal', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(lsp.waitForOutboundLiquidity(1, { timeoutMs: 1000, signal: controller.signal }))
+      .rejects.toThrow('operation aborted')
+  })
+})
+
+// ── sendAsset ──────────────────────────────────────────────────────────────
+
+describe('sendAsset', () => {
+  it('throws when rgbInvoice is missing or empty', async () => {
+    const lsp = makeLsp(makeAccount())
+    await expect(lsp.sendAsset({})).rejects.toThrow('rgbInvoice required')
+    await expect(lsp.sendAsset({ rgbInvoice: '' })).rejects.toThrow('rgbInvoice required')
+  })
+
+  it('issues an LN invoice via the LSP then pays it through the account', async () => {
+    const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'sent' })) })
+    const lsp = makeLsp(account)
+    const ln = { amtMsat: 1000, expirySec: 60 }
+    const out = await lsp.sendAsset({ rgbInvoice: 'rgb:xyz', ln })
+    expect(lsp.http.onchainSend).toHaveBeenCalledWith({ rgbInvoice: 'rgb:xyz', ln })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: 'lnbcrt-issued' })
+    expect(out).toEqual({
+      lnInvoice: 'lnbcrt-issued',
+      rgbInvoice: 'rgb:xyz',
+      mappingId: '2',
+      sendResult: { payment_hash: 'sent' }
+    })
+  })
+})
+
+// ── payAddress ─────────────────────────────────────────────────────────────
+
+describe('payAddress', () => {
+  it('rejects a malformed Lightning Address', async () => {
+    const lsp = makeLsp(makeAccount())
+    await expect(lsp.payAddress({ address: 'noatsign' })).rejects.toThrow('invalid Lightning Address')
+    await expect(lsp.payAddress({ address: 123 })).rejects.toThrow('invalid Lightning Address')
+  })
+
+  it('rejects an address with an empty username or domain', async () => {
+    const lsp = makeLsp(makeAccount())
+    await expect(lsp.payAddress({ address: '@host' })).rejects.toThrow('invalid Lightning Address')
+    await expect(lsp.payAddress({ address: 'user@' })).rejects.toThrow('invalid Lightning Address')
+  })
+
+  it('resolves via the LSP and pays the returned invoice', async () => {
+    const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'paid' })) })
+    const lsp = makeLsp(account)
+    const out = await lsp.payAddress({
+      address: 'alice@lsp.example.io',
+      amtMsat: 2000,
+      asset: { assetId: 'assetX', assetAmount: 7 }
+    })
+    expect(lsp.http.resolveAddress).toHaveBeenCalledWith('alice', 2000, { assetId: 'assetX', assetAmount: 7 })
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: 'lnbcrt-resolved' })
+    expect(out).toEqual({ invoice: 'lnbcrt-resolved', sendResult: { payment_hash: 'paid' } })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('falls back to LNURL discovery on the address domain when the LSP resolve fails', async () => {
+    const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'fb' })) })
+    const lsp = makeLsp(account)
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('lsp resolve down') })
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://other.test/cb?x=1' }) })
+      .mockResolvedValueOnce({ json: async () => ({ pr: 'lnbcrt-lnurl' }) })
+
+    const out = await lsp.payAddress({
+      address: 'bob@other.test',
+      amtMsat: 3000,
+      asset: { assetId: 'assetY', assetAmount: 9 }
+    })
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(1, 'https://other.test/.well-known/lnurlp/bob')
+    const secondUrl = globalThis.fetch.mock.calls[1][0]
+    expect(secondUrl).toContain('https://other.test/cb?x=1')
+    expect(secondUrl).toContain('&amount=3000')
+    expect(secondUrl).toContain('&asset_id=assetY')
+    expect(secondUrl).toContain('&asset_amount=9')
+    expect(out).toEqual({ invoice: 'lnbcrt-lnurl', sendResult: { payment_hash: 'fb' } })
+  })
+
+  it('uses a ? separator in the fallback callback when none is present', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://other.test/cb' }) })
+      .mockResolvedValueOnce({ json: async () => ({ pr: 'lnbcrt-q' }) })
+    await lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 })
+    expect(globalThis.fetch.mock.calls[1][0]).toContain('https://other.test/cb?amount=1')
+  })
+
+  it('throws when no global fetch is available for the fallback', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
+    delete globalThis.fetch
+    await expect(lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 }))
+      .rejects.toThrow('no global fetch for LNURL fallback')
+  })
+
+  it('throws when the LNURL response has no callback', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
+    globalThis.fetch = jest.fn().mockResolvedValueOnce({ json: async () => ({}) })
+    await expect(lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 }))
+      .rejects.toThrow('missing callback in LNURL response')
+  })
+
+  it('throws when no invoice is returned from either path', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => ({ pr: undefined }))
+    await expect(lsp.payAddress({ address: 'alice@lsp.example.io', amtMsat: 1 }))
+      .rejects.toThrow('no invoice returned for Lightning Address')
+  })
+})
+
+// ── enableLightningAddress ─────────────────────────────────────────────────
+
+describe('enableLightningAddress', () => {
+  it('registers the apay pool and reads back the assigned Lightning Address', async () => {
+    const account = makeAccount({ getNodeInfo: jest.fn(async () => ({ pubkey: 'wallet-pk' })) })
+    const lsp = makeLsp(account)
+    const out = await lsp.enableLightningAddress()
+    expect(lsp.http.getInfo).toHaveBeenCalled()
+    expect(account.apayNew).toHaveBeenCalledWith('lsppubkey')
+    expect(lsp.http.getLightningAddressByPubkey).toHaveBeenCalledWith('wallet-pk')
+    expect(out).toEqual({ username: 'alice', domain: 'lsp.example.io', address: 'alice@lsp.example.io' })
+  })
+
+  it('throws when the wallet is not unlocked (no pubkey)', async () => {
+    const account = makeAccount({ getNodeInfo: jest.fn(async () => ({})) })
+    const lsp = makeLsp(account)
+    await expect(lsp.enableLightningAddress()).rejects.toThrow('wallet not unlocked')
+    expect(account.apayNew).not.toHaveBeenCalled()
+  })
+
+  it('throws when the LSP /get_info returns no pubkey', async () => {
+    const account = makeAccount({ getNodeInfo: jest.fn(async () => ({ pubkey: 'wallet-pk' })) })
+    const lsp = makeLsp(account)
+    lsp.http.getInfo = jest.fn(async () => ({}))
+    await expect(lsp.enableLightningAddress()).rejects.toThrow('returned no pubkey')
+    expect(account.apayNew).not.toHaveBeenCalled()
+  })
+})
+
+// ── claimPendingPayments ───────────────────────────────────────────────────
+
+describe('claimPendingPayments', () => {
+  it('returns an empty list when there are no claimable payments', async () => {
+    const account = makeAccount({ listPayments: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    await expect(lsp.claimPendingPayments()).resolves.toEqual([])
+    expect(account.claimHodlInvoice).not.toHaveBeenCalled()
+  })
+
+  it('claims CLAIMABLE and CLAIMING payments (camelCase + snake_case shapes)', async () => {
+    const payments = [
+      { status: 'CLAIMABLE', paymentHash: 'h1', paymentPreimage: 'p1' },
+      { status: 'claiming', payment_hash: 'h2', payment_preimage: 'p2' },
+      { status: 'SUCCEEDED', paymentHash: 'h3' }
+    ]
+    const account = makeAccount({ listPayments: jest.fn(async () => ({ payments })) })
+    const lsp = makeLsp(account)
+    const results = await lsp.claimPendingPayments()
+    expect(account.claimHodlInvoice).toHaveBeenCalledTimes(2)
+    expect(account.claimHodlInvoice).toHaveBeenNthCalledWith(1, { payment_hash: 'h1', payment_preimage: 'p1' })
+    expect(account.claimHodlInvoice).toHaveBeenNthCalledWith(2, { payment_hash: 'h2', payment_preimage: 'p2' })
+    expect(results).toEqual([
+      { paymentHash: 'h1', claimed: true },
+      { paymentHash: 'h2', claimed: true }
+    ])
+  })
+
+  it('falls back to the paymentImage preimage key', async () => {
+    const payments = [{ status: 'CLAIMABLE', paymentHash: 'h1', paymentImage: 'img-preimage' }]
+    const account = makeAccount({ listPayments: jest.fn(async () => payments) })
+    const lsp = makeLsp(account)
+    await lsp.claimPendingPayments()
+    expect(account.claimHodlInvoice).toHaveBeenCalledWith({ payment_hash: 'h1', payment_preimage: 'img-preimage' })
+  })
+
+  it('records a failed claim with its error message and keeps going', async () => {
+    const payments = [
+      { status: 'CLAIMABLE', paymentHash: 'boom', paymentPreimage: 'p' },
+      { status: 'CLAIMABLE', paymentHash: 'ok', paymentPreimage: 'p2' }
+    ]
+    const claimHodlInvoice = jest.fn()
+      .mockRejectedValueOnce(new Error('claim failed'))
+      .mockResolvedValueOnce({ ok: true })
+    const account = makeAccount({ listPayments: jest.fn(async () => payments), claimHodlInvoice })
+    const lsp = makeLsp(account)
+    const results = await lsp.claimPendingPayments()
+    expect(results).toEqual([
+      { paymentHash: 'boom', claimed: false, error: 'claim failed' },
+      { paymentHash: 'ok', claimed: true }
+    ])
+  })
+})
+
+// ── private helpers via observable behaviour ───────────────────────────────
+
+describe('list normalization helpers', () => {
+  it('_listChannels yields [] for a non-array, non-{channels} response (timeout path)', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => ({ foo: 'bar' })) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForChannel('a', { timeoutMs: 5, pollIntervalMs: 1 }))
+      .rejects.toBeInstanceOf(LspChannelTimeoutError)
+  })
+
+  it('_sleep rejects when the signal aborts mid-wait', async () => {
+    const account = makeAccount({ listChannels: jest.fn(async () => []) })
+    const lsp = makeLsp(account)
+    const controller = new AbortController()
+    const p = lsp.waitForChannel('a', { timeoutMs: 1000, pollIntervalMs: 50, signal: controller.signal })
+    // Abort after the first sync/list completes and the sleep has begun.
+    setTimeout(() => controller.abort(), 5)
+    await expect(p).rejects.toThrow('aborted')
+  })
+})

--- a/tests/utexo-lsp.test.js
+++ b/tests/utexo-lsp.test.js
@@ -240,6 +240,43 @@ describe('waitForChannel', () => {
     await expect(lsp.waitForChannel('wanted', { timeoutMs: 5, pollIntervalMs: 1 }))
       .rejects.toBeInstanceOf(LspChannelTimeoutError)
   })
+
+  it("reports the no-match progress message ('RGB usable: no') when nothing matches", async () => {
+    // Channel count is reported and the match flag is 'no' (not 'yes') for an
+    // asset that does not match. Pins the false arm of the onProgress ternary.
+    const account = makeAccount({ listChannels: jest.fn(async () => [{ assetId: 'other', isUsable: true }, { assetId: 'x' }]) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await expect(lsp.waitForChannel('wanted', { timeoutMs: 5, pollIntervalMs: 1, onProgress }))
+      .rejects.toBeInstanceOf(LspChannelTimeoutError)
+    expect(onProgress).toHaveBeenCalledWith('channels: 2 — RGB usable: no')
+    expect(onProgress).not.toHaveBeenCalledWith(expect.stringContaining('usable: yes'))
+  })
+
+  it('treats isUsable:false as NOT usable even when ready is true (nullish-coalescing precedence)', async () => {
+    // `isUsable ?? ready`: false is NOT nullish, so the explicit false wins and
+    // `ready:true` must NOT rescue the channel. If `??` were `||`, ready:true
+    // would (wrongly) make it usable and the wait would resolve instead of
+    // timing out.
+    const channel = { assetId: 'wanted', isUsable: false, ready: true, channelId: 'c-false' }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    await expect(lsp.waitForChannel('wanted', { timeoutMs: 5, pollIntervalMs: 1 }))
+      .rejects.toBeInstanceOf(LspChannelTimeoutError)
+  })
+
+  it('reads the localBalanceMsat (camelCase) middle rung and defaults inbound to 0', async () => {
+    // _outboundMsat: outboundBalanceMsat is absent, so the camelCase
+    // localBalanceMsat fallback rung supplies the value; inbound is absent so
+    // the `?? 0` default applies.
+    const channel = { assetId: 'wanted', isUsable: true, channelId: 'c-local', localBalanceMsat: 4242 }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    const info = await lsp.waitForChannel('wanted', { timeoutMs: 1000 })
+    expect(info.outboundBalanceMsat).toBe(4242)
+    expect(info.inboundBalanceMsat).toBe(0)
+    expect(info.capacitySat).toBe(0)
+  })
 })
 
 // ── receiveAsset ───────────────────────────────────────────────────────────
@@ -263,11 +300,63 @@ describe('receiveAsset', () => {
       assetId: 'assetX',
       assetAmount: 5
     })
+    // No measurable elapsed time in a fast unit test, so the remaining
+    // lifetime equals the full expiry. Pins the exact forwarded value so a
+    // sign flip / doubling / drop of the elapsed-subtraction is caught even
+    // before the elapsed-aware tests below.
     expect(lsp.http.lightningReceive).toHaveBeenCalledWith({
       lnInvoice: 'lnbcrt-mine',
-      rgb: { assetId: 'assetX', durationSeconds: expect.any(Number) }
+      rgb: { assetId: 'assetX', durationSeconds: 600 }
     })
     expect(out).toEqual({ lnInvoice: 'lnbcrt-mine', rgbInvoice: 'rgb:abc', mappingId: '1' })
+  })
+
+  it('forwards the LN invoice REMAINING lifetime (expiry minus elapsed) as durationSeconds', async () => {
+    // Drive Date.now() deterministically: the source reads it once before
+    // createLightningInvoice (createdAtMs) and once after (to derive
+    // elapsedSeconds). We make invoice creation "take" 7000ms of wall clock
+    // so elapsedSeconds === 7, and durationSeconds === expiry - 7.
+    const nowSpy = jest.spyOn(Date, 'now')
+    nowSpy.mockReturnValueOnce(1_000_000) // createdAtMs
+    const account = makeAccount({
+      createLightningInvoice: jest.fn(async () => {
+        nowSpy.mockReturnValue(1_007_000) // +7000ms elapsed during creation
+        return { invoice: 'lnbcrt-mine' }
+      })
+    })
+    const lsp = makeLsp(account)
+    try {
+      await lsp.receiveAsset({ assetId: 'assetX', expirySeconds: 600 })
+    } finally {
+      nowSpy.mockRestore()
+    }
+    expect(lsp.http.lightningReceive).toHaveBeenCalledWith({
+      lnInvoice: 'lnbcrt-mine',
+      rgb: { assetId: 'assetX', durationSeconds: 593 } // 600 - 7, NOT 600 and NOT 607
+    })
+  })
+
+  it('floors durationSeconds at 1 when invoice creation outlasts the expiry', async () => {
+    // elapsedSeconds (50) exceeds expiry (10): expiry - elapsed = -40, so the
+    // Math.max(1, …) floor must clamp to exactly 1.
+    const nowSpy = jest.spyOn(Date, 'now')
+    nowSpy.mockReturnValueOnce(2_000_000) // createdAtMs
+    const account = makeAccount({
+      createLightningInvoice: jest.fn(async () => {
+        nowSpy.mockReturnValue(2_050_000) // +50_000ms elapsed
+        return { invoice: 'lnbcrt-slow' }
+      })
+    })
+    const lsp = makeLsp(account)
+    try {
+      await lsp.receiveAsset({ assetId: 'assetX', expirySeconds: 10 })
+    } finally {
+      nowSpy.mockRestore()
+    }
+    expect(lsp.http.lightningReceive).toHaveBeenCalledWith({
+      lnInvoice: 'lnbcrt-slow',
+      rgb: { assetId: 'assetX', durationSeconds: 1 }
+    })
   })
 
   it('omits amountMsat for an amountless invoice and defaults expiry to 3600', async () => {
@@ -316,6 +405,26 @@ describe('awaitReceiveSettlement', () => {
     expect(err.step).toBe('ln_invoice')
   })
 
+  it('keeps polling through Pending and settles on a later Succeeded (multi-iteration)', async () => {
+    const getInvoiceStatus = jest.fn()
+      .mockResolvedValueOnce({ status: 'Pending' })
+      .mockResolvedValueOnce({ status: 'Pending' })
+      .mockResolvedValueOnce({ status: 'Succeeded' })
+    const account = makeAccount({ getInvoiceStatus })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await expect(lsp.awaitReceiveSettlement('ln', { timeoutMs: 1000, pollIntervalMs: 1, onProgress }))
+      .resolves.toBe('settled')
+    // Three polls: Pending, Pending, then Succeeded — proves the loop iterates
+    // across the sleep instead of resolving on the first read.
+    expect(getInvoiceStatus).toHaveBeenCalledTimes(3)
+    expect(account.sync).toHaveBeenCalledTimes(3)
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'Pending')
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'Pending')
+    expect(onProgress).toHaveBeenNthCalledWith(3, 'Succeeded')
+    expect(onProgress).not.toHaveBeenCalledWith('timeout')
+  })
+
   it('throws LspSettlementError on an Expired status', async () => {
     const account = makeAccount({ getInvoiceStatus: jest.fn(async () => ({ status: 'Expired' })) })
     const lsp = makeLsp(account)
@@ -358,7 +467,12 @@ describe('waitForOutboundLiquidity', () => {
     const channel = { peer_pubkey: PEER.peerPubkey, is_usable: true, outbound_balance_msat: 9000 }
     const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
     const lsp = makeLsp(account)
-    await expect(lsp.waitForOutboundLiquidity(1, { timeoutMs: 1000 })).resolves.toBeUndefined()
+    const onProgress = jest.fn()
+    await expect(lsp.waitForOutboundLiquidity(1, { timeoutMs: 1000, onProgress })).resolves.toBeUndefined()
+    // Resolution on the FIRST poll (not a timeout): proves the snake_case
+    // channel was selected and its outbound (9000) was read, meeting need=1.
+    expect(onProgress).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith('outbound: 9000 msat (need 1)')
   })
 
   it('keeps polling and returns (without throwing) when liquidity never arrives', async () => {
@@ -366,6 +480,33 @@ describe('waitForOutboundLiquidity', () => {
     const lsp = makeLsp(account)
     await expect(lsp.waitForOutboundLiquidity(10000, { timeoutMs: 5, pollIntervalMs: 1 }))
       .resolves.toBeUndefined()
+  })
+
+  it('IGNORES a peer-matching channel that is not usable (the is_usable conjunct)', async () => {
+    // Right peer, ample outbound, but is_usable=false: the AND-guard must
+    // reject it so no channel is selected and outbound reads 0 (need 5000 ->
+    // never met). If the is_usable conjunct were dropped, this channel would
+    // be selected and onProgress would report 9999 msat. We assert the EXACT
+    // reported outbound to pin the distinct outcome.
+    const channel = { peerPubkey: PEER.peerPubkey, isUsable: false, outboundBalanceMsat: 9999 }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress })
+    expect(onProgress).toHaveBeenCalledWith('outbound: 0 msat (need 5000)')
+    expect(onProgress).not.toHaveBeenCalledWith(expect.stringContaining('9999'))
+  })
+
+  it('IGNORES a usable channel on the WRONG peer (the peerPubkey conjunct)', async () => {
+    // Usable, ample outbound, but a different peer: must not satisfy the
+    // liquidity wait. Pins the peerPubkey side of the AND.
+    const channel = { peerPubkey: '03' + 'f'.repeat(64), isUsable: true, outboundBalanceMsat: 9999 }
+    const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
+    const lsp = makeLsp(account)
+    const onProgress = jest.fn()
+    await lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress })
+    expect(onProgress).toHaveBeenCalledWith('outbound: 0 msat (need 5000)')
+    expect(onProgress).not.toHaveBeenCalledWith(expect.stringContaining('9999'))
   })
 
   it('aborts on an already-aborted signal', async () => {
@@ -551,6 +692,29 @@ describe('claimPendingPayments', () => {
     const lsp = makeLsp(account)
     await lsp.claimPendingPayments()
     expect(account.claimHodlInvoice).toHaveBeenCalledWith({ payment_hash: 'h1', payment_preimage: 'img-preimage' })
+  })
+
+  it('reads a snake_case-only payment_preimage (camel paymentPreimage absent)', async () => {
+    // First rung `paymentPreimage` is undefined, so the `_raw` snake fallback
+    // must supply `payment_preimage`. payment_hash also via snake fallback.
+    const payments = [{ status: 'CLAIMING', payment_hash: 'snakeH', payment_preimage: 'snakeP' }]
+    const account = makeAccount({ listPayments: jest.fn(async () => payments) })
+    const lsp = makeLsp(account)
+    const results = await lsp.claimPendingPayments()
+    expect(account.claimHodlInvoice).toHaveBeenCalledWith({ payment_hash: 'snakeH', payment_preimage: 'snakeP' })
+    expect(results).toEqual([{ paymentHash: 'snakeH', claimed: true }])
+  })
+
+  it("defaults the preimage to '' when no preimage key is present", async () => {
+    // No paymentPreimage / payment_preimage / paymentImage at all: the final
+    // `?? ''` default must produce an empty-string preimage (still attempts
+    // the claim with the hash). Pins the terminal default of the chain.
+    const payments = [{ status: 'CLAIMABLE', paymentHash: 'noPreimage' }]
+    const account = makeAccount({ listPayments: jest.fn(async () => payments) })
+    const lsp = makeLsp(account)
+    const results = await lsp.claimPendingPayments()
+    expect(account.claimHodlInvoice).toHaveBeenCalledWith({ payment_hash: 'noPreimage', payment_preimage: '' })
+    expect(results).toEqual([{ paymentHash: 'noPreimage', claimed: true }])
   })
 
   it('records a failed claim with its error message and keeps going', async () => {

--- a/tests/wallet-account-surface.test.js
+++ b/tests/wallet-account-surface.test.js
@@ -1,0 +1,996 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Surface coverage for WalletAccountRgbLightning + the read-only façade
+// it returns from toReadOnlyAccount(). Most methods are 1-line
+// passthroughs to this._node.<x>() (the _node getter returns
+// this._binding.node) or this._binding.<x>(); these tests assert each
+// account method forwards to the right node/binding method with the
+// right args and maps the result as documented.
+//
+// transfer/quoteTransfer, _classifyRecipient, verify/signTransaction,
+// and vssStatus/clearVssFence/vssBackup are covered by other suites and
+// are NOT re-tested here.
+
+import { jest } from '@jest/globals'
+import WalletAccountRgbLightning, {
+  PENDING_ADDRESS
+} from '../src/wallet-account-rgb-lightning.js'
+import { UnlockError, ApayError, NotImplementedError } from '../src/errors.js'
+
+// Build a fake RLN node whose methods are jest.fn returning canned
+// values. Every method the account forwards to is present so we can
+// assert forwarding + arg pass-through.
+function makeNode (overrides = {}) {
+  return {
+    nodeInfo: jest.fn(() => ({ pubkey: 'np' })),
+    networkInfo: jest.fn(() => ({ height: 100 })),
+    sync: jest.fn(() => undefined),
+    address: jest.fn(() => ({ address: 'tb1qreal' })),
+    openChannel: jest.fn((r) => ({ opened: r })),
+    closeChannel: jest.fn(() => undefined),
+    listChannels: jest.fn(() => [{ id: 'c1' }]),
+    getChannelId: jest.fn((h) => ({ channel_id: h })),
+    connectPeer: jest.fn(() => undefined),
+    disconnectPeer: jest.fn(() => undefined),
+    listPeers: jest.fn(() => ({ peers: [] })),
+    lnInvoice: jest.fn((r) => ({ invoice: 'lnbc1', payment_hash: 'ph', echo: r })),
+    decodeLnInvoice: jest.fn((i) => ({ decoded: i })),
+    invoiceStatus: jest.fn((i) => ({ status: 'Pending', echo: i })),
+    cancelHodlInvoice: jest.fn(() => undefined),
+    claimHodlInvoice: jest.fn((r) => ({ claimed: r })),
+    sendPayment: jest.fn((r) => ({ payment_hash: 'sp', echo: r })),
+    keysend: jest.fn((r) => ({ payment_hash: 'ks', echo: r })),
+    listPayments: jest.fn(() => [{ p: 1 }]),
+    getPayment: jest.fn((h, t) => ({ payment_hash: h, type: t })),
+    issueAssetNia: jest.fn((r) => ({ nia: r })),
+    issueAssetUda: jest.fn((r) => ({ uda: r })),
+    issueAssetCfa: jest.fn((r) => ({ cfa: r })),
+    issueAssetIfa: jest.fn((r) => ({ ifa: r })),
+    listAssets: jest.fn((f) => ({ assets: f })),
+    assetBalance: jest.fn((id) => ({ settled: 7, asset: id })),
+    assetMetadata: jest.fn((id) => ({ meta: id })),
+    listTransfers: jest.fn((id) => ({ transfers: id })),
+    refreshTransfers: jest.fn(() => undefined),
+    failTransfers: jest.fn((r) => ({ failed: r })),
+    rgbInvoice: jest.fn((r) => ({ rgbinv: r })),
+    decodeRgbInvoice: jest.fn((i) => ({ decodedRgb: i })),
+    sendRgb: jest.fn((r) => ({ txid: 'rgbtx', echo: r })),
+    inflate: jest.fn((r) => ({ inflated: r })),
+    getAssetMedia: jest.fn((d) => ({ media: d })),
+    postAssetMedia: jest.fn((r) => ({ posted: r })),
+    btcBalance: jest.fn(() => ({ vanilla: { spendable: 1234, settled: 1000 } })),
+    sendBtc: jest.fn((r) => ({ txid: 'btctx', echo: r })),
+    listTransactions: jest.fn(() => ({ transactions: [] })),
+    listUnspents: jest.fn(() => ({ unspents: [] })),
+    createUtxos: jest.fn(() => undefined),
+    estimateFee: jest.fn(() => ({ fee_rate: 12 })),
+    sendOnionMessage: jest.fn(() => undefined),
+    signMessage: jest.fn((m) => ({ signature: 'sig:' + m })),
+    checkIndexerUrl: jest.fn((u) => ({ ok: true, url: u })),
+    checkProxyEndpoint: jest.fn(() => undefined),
+    ...overrides
+  }
+}
+
+// Build a fake binding around a node. node-level overrides go via
+// `node`; binding-level overrides spread on top.
+function makeBinding (overrides = {}) {
+  const node = overrides.node ?? makeNode()
+  const binding = {
+    unlock: jest.fn(() => undefined),
+    bootstrap: jest.fn(() => ({ node_id: 'aa'.repeat(33) })),
+    shutdown: jest.fn(() => undefined),
+    apayNew: jest.fn(() => ({ order_id: 'o1' })),
+    ...overrides
+  }
+  // Ensure the binding's `node` getter target is the resolved node even
+  // when overrides supplied one (or none).
+  binding.node = node
+  return binding
+}
+
+function makeAccount (bindingOverrides = {}) {
+  return new WalletAccountRgbLightning({ binding: makeBinding(bindingOverrides) })
+}
+
+describe('construction', () => {
+  it('throws when no binding is provided', () => {
+    expect(() => new WalletAccountRgbLightning()).toThrow(/requires a BareRgbLightningBinding/)
+    expect(() => new WalletAccountRgbLightning({})).toThrow(/requires a BareRgbLightningBinding/)
+  })
+
+  it('exposes the node via the _binding.node getter', () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    expect(account._node).toBe(node)
+  })
+})
+
+describe('lifecycle', () => {
+  it('unlock forwards the request and returns { ok: true }', async () => {
+    const unlock = jest.fn()
+    const account = makeAccount({ unlock })
+    const req = { bitcoind_rpc_username: 'u' }
+    await expect(account.unlock(req)).resolves.toEqual({ ok: true })
+    expect(unlock).toHaveBeenCalledWith(req)
+  })
+
+  it('unlock wraps a binding failure into an UnlockError preserving the message', async () => {
+    const account = makeAccount({
+      unlock: () => { throw new Error('Rln(NotInitialized): bad creds') }
+    })
+    const err = await account.unlock({}).catch((e) => e)
+    expect(err).toBeInstanceOf(UnlockError)
+    expect(err.message).toBe('Rln(NotInitialized): bad creds')
+    expect(err.code).toBe('UNLOCK_FAILED')
+  })
+
+  it('getBootstrap returns the binding bootstrap dictionary', async () => {
+    const boot = { node_id: 'bb', account_xpubs: [] }
+    const account = makeAccount({ bootstrap: () => boot })
+    await expect(account.getBootstrap()).resolves.toBe(boot)
+  })
+
+  it('shutdown calls the binding and returns { ok: true }', async () => {
+    const shutdown = jest.fn()
+    const account = makeAccount({ shutdown })
+    await expect(account.shutdown()).resolves.toEqual({ ok: true })
+    expect(shutdown).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('apayNew', () => {
+  it('forwards to the binding and returns the order response', async () => {
+    const apayNew = jest.fn(() => ({ order_id: 'X' }))
+    const account = makeAccount({ apayNew })
+    await expect(account.apayNew('host')).resolves.toEqual({ order_id: 'X' })
+    expect(apayNew).toHaveBeenCalledWith('host')
+  })
+
+  it('wraps a binding failure into an ApayError', async () => {
+    const account = makeAccount({ apayNew: () => { throw new Error('lsp unreachable') } })
+    const err = await account.apayNew('host').catch((e) => e)
+    expect(err).toBeInstanceOf(ApayError)
+    expect(err.message).toBe('lsp unreachable')
+  })
+})
+
+describe('node info / network / sync', () => {
+  it('getNodeInfo forwards to node.nodeInfo', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getNodeInfo()).resolves.toEqual({ pubkey: 'np' })
+    expect(node.nodeInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('getNetworkInfo forwards to node.networkInfo', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getNetworkInfo()).resolves.toEqual({ height: 100 })
+    expect(node.networkInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('sync calls node.sync and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.sync()).resolves.toEqual({ ok: true })
+    expect(node.sync).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getAddress', () => {
+  it('returns the .address field when node.address returns an object', () => {
+    const account = makeAccount({ node: makeNode({ address: () => ({ address: 'tb1qabc' }) }) })
+    expect(account.getAddress()).toBe('tb1qabc')
+  })
+
+  it('returns the string directly when node.address returns a string', () => {
+    const account = makeAccount({ node: makeNode({ address: () => 'tb1qstr' }) })
+    expect(account.getAddress()).toBe('tb1qstr')
+  })
+
+  it('returns PENDING_ADDRESS when node.address throws', () => {
+    const account = makeAccount({ node: makeNode({ address: () => { throw new Error('NotInitialized') } }) })
+    expect(account.getAddress()).toBe(PENDING_ADDRESS)
+  })
+
+  it('returns PENDING_ADDRESS when node.address returns an empty string', () => {
+    const account = makeAccount({ node: makeNode({ address: () => '' }) })
+    expect(account.getAddress()).toBe(PENDING_ADDRESS)
+  })
+
+  it('returns PENDING_ADDRESS when node.address returns an object without .address', () => {
+    const account = makeAccount({ node: makeNode({ address: () => ({}) }) })
+    expect(account.getAddress()).toBe(PENDING_ADDRESS)
+  })
+})
+
+describe('channels', () => {
+  it('openChannel forwards the request and returns the response', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { capacity_sat: 100000 }
+    await expect(account.openChannel(req)).resolves.toEqual({ opened: req })
+    expect(node.openChannel).toHaveBeenCalledWith(req)
+  })
+
+  it('closeChannel forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { channel_id: 'c1' }
+    await expect(account.closeChannel(req)).resolves.toEqual({ ok: true })
+    expect(node.closeChannel).toHaveBeenCalledWith(req)
+  })
+
+  it('listChannels forwards to node.listChannels', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.listChannels()).resolves.toEqual([{ id: 'c1' }])
+  })
+
+  it('getChannelId forwards the temporary id', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getChannelId('tmp')).resolves.toEqual({ channel_id: 'tmp' })
+    expect(node.getChannelId).toHaveBeenCalledWith('tmp')
+  })
+})
+
+describe('peers', () => {
+  it('connectPeer forwards and returns { ok: true } on success', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.connectPeer('pk@host:9735')).resolves.toEqual({ ok: true })
+    expect(node.connectPeer).toHaveBeenCalledWith('pk@host:9735')
+  })
+
+  it('connectPeer swallows a Conflict error and returns { ok: true }', async () => {
+    const account = makeAccount({
+      node: makeNode({ connectPeer: () => { throw new Error('Rln(Conflict): peer known') } })
+    })
+    await expect(account.connectPeer('pk@host')).resolves.toEqual({ ok: true })
+  })
+
+  it('connectPeer rethrows non-Conflict errors', async () => {
+    const account = makeAccount({
+      node: makeNode({ connectPeer: () => { throw new Error('connection refused') } })
+    })
+    await expect(account.connectPeer('pk@host')).rejects.toThrow('connection refused')
+  })
+
+  it('disconnectPeer forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { peer_pubkey: 'pk' }
+    await expect(account.disconnectPeer(req)).resolves.toEqual({ ok: true })
+    expect(node.disconnectPeer).toHaveBeenCalledWith(req)
+  })
+
+  it('listPeers forwards to node.listPeers', async () => {
+    const node = makeNode({ listPeers: () => ({ peers: [{ pubkey: 'p' }] }) })
+    const account = makeAccount({ node })
+    await expect(account.listPeers()).resolves.toEqual({ peers: [{ pubkey: 'p' }] })
+  })
+})
+
+describe('invoices', () => {
+  it('createInvoice forwards to node.lnInvoice', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { expiry_sec: 3600 }
+    await expect(account.createInvoice(req)).resolves.toMatchObject({ invoice: 'lnbc1' })
+    expect(node.lnInvoice).toHaveBeenCalledWith(req)
+  })
+
+  it('createLightningInvoice maps camelCase keys to snake_case before lnInvoice', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await account.createLightningInvoice({
+      amountMsat: 1000,
+      expirySec: 3600,
+      assetId: 'aid',
+      assetAmount: 5,
+      paymentHash: 'ph',
+      descriptionHash: 'dh',
+      minFinalCltvExpiryDelta: 18
+    })
+    expect(node.lnInvoice).toHaveBeenCalledWith({
+      amt_msat: 1000,
+      expiry_sec: 3600,
+      asset_id: 'aid',
+      asset_amount: 5,
+      payment_hash: 'ph',
+      description_hash: 'dh',
+      min_final_cltv_expiry_delta: 18
+    })
+  })
+
+  it('_toLnInvoiceRequest passes snake_case keys through untouched', () => {
+    const snake = { amt_msat: 1, expiry_sec: 2, asset_id: 'a' }
+    expect(WalletAccountRgbLightning._toLnInvoiceRequest(snake)).toEqual(snake)
+  })
+
+  it('_toLnInvoiceRequest returns non-object input unchanged', () => {
+    expect(WalletAccountRgbLightning._toLnInvoiceRequest(undefined)).toBeUndefined()
+    expect(WalletAccountRgbLightning._toLnInvoiceRequest('x')).toBe('x')
+  })
+
+  it('_toLnInvoiceRequest keeps an existing snake_case value when both forms present', () => {
+    const out = WalletAccountRgbLightning._toLnInvoiceRequest({ amountMsat: 1, amt_msat: 999 })
+    // snake already present → camel is left in place, not overwritten
+    expect(out.amt_msat).toBe(999)
+    expect(out.amountMsat).toBe(1)
+  })
+
+  it('decodeInvoice forwards to node.decodeLnInvoice', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.decodeInvoice('lnbc1')).resolves.toEqual({ decoded: 'lnbc1' })
+    expect(node.decodeLnInvoice).toHaveBeenCalledWith('lnbc1')
+  })
+
+  it('getInvoiceStatus forwards to node.invoiceStatus', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getInvoiceStatus('lnbc1')).resolves.toMatchObject({ status: 'Pending' })
+    expect(node.invoiceStatus).toHaveBeenCalledWith('lnbc1')
+  })
+
+  it('createHodlInvoice throws TypeError when paymentHash is missing', async () => {
+    const account = makeAccount()
+    await expect(account.createHodlInvoice({})).rejects.toBeInstanceOf(TypeError)
+    await expect(account.createHodlInvoice()).rejects.toBeInstanceOf(TypeError)
+    await expect(account.createHodlInvoice({ paymentHash: '' })).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it('createHodlInvoice shapes { bolt11, paymentHash } from RLN response', async () => {
+    const node = makeNode({ lnInvoice: () => ({ invoice: 'lnbc-hodl', payment_hash: 'returnedhash' }) })
+    const account = makeAccount({ node })
+    await expect(account.createHodlInvoice({
+      paymentHash: 'ph',
+      amtMsat: 2000,
+      expirySec: 900,
+      assetId: 'aid',
+      assetAmount: 3,
+      minFinalCltvExpiryDelta: 40
+    })).resolves.toEqual({ bolt11: 'lnbc-hodl', paymentHash: 'returnedhash' })
+  })
+
+  it('createHodlInvoice falls back to res.bolt11 and the supplied hash', async () => {
+    const node = makeNode({ lnInvoice: () => ({ bolt11: 'fromBolt11' }) })
+    const account = makeAccount({ node })
+    await expect(account.createHodlInvoice({ paymentHash: 'mine', expirySec: 60 }))
+      .resolves.toEqual({ bolt11: 'fromBolt11', paymentHash: 'mine' })
+  })
+
+  it('createHodlInvoice yields empty bolt11 when neither invoice nor bolt11 present', async () => {
+    const node = makeNode({ lnInvoice: () => ({}) })
+    const account = makeAccount({ node })
+    await expect(account.createHodlInvoice({ paymentHash: 'mine', expirySec: 60 }))
+      .resolves.toEqual({ bolt11: '', paymentHash: 'mine' })
+  })
+
+  it('cancelHodlInvoice forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { payment_hash: 'ph' }
+    await expect(account.cancelHodlInvoice(req)).resolves.toEqual({ ok: true })
+    expect(node.cancelHodlInvoice).toHaveBeenCalledWith(req)
+  })
+
+  it('claimHodlInvoice forwards and returns the response', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { payment_hash: 'ph', preimage: 'pi' }
+    await expect(account.claimHodlInvoice(req)).resolves.toEqual({ claimed: req })
+  })
+})
+
+describe('payments', () => {
+  it('sendPayment forwards to node.sendPayment', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { invoice: 'lnbc1' }
+    await expect(account.sendPayment(req)).resolves.toMatchObject({ payment_hash: 'sp' })
+    expect(node.sendPayment).toHaveBeenCalledWith(req)
+  })
+
+  it('keysend forwards to node.keysend', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { dest_pubkey: 'pk', amt_msat: 1 }
+    await expect(account.keysend(req)).resolves.toMatchObject({ payment_hash: 'ks' })
+    expect(node.keysend).toHaveBeenCalledWith(req)
+  })
+
+  it('listPayments forwards to node.listPayments', async () => {
+    const account = makeAccount()
+    await expect(account.listPayments()).resolves.toEqual([{ p: 1 }])
+  })
+
+  it('getPayment forwards the hash + type', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getPayment('h', 'sent')).resolves.toEqual({ payment_hash: 'h', type: 'sent' })
+    expect(node.getPayment).toHaveBeenCalledWith('h', 'sent')
+  })
+})
+
+describe('RGB issuance passthroughs', () => {
+  it.each([
+    ['issueAssetNia', 'issueAssetNia', 'nia'],
+    ['issueAssetUda', 'issueAssetUda', 'uda'],
+    ['issueAssetCfa', 'issueAssetCfa', 'cfa'],
+    ['issueAssetIfa', 'issueAssetIfa', 'ifa'],
+    ['inflate', 'inflate', 'inflated']
+  ])('%s forwards to node.%s', async (method, nodeMethod, key) => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { x: 1 }
+    const res = await account[method](req)
+    expect(res).toEqual({ [key]: req })
+    expect(node[nodeMethod]).toHaveBeenCalledWith(req)
+  })
+})
+
+describe('RGB assets', () => {
+  it('listAssets forwards the schema filter', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.listAssets(['Nia'])).resolves.toEqual({ assets: ['Nia'] })
+    expect(node.listAssets).toHaveBeenCalledWith(['Nia'])
+  })
+
+  it('getAssetBalance forwards to node.assetBalance', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getAssetBalance('aid')).resolves.toEqual({ settled: 7, asset: 'aid' })
+    expect(node.assetBalance).toHaveBeenCalledWith('aid')
+  })
+
+  it('getAssetMetadata forwards to node.assetMetadata', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getAssetMetadata('aid')).resolves.toEqual({ meta: 'aid' })
+  })
+
+  it('listTransfers forwards to node.listTransfers', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.listTransfers('aid')).resolves.toEqual({ transfers: 'aid' })
+  })
+
+  it('refreshTransfers forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { asset_id: 'aid' }
+    await expect(account.refreshTransfers(req)).resolves.toEqual({ ok: true })
+    expect(node.refreshTransfers).toHaveBeenCalledWith(req)
+  })
+
+  it('failTransfers forwards to node.failTransfers', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { batch_transfer_idx: 1 }
+    await expect(account.failTransfers(req)).resolves.toEqual({ failed: req })
+  })
+})
+
+describe('RGB invoices / transfers / media', () => {
+  it('createRgbInvoice forwards to node.rgbInvoice', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { asset_id: 'aid' }
+    await expect(account.createRgbInvoice(req)).resolves.toEqual({ rgbinv: req })
+  })
+
+  it('decodeRgbInvoice forwards to node.decodeRgbInvoice', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.decodeRgbInvoice('rgb:abc')).resolves.toEqual({ decodedRgb: 'rgb:abc' })
+  })
+
+  it('sendRgbAsset forwards to node.sendRgb', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { recipient_id: 'rgb:abc' }
+    await expect(account.sendRgbAsset(req)).resolves.toMatchObject({ txid: 'rgbtx' })
+    expect(node.sendRgb).toHaveBeenCalledWith(req)
+  })
+
+  it('getAssetMedia forwards the digest', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.getAssetMedia('digest')).resolves.toEqual({ media: 'digest' })
+  })
+
+  it('postAssetMedia forwards the request', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { file_path: '/x' }
+    await expect(account.postAssetMedia(req)).resolves.toEqual({ posted: req })
+  })
+})
+
+describe('BTC ops', () => {
+  it('getBalance parses vanilla.spendable to a string', async () => {
+    const account = makeAccount({
+      node: makeNode({ btcBalance: () => ({ vanilla: { spendable: 4242, settled: 100 } }) })
+    })
+    await expect(account.getBalance()).resolves.toBe('4242')
+  })
+
+  it('getBalance falls back to vanilla.settled when spendable is absent', async () => {
+    const account = makeAccount({
+      node: makeNode({ btcBalance: () => ({ vanilla: { settled: 77 } }) })
+    })
+    await expect(account.getBalance()).resolves.toBe('77')
+  })
+
+  it('getBalance returns "0" when node.btcBalance throws', async () => {
+    const account = makeAccount({
+      node: makeNode({ btcBalance: () => { throw new Error('NotInitialized') } })
+    })
+    await expect(account.getBalance()).resolves.toBe('0')
+  })
+
+  it('getBalance forwards the skipSync flag', async () => {
+    const btcBalance = jest.fn(() => ({ vanilla: { spendable: 1 } }))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await account.getBalance(true)
+    expect(btcBalance).toHaveBeenCalledWith(true)
+  })
+
+  it('getBalanceDetails forwards to node.btcBalance with coerced skipSync', async () => {
+    const btcBalance = jest.fn(() => ({ vanilla: { spendable: 5 } }))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await expect(account.getBalanceDetails(true)).resolves.toEqual({ vanilla: { spendable: 5 } })
+    expect(btcBalance).toHaveBeenCalledWith(true)
+  })
+
+  it('sendTransaction forwards to node.sendBtc', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { address: 'tb1q', amount: 1000 }
+    await expect(account.sendTransaction(req)).resolves.toMatchObject({ txid: 'btctx' })
+    expect(node.sendBtc).toHaveBeenCalledWith(req)
+  })
+
+  it('getTransactions forwards to node.listTransactions with coerced skipSync', async () => {
+    const listTransactions = jest.fn(() => ({ transactions: [] }))
+    const account = makeAccount({ node: makeNode({ listTransactions }) })
+    await account.getTransactions(true)
+    expect(listTransactions).toHaveBeenCalledWith(true)
+  })
+
+  it('listUnspents forwards to node.listUnspents', async () => {
+    const listUnspents = jest.fn(() => ({ unspents: [] }))
+    const account = makeAccount({ node: makeNode({ listUnspents }) })
+    await expect(account.listUnspents(false)).resolves.toEqual({ unspents: [] })
+    expect(listUnspents).toHaveBeenCalledWith(false)
+  })
+
+  it('createUtxos forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { num: 4 }
+    await expect(account.createUtxos(req)).resolves.toEqual({ ok: true })
+    expect(node.createUtxos).toHaveBeenCalledWith(req)
+  })
+
+  it('estimateFee forwards the blocks target', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.estimateFee(6)).resolves.toEqual({ fee_rate: 12 })
+    expect(node.estimateFee).toHaveBeenCalledWith(6)
+  })
+})
+
+describe('diagnostics / onion / signing', () => {
+  it('sendOnionMessage forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    const req = { node_id: 'pk' }
+    await expect(account.sendOnionMessage(req)).resolves.toEqual({ ok: true })
+    expect(node.sendOnionMessage).toHaveBeenCalledWith(req)
+  })
+
+  it('sign forwards to node.signMessage', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.sign('hello')).resolves.toEqual({ signature: 'sig:hello' })
+    expect(node.signMessage).toHaveBeenCalledWith('hello')
+  })
+
+  it('checkIndexerUrl forwards the url', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.checkIndexerUrl('http://idx')).resolves.toEqual({ ok: true, url: 'http://idx' })
+  })
+
+  it('checkProxyEndpoint forwards and returns { ok: true }', async () => {
+    const node = makeNode()
+    const account = makeAccount({ node })
+    await expect(account.checkProxyEndpoint('http://proxy')).resolves.toEqual({ ok: true })
+    expect(node.checkProxyEndpoint).toHaveBeenCalledWith('http://proxy')
+  })
+})
+
+describe('quoteSendTransaction', () => {
+  it('uses estimateFee-derived rate × vbytes', async () => {
+    const account = makeAccount()
+    // override _defaultFeeRate to avoid relying on node fee shape
+    account._defaultFeeRate = async () => 10
+    await expect(account.quoteSendTransaction({})).resolves.toEqual({ fee: BigInt(10 * 141) })
+  })
+})
+
+describe('_defaultFeeRate', () => {
+  it('reads fee_rate from estimateFee', async () => {
+    const account = makeAccount({ node: makeNode({ estimateFee: () => ({ fee_rate: 9 }) }) })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(9)
+  })
+
+  it('reads feerate alias', async () => {
+    const account = makeAccount({ node: makeNode({ estimateFee: () => ({ feerate: 8 }) }) })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(8)
+  })
+
+  it('accepts a bare numeric estimateFee result', async () => {
+    const account = makeAccount({ node: makeNode({ estimateFee: () => 3 }) })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(3)
+  })
+
+  it('falls back to the default rate when estimateFee returns a non-positive value', async () => {
+    const account = makeAccount({ node: makeNode({ estimateFee: () => ({ fee_rate: 0 }) }) })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(5)
+  })
+
+  it('falls back to the default rate when estimateFee throws', async () => {
+    const account = makeAccount({ node: makeNode({ estimateFee: () => { throw new Error('no') } }) })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(5)
+  })
+})
+
+describe('getTransactionReceipt', () => {
+  it('throws when the hash is empty', async () => {
+    const account = makeAccount()
+    await expect(account.getTransactionReceipt('')).rejects.toThrow(/hash is required/)
+    await expect(account.getTransactionReceipt(undefined)).rejects.toThrow(/hash is required/)
+  })
+
+  it('finds an on-chain tx via getTransactions ({ transactions })', async () => {
+    const hit = { txid: 'abc', confirmations: 3 }
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [{ txid: 'zzz' }, hit] }) })
+    })
+    await expect(account.getTransactionReceipt('abc')).resolves.toBe(hit)
+  })
+
+  it('finds an on-chain tx when getTransactions returns a bare array', async () => {
+    const hit = { txid: 'def' }
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => [hit] })
+    })
+    await expect(account.getTransactionReceipt('def')).resolves.toBe(hit)
+  })
+
+  it('falls back to a sent LN payment when not found on-chain', async () => {
+    const sent = { payment_hash: 'ph1', amt_msat: 1 }
+    const account = makeAccount({
+      node: makeNode({
+        listTransactions: () => ({ transactions: [] }),
+        getPayment: (h, t) => (t === 'sent' ? sent : null)
+      })
+    })
+    await expect(account.getTransactionReceipt('ph1')).resolves.toBe(sent)
+  })
+
+  it('falls back to a received LN payment when not sent', async () => {
+    const recv = { payment_hash: 'ph2' }
+    const account = makeAccount({
+      node: makeNode({
+        listTransactions: () => ({ transactions: [] }),
+        getPayment: (h, t) => {
+          if (t === 'sent') throw new Error('not a sent payment')
+          return recv
+        }
+      })
+    })
+    await expect(account.getTransactionReceipt('ph2')).resolves.toBe(recv)
+  })
+
+  it('returns null when found nowhere', async () => {
+    const account = makeAccount({
+      node: makeNode({
+        listTransactions: () => ({ transactions: [] }),
+        getPayment: () => { throw new Error('not found') }
+      })
+    })
+    await expect(account.getTransactionReceipt('nope')).resolves.toBeNull()
+  })
+
+  it('continues to LN lookup when getTransactions itself throws', async () => {
+    const sent = { payment_hash: 'ph3' }
+    const account = makeAccount({
+      node: makeNode({
+        listTransactions: () => { throw new Error('boom') },
+        getPayment: (h, t) => (t === 'sent' ? sent : null)
+      })
+    })
+    await expect(account.getTransactionReceipt('ph3')).resolves.toBe(sent)
+  })
+})
+
+describe('getKeyPair', () => {
+  it('returns the node_id as a Buffer publicKey with null privateKey', () => {
+    const account = makeAccount({ bootstrap: () => ({ node_id: 'aabbcc' }) })
+    const kp = account.getKeyPair()
+    expect(kp.publicKey).toEqual(Buffer.from('aabbcc', 'hex'))
+    expect(kp.privateKey).toBeNull()
+  })
+
+  it('throws when bootstrap has no node_id', () => {
+    const account = makeAccount({ bootstrap: () => ({}) })
+    expect(() => account.getKeyPair()).toThrow(/did not return a node_id/)
+  })
+
+  it('throws when bootstrap returns null', () => {
+    const account = makeAccount({ bootstrap: () => null })
+    expect(() => account.getKeyPair()).toThrow(/did not return a node_id/)
+  })
+})
+
+describe('getLspConfig', () => {
+  it('reads lspBaseUrl / lspBearerToken from binding._config', () => {
+    const account = makeAccount({ _config: { lspBaseUrl: 'https://lsp', lspBearerToken: 'tok' } })
+    expect(account.getLspConfig()).toEqual({ baseUrl: 'https://lsp', bearerToken: 'tok' })
+  })
+
+  it('returns nulls when config is absent', () => {
+    const account = makeAccount()
+    expect(account.getLspConfig()).toEqual({ baseUrl: null, bearerToken: null })
+  })
+
+  it('returns nulls when individual fields are absent', () => {
+    const account = makeAccount({ _config: {} })
+    expect(account.getLspConfig()).toEqual({ baseUrl: null, bearerToken: null })
+  })
+})
+
+describe('createLsp', () => {
+  it('returns a UtexoLsp for an explicit peer without auto-discovery', async () => {
+    const account = makeAccount()
+    const peer = {
+      baseUrl: 'https://lsp.example',
+      peerPubkey: 'pk',
+      peerHost: 'lsp.example',
+      peerPort: 9735
+    }
+    const lsp = await account.createLsp(peer)
+    expect(lsp).toBeTruthy()
+    expect(lsp.peer).toBe(peer)
+    expect(lsp.account).toBe(account)
+  })
+
+  it('throws when no peer is given and lspBaseUrl is not configured', async () => {
+    const account = makeAccount()
+    await expect(account.createLsp()).rejects.toThrow(/lspBaseUrl not set/)
+  })
+})
+
+describe('bootstrapLsp', () => {
+  it('throws TypeError when peerPubkeyAndAddr is missing', async () => {
+    const account = makeAccount()
+    await expect(account.bootstrapLsp({})).rejects.toBeInstanceOf(TypeError)
+    await expect(account.bootstrapLsp()).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it('throws TypeError when peerPubkeyAndAddr is not a string', async () => {
+    const account = makeAccount()
+    await expect(account.bootstrapLsp({ peerPubkeyAndAddr: 123 })).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it('treats the whole string as the pubkey when no @ separator is present', async () => {
+    // No '@' → peerPubkey is the full string; we just exercise the
+    // connect + (immediate, waitForPeerMs:0) poll path without hanging.
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => ({ peers: [] }))
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'BAREPUBKEY', waitForPeerMs: 0 })
+    expect(res).toEqual({ connect: { ok: true }, peerVisible: false })
+    expect(account.connectPeer).toHaveBeenCalledWith('BAREPUBKEY')
+  })
+
+  it('connects and reports peerVisible when listPeers shows the peer immediately', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => ({ peers: [{ pubkey: 'PK' }] }))
+    const apaySpy = jest.fn()
+    account.apayNew = apaySpy
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'PK@host:9735', waitForPeerMs: 1000 })
+    expect(res).toEqual({ connect: { ok: true }, peerVisible: true })
+    expect(account.connectPeer).toHaveBeenCalledWith('PK@host:9735')
+    expect(apaySpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a bare-array listPeers shape', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => [{ pubkey: 'PK' }])
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'PK@host:9735', waitForPeerMs: 1000 })
+    expect(res.peerVisible).toBe(true)
+  })
+
+  it('calls apayNew when hostNodeId is set and the peer is visible', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => ({ peers: [{ pubkey: 'PK' }] }))
+    account.apayNew = jest.fn(async () => ({ order_id: 'o9' }))
+    const res = await account.bootstrapLsp({
+      peerPubkeyAndAddr: 'PK@host:9735',
+      hostNodeId: 'host',
+      waitForPeerMs: 1000
+    })
+    expect(res).toEqual({ connect: { ok: true }, peerVisible: true, apay: { order_id: 'o9' } })
+    expect(account.apayNew).toHaveBeenCalledWith('host')
+  })
+
+  it('throws ApayError when hostNodeId is set but the peer never appears', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => ({ peers: [] }))
+    account.apayNew = jest.fn()
+    const err = await account.bootstrapLsp({
+      peerPubkeyAndAddr: 'PK@host:9735',
+      hostNodeId: 'host',
+      waitForPeerMs: 0
+    }).catch((e) => e)
+    expect(err).toBeInstanceOf(ApayError)
+    expect(err.code).toBe('APAY_PEER_NOT_VISIBLE')
+    expect(account.apayNew).not.toHaveBeenCalled()
+  })
+
+  it('returns peerVisible:false (no apay) when peer absent and no hostNodeId', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => ({ peers: [] }))
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'PK@host:9735', waitForPeerMs: 0 })
+    expect(res).toEqual({ connect: { ok: true }, peerVisible: false })
+  })
+
+  it('keeps polling until the peer appears on a later poll', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    let calls = 0
+    account.listPeers = jest.fn(async () => {
+      calls += 1
+      return calls >= 2 ? { peers: [{ pubkey: 'PK' }] } : { peers: [] }
+    })
+    const res = await account.bootstrapLsp({
+      peerPubkeyAndAddr: 'PK@host:9735',
+      waitForPeerMs: 5000,
+      pollIntervalMs: 100
+    })
+    expect(res.peerVisible).toBe(true)
+    expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('tolerates a listPeers rejection during polling', async () => {
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    account.listPeers = jest.fn(async () => { throw new Error('rpc down') })
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'PK@host:9735', waitForPeerMs: 0 })
+    expect(res.peerVisible).toBe(false)
+  })
+})
+
+describe('LSP helper passthroughs', () => {
+  it('payLightningAddress / requestLspRgbDeposit / payRgbViaLsp are callable methods', () => {
+    const account = makeAccount()
+    expect(typeof account.payLightningAddress).toBe('function')
+    expect(typeof account.requestLspRgbDeposit).toBe('function')
+    expect(typeof account.payRgbViaLsp).toBe('function')
+  })
+
+  it('payLightningAddress forwards to the helper (rejects on a malformed address)', async () => {
+    const account = makeAccount()
+    // A malformed Lightning Address rejects early in the helper's
+    // resolveAddressToInvoice — no network reached; the passthrough
+    // line still executes.
+    await expect(account.payLightningAddress('not-an-address', 1000n)).rejects.toBeDefined()
+  })
+
+  it('requestLspRgbDeposit forwards to the helper (rejects when rgb params missing)', async () => {
+    const account = makeAccount()
+    await expect(account.requestLspRgbDeposit({})).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it('payRgbViaLsp forwards to the helper (rejects when rgbInvoice missing)', async () => {
+    const account = makeAccount()
+    await expect(account.payRgbViaLsp({ rgbInvoice: '' })).rejects.toBeInstanceOf(TypeError)
+  })
+})
+
+describe('dispose', () => {
+  it('is a no-op that does not throw', () => {
+    const account = makeAccount()
+    expect(account.dispose()).toBeUndefined()
+  })
+})
+
+describe('toReadOnlyAccount / ReadOnlyRgbLightningAccount', () => {
+  it('returns a façade whose getAddress proxies the account', async () => {
+    const account = makeAccount({ node: makeNode({ address: () => ({ address: 'tb1qro' }) }) })
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.getAddress()).resolves.toBe('tb1qro')
+  })
+
+  it('getAddress wraps a synchronous string result in a Promise', async () => {
+    const account = makeAccount({ node: makeNode({ address: () => 'tb1qsync' }) })
+    const ro = await account.toReadOnlyAccount()
+    const p = ro.getAddress()
+    expect(p).toBeInstanceOf(Promise)
+    await expect(p).resolves.toBe('tb1qsync')
+  })
+
+  it('verify rejects with NotImplementedError', async () => {
+    const account = makeAccount()
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.verify('m', 's')).rejects.toBeInstanceOf(NotImplementedError)
+  })
+
+  it('getBalance returns a BigInt of the account satoshi string', async () => {
+    const account = makeAccount({
+      node: makeNode({ btcBalance: () => ({ vanilla: { spendable: 5050 } }) })
+    })
+    const ro = await account.toReadOnlyAccount()
+    const bal = await ro.getBalance()
+    expect(bal).toBe(5050n)
+    expect(typeof bal).toBe('bigint')
+  })
+
+  it('getTokenBalance returns a BigInt from settled', async () => {
+    const account = makeAccount({ node: makeNode({ assetBalance: () => ({ settled: 9 }) }) })
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.getTokenBalance('aid')).resolves.toBe(9n)
+  })
+
+  it('getTokenBalance falls back to spendable when settled absent', async () => {
+    const account = makeAccount({ node: makeNode({ assetBalance: () => ({ spendable: 4 }) }) })
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.getTokenBalance('aid')).resolves.toBe(4n)
+  })
+
+  it('getTokenBalance defaults to 0n when neither field present', async () => {
+    const account = makeAccount({ node: makeNode({ assetBalance: () => ({}) }) })
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.getTokenBalance('aid')).resolves.toBe(0n)
+  })
+
+  it('quoteSendTransaction proxies to the account quote', async () => {
+    const account = makeAccount()
+    account._defaultFeeRate = async () => 4
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.quoteSendTransaction({})).resolves.toEqual({ fee: BigInt(4 * 141) })
+  })
+
+  it('quoteTransfer proxies to the account quote (LN form)', async () => {
+    const account = makeAccount()
+    const ro = await account.toReadOnlyAccount()
+    const res = await ro.quoteTransfer({ recipient: 'lnbc1abc', amount: 1000000 })
+    expect(res).toEqual({ fee: BigInt(Math.max(1, Math.ceil(1000000 * 50 / 10000))) })
+  })
+
+  it('getTransactionReceipt proxies to the account lookup', async () => {
+    const hit = { txid: 'roTx' }
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [hit] }) })
+    })
+    const ro = await account.toReadOnlyAccount()
+    await expect(ro.getTransactionReceipt('roTx')).resolves.toBe(hit)
+  })
+})

--- a/tests/wallet-account-surface.test.js
+++ b/tests/wallet-account-surface.test.js
@@ -19,6 +19,8 @@ import WalletAccountRgbLightning, {
   PENDING_ADDRESS
 } from '../src/wallet-account-rgb-lightning.js'
 import { UnlockError, ApayError, NotImplementedError } from '../src/errors.js'
+import { LspClient } from '../src/lsp-client.js'
+import { UtexoLsp } from '../src/utexo-lsp.js'
 
 // Build a fake RLN node whose methods are jest.fn returning canned
 // values. Every method the account forwards to is present so we can
@@ -128,10 +130,20 @@ describe('lifecycle', () => {
     expect(err.code).toBe('UNLOCK_FAILED')
   })
 
-  it('getBootstrap returns the binding bootstrap dictionary', async () => {
-    const boot = { node_id: 'bb', account_xpubs: [] }
+  it('getBootstrap returns the binding bootstrap dictionary verbatim', async () => {
+    // Real bootstrap dict (external-signer): node_id + per-keychain xpubs +
+    // master_fingerprint. The account must return it unchanged (identity).
+    const boot = {
+      node_id: 'aa'.repeat(33),
+      account_xpub_vanilla: 'tpubVanilla',
+      account_xpub_colored: 'tpubColored',
+      master_fingerprint: 'deadbeef'
+    }
     const account = makeAccount({ bootstrap: () => boot })
-    await expect(account.getBootstrap()).resolves.toBe(boot)
+    const out = await account.getBootstrap()
+    expect(out).toBe(boot)
+    expect(out.account_xpub_vanilla).toBe('tpubVanilla')
+    expect(out.master_fingerprint).toBe('deadbeef')
   })
 
   it('shutdown calls the binding and returns { ok: true }', async () => {
@@ -143,10 +155,29 @@ describe('lifecycle', () => {
 })
 
 describe('apayNew', () => {
-  it('forwards to the binding and returns the order response', async () => {
-    const apayNew = jest.fn(() => ({ order_id: 'X' }))
+  it('forwards to the binding and returns the AsyncOrderNewResponse verbatim', async () => {
+    // Real apay_new (rgb-lightning-node PR #51) returns an
+    // AsyncOrderNewResponse with snake_case fields. Assert the account is a
+    // transparent passthrough that neither remaps nor drops fields.
+    const orderResp = {
+      request_id: 'req-1',
+      host_node_id: 'bb'.repeat(33),
+      protocol_version: 1,
+      order_id: 'order-9',
+      status: 'created',
+      accepted_through_index: 0,
+      next_index_expected: 1,
+      unused_hashes: ['h0', 'h1'],
+      refill_batch_size: 64,
+      first_hash_index: 0
+    }
+    const apayNew = jest.fn(() => orderResp)
     const account = makeAccount({ apayNew })
-    await expect(account.apayNew('host')).resolves.toEqual({ order_id: 'X' })
+    const out = await account.apayNew('host')
+    expect(out).toBe(orderResp)
+    expect(out.order_id).toBe('order-9')
+    expect(out.request_id).toBe('req-1')
+    expect(out.status).toBe('created')
     expect(apayNew).toHaveBeenCalledWith('host')
   })
 
@@ -366,6 +397,30 @@ describe('invoices', () => {
       .resolves.toEqual({ bolt11: 'fromBolt11', paymentHash: 'mine' })
   })
 
+  it('createHodlInvoice prefers res.invoice over res.bolt11 when BOTH are present', async () => {
+    // Precedence guard: `res?.invoice ?? res?.bolt11`. RLN's real lnInvoice
+    // returns `invoice`; a defensive `bolt11` fallback exists. With BOTH keys
+    // present the `invoice` value MUST win — swapping the operands
+    // (`bolt11 ?? invoice`) would yield 'fromBolt11' and fail this.
+    const node = makeNode({
+      lnInvoice: () => ({ invoice: 'fromInvoice', bolt11: 'fromBolt11', payment_hash: 'h' })
+    })
+    const account = makeAccount({ node })
+    await expect(account.createHodlInvoice({ paymentHash: 'mine', expirySec: 60 }))
+      .resolves.toEqual({ bolt11: 'fromInvoice', paymentHash: 'h' })
+  })
+
+  it('createHodlInvoice prefers res.payment_hash over the supplied hash', async () => {
+    // `res?.payment_hash ?? params.paymentHash`: RLN echoes back the real hash.
+    // When present it must win over the caller-supplied one.
+    const node = makeNode({
+      lnInvoice: () => ({ invoice: 'lnbc-x', payment_hash: 'rlnHash' })
+    })
+    const account = makeAccount({ node })
+    await expect(account.createHodlInvoice({ paymentHash: 'mine', expirySec: 60 }))
+      .resolves.toEqual({ bolt11: 'lnbc-x', paymentHash: 'rlnHash' })
+  })
+
   it('createHodlInvoice yields empty bolt11 when neither invoice nor bolt11 present', async () => {
     const node = makeNode({ lnInvoice: () => ({}) })
     const account = makeAccount({ node })
@@ -414,8 +469,8 @@ describe('payments', () => {
   it('getPayment forwards the hash + type', async () => {
     const node = makeNode()
     const account = makeAccount({ node })
-    await expect(account.getPayment('h', 'sent')).resolves.toEqual({ payment_hash: 'h', type: 'sent' })
-    expect(node.getPayment).toHaveBeenCalledWith('h', 'sent')
+    await expect(account.getPayment('h', 'Outbound')).resolves.toEqual({ payment_hash: 'h', type: 'Outbound' })
+    expect(node.getPayment).toHaveBeenCalledWith('h', 'Outbound')
   })
 })
 
@@ -544,11 +599,53 @@ describe('BTC ops', () => {
     expect(btcBalance).toHaveBeenCalledWith(true)
   })
 
+  it('getBalance coerces a truthy non-boolean skipSync to a real boolean', async () => {
+    // Passing the literal `true` cannot distinguish `btcBalance(!!skipSync)`
+    // from `btcBalance(skipSync)`. Pass a truthy *non-boolean* (1): under the
+    // documented `!!` coercion the node must receive the boolean `true`, NOT 1.
+    const btcBalance = jest.fn(() => ({ vanilla: { spendable: 1 } }))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await account.getBalance(1)
+    expect(btcBalance).toHaveBeenCalledWith(true)
+    // Strict identity: the argument is the primitive boolean true, not 1.
+    const arg = btcBalance.mock.calls[0][0]
+    expect(arg).toBe(true)
+    expect(typeof arg).toBe('boolean')
+  })
+
+  it('getBalance coerces a falsy non-boolean skipSync to false', async () => {
+    const btcBalance = jest.fn(() => ({ vanilla: { spendable: 1 } }))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await account.getBalance(0)
+    const arg = btcBalance.mock.calls[0][0]
+    expect(arg).toBe(false)
+    expect(typeof arg).toBe('boolean')
+  })
+
+  it('getBalance returns "0" via the absent-vanilla path (not the catch)', async () => {
+    // btcBalance succeeds but the result has no `vanilla` at all → the
+    // `?? 0` final default fires (String(0)='0'), a DIFFERENT code path than
+    // the catch-block '0'. Spy proves btcBalance was actually invoked.
+    const btcBalance = jest.fn(() => ({}))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await expect(account.getBalance()).resolves.toBe('0')
+    expect(btcBalance).toHaveBeenCalledTimes(1)
+  })
+
   it('getBalanceDetails forwards to node.btcBalance with coerced skipSync', async () => {
     const btcBalance = jest.fn(() => ({ vanilla: { spendable: 5 } }))
     const account = makeAccount({ node: makeNode({ btcBalance }) })
     await expect(account.getBalanceDetails(true)).resolves.toEqual({ vanilla: { spendable: 5 } })
     expect(btcBalance).toHaveBeenCalledWith(true)
+  })
+
+  it('getBalanceDetails coerces a truthy non-boolean skipSync to a real boolean', async () => {
+    const btcBalance = jest.fn(() => ({ vanilla: { spendable: 5 } }))
+    const account = makeAccount({ node: makeNode({ btcBalance }) })
+    await account.getBalanceDetails(1)
+    const arg = btcBalance.mock.calls[0][0]
+    expect(arg).toBe(true)
+    expect(typeof arg).toBe('boolean')
   })
 
   it('sendTransaction forwards to node.sendBtc', async () => {
@@ -566,11 +663,32 @@ describe('BTC ops', () => {
     expect(listTransactions).toHaveBeenCalledWith(true)
   })
 
+  it('getTransactions forwards skipSync RAW (no boolean coercion)', async () => {
+    // Unlike getBalance/getBalanceDetails, getTransactions passes skipSync
+    // through verbatim. A non-boolean truthy (1) must reach the node AS 1,
+    // not coerced to `true` — this catches an accidental `!!` being added.
+    const listTransactions = jest.fn(() => ({ transactions: [] }))
+    const account = makeAccount({ node: makeNode({ listTransactions }) })
+    await account.getTransactions(1)
+    const arg = listTransactions.mock.calls[0][0]
+    expect(arg).toBe(1)
+    expect(typeof arg).toBe('number')
+  })
+
   it('listUnspents forwards to node.listUnspents', async () => {
     const listUnspents = jest.fn(() => ({ unspents: [] }))
     const account = makeAccount({ node: makeNode({ listUnspents }) })
     await expect(account.listUnspents(false)).resolves.toEqual({ unspents: [] })
     expect(listUnspents).toHaveBeenCalledWith(false)
+  })
+
+  it('listUnspents forwards skipSync RAW (no boolean coercion)', async () => {
+    const listUnspents = jest.fn(() => ({ unspents: [] }))
+    const account = makeAccount({ node: makeNode({ listUnspents }) })
+    await account.listUnspents(1)
+    const arg = listUnspents.mock.calls[0][0]
+    expect(arg).toBe(1)
+    expect(typeof arg).toBe('number')
   })
 
   it('createUtxos forwards and returns { ok: true }', async () => {
@@ -605,10 +723,17 @@ describe('diagnostics / onion / signing', () => {
     expect(node.signMessage).toHaveBeenCalledWith('hello')
   })
 
-  it('checkIndexerUrl forwards the url', async () => {
-    const node = makeNode()
-    const account = makeAccount({ node })
-    await expect(account.checkIndexerUrl('http://idx')).resolves.toEqual({ ok: true, url: 'http://idx' })
+  it('checkIndexerUrl forwards the url and returns the indexer response verbatim', async () => {
+    // Pure passthrough: the account must forward the url and return whatever
+    // the node returns (the indexer's own response), not synthesise a shape.
+    // Use a realistic indexer payload and assert object identity to pin the
+    // passthrough — a mutant that wrapped/remapped the result would fail.
+    const indexerResp = { indexer_protocol: 'Electrum', block_height: 102 }
+    const checkIndexerUrl = jest.fn(() => indexerResp)
+    const account = makeAccount({ node: makeNode({ checkIndexerUrl }) })
+    const out = await account.checkIndexerUrl('http://idx')
+    expect(out).toBe(indexerResp)
+    expect(checkIndexerUrl).toHaveBeenCalledWith('http://idx')
   })
 
   it('checkProxyEndpoint forwards and returns { ok: true }', async () => {
@@ -629,19 +754,38 @@ describe('quoteSendTransaction', () => {
 })
 
 describe('_defaultFeeRate', () => {
-  it('reads fee_rate from estimateFee', async () => {
+  it('reads fee_rate from estimateFee (the real RLN shape)', async () => {
+    // Real estimateFee contract: Promise<{ fee_rate?: number }>.
     const account = makeAccount({ node: makeNode({ estimateFee: () => ({ fee_rate: 9 }) }) })
     await expect(account._defaultFeeRate(6)).resolves.toBe(9)
   })
 
-  it('reads feerate alias', async () => {
+  it('prefers fee_rate over the feerate alias when BOTH are present', async () => {
+    // Precedence in `r?.fee_rate ?? r?.feerate ?? r`: the canonical
+    // snake_case `fee_rate` must win. Reordering the operands would
+    // surface the alias (8) instead of the real field (9) and fail here.
+    const account = makeAccount({
+      node: makeNode({ estimateFee: () => ({ fee_rate: 9, feerate: 8 }) })
+    })
+    await expect(account._defaultFeeRate(6)).resolves.toBe(9)
+  })
+
+  it('reads feerate alias (defensive fallback when fee_rate absent)', async () => {
     const account = makeAccount({ node: makeNode({ estimateFee: () => ({ feerate: 8 }) }) })
     await expect(account._defaultFeeRate(6)).resolves.toBe(8)
   })
 
-  it('accepts a bare numeric estimateFee result', async () => {
+  it('accepts a bare numeric estimateFee result (final fallback arm)', async () => {
     const account = makeAccount({ node: makeNode({ estimateFee: () => 3 }) })
     await expect(account._defaultFeeRate(6)).resolves.toBe(3)
+  })
+
+  it('forwards the blocks target to estimateFee', async () => {
+    // Guards against dropping/altering the `blocks` argument in the source.
+    const estimateFee = jest.fn(() => ({ fee_rate: 9 }))
+    const account = makeAccount({ node: makeNode({ estimateFee }) })
+    await account._defaultFeeRate(6)
+    expect(estimateFee).toHaveBeenCalledWith(6)
   })
 
   it('falls back to the default rate when estimateFee returns a non-positive value', async () => {
@@ -678,39 +822,84 @@ describe('getTransactionReceipt', () => {
     await expect(account.getTransactionReceipt('def')).resolves.toBe(hit)
   })
 
-  it('falls back to a sent LN payment when not found on-chain', async () => {
+  it('falls back to an Outbound LN payment when not found on-chain', async () => {
     const sent = { payment_hash: 'ph1', amt_msat: 1 }
+    const getPayment = jest.fn((h, t) => (t === 'Outbound' ? sent : null))
     const account = makeAccount({
-      node: makeNode({
-        listTransactions: () => ({ transactions: [] }),
-        getPayment: (h, t) => (t === 'sent' ? sent : null)
-      })
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
     })
     await expect(account.getTransactionReceipt('ph1')).resolves.toBe(sent)
+    // Must use RLN's real payment-type enum, not the old HTTP 'sent' string —
+    // the C-FFI errors on any value outside Outbound/InboundAutoClaim/InboundHodl.
+    expect(getPayment).toHaveBeenCalledWith('ph1', 'Outbound')
   })
 
-  it('falls back to a received LN payment when not sent', async () => {
+  it('falls back to an InboundAutoClaim payment when not Outbound', async () => {
     const recv = { payment_hash: 'ph2' }
+    const getPayment = jest.fn((h, t) => {
+      if (t === 'Outbound') throw new Error('not an outbound payment')
+      return t === 'InboundAutoClaim' ? recv : null
+    })
     const account = makeAccount({
-      node: makeNode({
-        listTransactions: () => ({ transactions: [] }),
-        getPayment: (h, t) => {
-          if (t === 'sent') throw new Error('not a sent payment')
-          return recv
-        }
-      })
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
     })
     await expect(account.getTransactionReceipt('ph2')).resolves.toBe(recv)
+    expect(getPayment).toHaveBeenCalledWith('ph2', 'InboundAutoClaim')
   })
 
-  it('returns null when found nowhere', async () => {
+  it('falls back to an InboundHodl payment when neither Outbound nor InboundAutoClaim', async () => {
+    const hodl = { payment_hash: 'ph2b' }
+    const getPayment = jest.fn((h, t) => (t === 'InboundHodl' ? hodl : null))
     const account = makeAccount({
-      node: makeNode({
-        listTransactions: () => ({ transactions: [] }),
-        getPayment: () => { throw new Error('not found') }
-      })
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
+    })
+    await expect(account.getTransactionReceipt('ph2b')).resolves.toBe(hodl)
+    expect(getPayment).toHaveBeenCalledWith('ph2b', 'InboundHodl')
+  })
+
+  it('ignores a payment object lacking a payment_hash', async () => {
+    const getPayment = jest.fn((h, t) => (t === 'Outbound' ? { amt_msat: 5 } : null))
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
+    })
+    await expect(account.getTransactionReceipt('ph4')).resolves.toBeNull()
+  })
+
+  it('skips a hash-less InboundAutoClaim hit and continues to InboundHodl', async () => {
+    // The `recv && recv.payment_hash` guard's FALSE branch: an
+    // InboundAutoClaim object WITHOUT payment_hash must NOT be returned —
+    // the lookup keeps going and returns the InboundHodl match instead.
+    const hodl = { payment_hash: 'ph5', amt_msat: 9 }
+    const getPayment = jest.fn((h, t) => {
+      if (t === 'Outbound') return null
+      if (t === 'InboundAutoClaim') return { amt_msat: 5 } // truthy but no payment_hash
+      return t === 'InboundHodl' ? hodl : null
+    })
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
+    })
+    await expect(account.getTransactionReceipt('ph5')).resolves.toBe(hodl)
+    expect(getPayment.mock.calls.map((c) => c[1])).toEqual(['Outbound', 'InboundAutoClaim', 'InboundHodl'])
+  })
+
+  it('returns null when every payment hit lacks a payment_hash', async () => {
+    // All three guard FALSE branches: truthy objects with no payment_hash
+    // for all payment types → must end at `return null`.
+    const getPayment = jest.fn(() => ({ amt_msat: 1 }))
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
+    })
+    await expect(account.getTransactionReceipt('ph6')).resolves.toBeNull()
+    expect(getPayment.mock.calls.map((c) => c[1])).toEqual(['Outbound', 'InboundAutoClaim', 'InboundHodl'])
+  })
+
+  it('returns null when found nowhere, after trying every payment type in order', async () => {
+    const getPayment = jest.fn(() => { throw new Error('not found') })
+    const account = makeAccount({
+      node: makeNode({ listTransactions: () => ({ transactions: [] }), getPayment })
     })
     await expect(account.getTransactionReceipt('nope')).resolves.toBeNull()
+    expect(getPayment.mock.calls.map((c) => c[1])).toEqual(['Outbound', 'InboundAutoClaim', 'InboundHodl'])
   })
 
   it('continues to LN lookup when getTransactions itself throws', async () => {
@@ -718,7 +907,7 @@ describe('getTransactionReceipt', () => {
     const account = makeAccount({
       node: makeNode({
         listTransactions: () => { throw new Error('boom') },
-        getPayment: (h, t) => (t === 'sent' ? sent : null)
+        getPayment: (h, t) => (t === 'Outbound' ? sent : null)
       })
     })
     await expect(account.getTransactionReceipt('ph3')).resolves.toBe(sent)
@@ -780,6 +969,59 @@ describe('createLsp', () => {
     const account = makeAccount()
     await expect(account.createLsp()).rejects.toThrow(/lspBaseUrl not set/)
   })
+
+  it('auto-discovers the peer from lspBaseUrl via GET /get_info', async () => {
+    // No-arg form: pubkey from /get_info, host from the base URL hostname,
+    // port from the peerPort default (9735). Real LSP /get_info returns the
+    // node pubkey (hex 33-byte compressed key); stub getInfo so no network.
+    const getInfoSpy = jest.spyOn(LspClient.prototype, 'getInfo')
+      .mockResolvedValue({ pubkey: 'ab'.repeat(33), num_channels: 4 })
+    try {
+      const account = makeAccount({
+        _config: { lspBaseUrl: 'https://lsp.example:8443/api', lspBearerToken: 'tok' }
+      })
+      const lsp = await account.createLsp()
+      expect(lsp).toBeInstanceOf(UtexoLsp)
+      expect(lsp.account).toBe(account)
+      // peer must be assembled from /get_info + base URL hostname + default port.
+      expect(lsp.peer).toEqual({
+        baseUrl: 'https://lsp.example:8443/api',
+        peerPubkey: 'ab'.repeat(33),
+        peerHost: 'lsp.example',
+        peerPort: 9735,
+        bearerToken: 'tok'
+      })
+      expect(getInfoSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      getInfoSpy.mockRestore()
+    }
+  })
+
+  it('honours an explicit peerPort override in the no-arg form', async () => {
+    const getInfoSpy = jest.spyOn(LspClient.prototype, 'getInfo')
+      .mockResolvedValue({ pubkey: 'cd'.repeat(33) })
+    try {
+      const account = makeAccount({ _config: { lspBaseUrl: 'https://lsp.example' } })
+      const lsp = await account.createLsp(undefined, 9999)
+      expect(lsp.peer.peerPort).toBe(9999)
+      expect(lsp.peer.peerHost).toBe('lsp.example')
+      // No bearer token configured → undefined, not null/'' .
+      expect(lsp.peer.bearerToken).toBeUndefined()
+    } finally {
+      getInfoSpy.mockRestore()
+    }
+  })
+
+  it('throws when /get_info returns no pubkey', async () => {
+    const getInfoSpy = jest.spyOn(LspClient.prototype, 'getInfo')
+      .mockResolvedValue({ num_channels: 0 })
+    try {
+      const account = makeAccount({ _config: { lspBaseUrl: 'https://lsp.example' } })
+      await expect(account.createLsp()).rejects.toThrow(/returned no pubkey/)
+    } finally {
+      getInfoSpy.mockRestore()
+    }
+  })
 })
 
 describe('bootstrapLsp', () => {
@@ -803,6 +1045,25 @@ describe('bootstrapLsp', () => {
     const res = await account.bootstrapLsp({ peerPubkeyAndAddr: 'BAREPUBKEY', waitForPeerMs: 0 })
     expect(res).toEqual({ connect: { ok: true }, peerVisible: false })
     expect(account.connectPeer).toHaveBeenCalledWith('BAREPUBKEY')
+  })
+
+  it('treats a leading-@ string as a full pubkey (atIdx>0, not >=0) without throwing', async () => {
+    // '@host' → indexOf('@') === 0. The guard is `atIdx > 0`, so the
+    // condition is FALSE and peerPubkey becomes the FULL string '@host'
+    // (non-empty → no TypeError). If the guard were `atIdx >= 0`, the
+    // slice(0,0) would yield '' and trip the second `length === 0` guard,
+    // throwing 'must be in pubkey@host:port form'. So this must NOT throw,
+    // and the empty matcher means no peer is ever found.
+    const account = makeAccount()
+    account.connectPeer = jest.fn(async () => ({ ok: true }))
+    const listPeers = jest.fn(async () => ({ peers: [{ pubkey: '@host' }] }))
+    account.listPeers = listPeers
+    const res = await account.bootstrapLsp({ peerPubkeyAndAddr: '@host', waitForPeerMs: 1000 })
+    // peerVisible true confirms the matcher compared against the full
+    // '@host' pubkey — only possible if peerPubkey === '@host', i.e. the
+    // `atIdx > 0` (false) branch was taken.
+    expect(res).toEqual({ connect: { ok: true }, peerVisible: true })
+    expect(account.connectPeer).toHaveBeenCalledWith('@host')
   })
 
   it('connects and reports peerVisible when listPeers shows the peer immediately', async () => {
@@ -877,6 +1138,42 @@ describe('bootstrapLsp', () => {
     })
     expect(res.peerVisible).toBe(true)
     expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('clamps the poll interval to a 100ms floor for sub-floor pollIntervalMs', async () => {
+    // The source clamps: pollMs = Math.max(100, Number(pollIntervalMs) || 1000).
+    // Passing pollIntervalMs:1 (below the floor) must produce a 100ms gap
+    // between polls. Under a lowered floor (e.g. Math.max(10, …)) the second
+    // poll would already have fired by t=50ms — so we pin the exact 100ms.
+    jest.useFakeTimers()
+    try {
+      const account = makeAccount()
+      account.connectPeer = jest.fn(async () => ({ ok: true }))
+      // Never returns the peer → polling continues for the whole window.
+      account.listPeers = jest.fn(async () => ({ peers: [] }))
+      const p = account.bootstrapLsp({
+        peerPubkeyAndAddr: 'PK@host:9735',
+        waitForPeerMs: 1000,
+        pollIntervalMs: 1
+      })
+      // Let the first (immediate, t=0) poll run.
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(account.listPeers).toHaveBeenCalledTimes(1)
+      // Advance well past a 10ms floor but short of the real 100ms floor:
+      // with the correct floor NO new poll has fired yet.
+      await jest.advanceTimersByTimeAsync(50)
+      expect(account.listPeers).toHaveBeenCalledTimes(1)
+      // Reaching exactly 100ms triggers the second poll.
+      await jest.advanceTimersByTimeAsync(50)
+      expect(account.listPeers).toHaveBeenCalledTimes(2)
+      // Drain the remaining window so the promise settles cleanly.
+      await jest.advanceTimersByTimeAsync(1000)
+      const res = await p
+      expect(res.peerVisible).toBe(false)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it('tolerates a listPeers rejection during polling', async () => {
@@ -978,11 +1275,48 @@ describe('toReadOnlyAccount / ReadOnlyRgbLightningAccount', () => {
     await expect(ro.quoteSendTransaction({})).resolves.toEqual({ fee: BigInt(4 * 141) })
   })
 
-  it('quoteTransfer proxies to the account quote (LN form)', async () => {
+  it('quoteTransfer proxies to the account quote (LN bolt11 form)', async () => {
     const account = makeAccount()
     const ro = await account.toReadOnlyAccount()
     const res = await ro.quoteTransfer({ recipient: 'lnbc1abc', amount: 1000000 })
-    expect(res).toEqual({ fee: BigInt(Math.max(1, Math.ceil(1000000 * 50 / 10000))) })
+    // LN_FEE_BPS = 50 → ceil(1_000_000 * 50 / 10000) = 5000.
+    expect(res).toEqual({ fee: 5000n })
+  })
+
+  it('quoteTransfer LN ln-pubkey form also uses the bps fee, not the on-chain rate', async () => {
+    // 66-hex → classified ln-pubkey → same LN bps branch (not on-chain).
+    const account = makeAccount()
+    const ro = await account.toReadOnlyAccount()
+    const res = await ro.quoteTransfer({ recipient: 'ab'.repeat(33), amount: 2000000 })
+    // ceil(2_000_000 * 50 / 10000) = 10000.
+    expect(res).toEqual({ fee: 10000n })
+  })
+
+  it('quoteTransfer LN form floors the fee at 1 for tiny amounts', async () => {
+    // Math.max(1, …): amount 1 → ceil(1*50/10000)=ceil(0.005)=1 already, but
+    // amount 0 → ceil(0)=0 → floored to 1. Pins the Math.max(1, …) guard.
+    const account = makeAccount()
+    const ro = await account.toReadOnlyAccount()
+    const res = await ro.quoteTransfer({ recipient: 'lnbc1abc', amount: 0 })
+    expect(res).toEqual({ fee: 1n })
+  })
+
+  it('quoteTransfer on-chain (btc-address) uses estimateFee rate × 141 vbytes', async () => {
+    // btc-address branch (lines 964-966): rate × APPROX_BTC_TX_VBYTES.
+    const account = makeAccount()
+    account._defaultFeeRate = async () => 7
+    const ro = await account.toReadOnlyAccount()
+    const res = await ro.quoteTransfer({ recipient: 'tb1qsomeaddress', amount: 50000 })
+    expect(res).toEqual({ fee: BigInt(7 * 141) })
+  })
+
+  it('quoteTransfer RGB invoice routes through the on-chain quote', async () => {
+    // RGB invoices settle on-chain → same rate × 141 path, NOT the LN bps.
+    const account = makeAccount()
+    account._defaultFeeRate = async () => 3
+    const ro = await account.toReadOnlyAccount()
+    const res = await ro.quoteTransfer({ recipient: 'rgb:abc123', amount: 50000 })
+    expect(res).toEqual({ fee: BigInt(3 * 141) })
   })
 
   it('getTransactionReceipt proxies to the account lookup', async () => {


### PR DESCRIPTION
Addresses the WDK review note on low coverage — and goes further: the new tests were mutation-tested, a real bug they surfaced was fixed, and the weak spots were hardened until the suite actually catches regressions.

## Coverage
`npm run test:coverage` — **12 suites, 436 tests, all passing**, **98.6% statements / 98.4% functions / 94.1% branches** (was 14.6% / 10.6%). Six new suites, native addon mocked + `fetch` injected (no live node/network).

## Quality, measured (not just coverage)
Empirical mutation testing (apply a source mutation, run the suite, check it fails) on the proposed weak spots:

| | Kill rate |
|---|---|
| Initial suite | 24/47 = **51%** |
| After hardening | **45/46 = 97.8%** |

The one remaining survivor is a provably **equivalent mutant** (the static addon passthroughs in `node-binding` — the mock returns the same value as the mutant literal, so no test can distinguish it; not a real defect).

Hardening replaced invented fixtures with the **real wire contracts** (RLN payment-type enum, `estimateFee { fee_rate }`, `AsyncOrderNewResponse`/bootstrap payloads, snake_case LSP bodies with dual-shape fallback tests) and added exact-outcome assertions for boundaries, coercion, timing/backoff, expiry/duration math, and the LSP polling state machine.

## Real bug found + fixed
`getTransactionReceipt` looked up Lightning payments with the pre-1.0 HTTP discriminants `'sent'`/`'received'`. RLN's C-FFI (`bindings/c-ffi` `get_payment`) deserialises `payment_type` into its `Outbound | InboundAutoClaim | InboundHodl` enum and **errors on any other value** — so against a live node every LN lookup threw and `getTransactionReceipt` silently returned `null` for Lightning payments. The original test mocked the *wrong* enum and blessed the bug (100% coverage, 0% correctness). Fixed to iterate the three real types; the test now asserts the real enum and would catch a regression.

No other `src/` changes — tests only, apart from that one-line fix. Lint clean; `coverage/` gitignored.