### PR TITLE
chore(release): v0.1.0-beta.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
Version bump so the hardened test suite + bug fix from #19 can be published.

## Why
`main` carries #19 (436 tests, ~98.6% coverage, mutation kill rate 97.8%, and the `getTransactionReceipt` enum fix) but is still labelled `0.1.0-beta.12` — which is on npm with the old 43-test / 14.6% suite the WDK reviewer audited. This bumps to `0.1.0-beta.13` so the work ships.

## Release after merge
Push the tag at the merge commit:
```
git tag v0.1.0-beta.13 <merge-sha> && git push origin v0.1.0-beta.13
```
The Release workflow then publishes `0.1.0-beta.13` to npm, auto-creates GitHub release `v0.1.0-beta.13`, and marks it Latest (make_latest from #16) — no manual steps. The reviewer's `npm run test:coverage` on the new tarball will then show ~98.6%.