### PR TITLE
fix: getPayment paymentType enum + RGB send request shape; tighten types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,52 @@ export interface OpenChannelRequest {
 }
 
 // ───────────────────────────────────────────────────────────────────
+// RGB / payment vocabulary (mirrors rgb-lightning-node's C-FFI enums)
+// ───────────────────────────────────────────────────────────────────
+
+/**
+ * RLN payment-type discriminant for {@link WalletAccountRgbLightning.getPayment}.
+ * The C-FFI deserialises this into its `Outbound | InboundAutoClaim |
+ * InboundHodl` enum and errors on any other value (the pre-1.0 HTTP API's
+ * `sent`/`received` are gone).
+ */
+export type RgbPaymentType = 'Outbound' | 'InboundAutoClaim' | 'InboundHodl'
+
+/** RGB assignment discriminant accepted by RLN's `parse_assignment_kind`. */
+export type RgbAssignmentKind = 'Fungible' | 'NonFungible' | 'InflationRight' | 'ReplaceRight' | 'Any'
+
+export interface RgbSendRecipient {
+  /** Recipient id (blinded UTXO or witness) — from `decodeRgbInvoice`. */
+  recipient_id: string
+  assignment_kind: RgbAssignmentKind
+  assignment_amount?: number
+  /** Consignment transport endpoints — from `decodeRgbInvoice`. */
+  transport_endpoints: string[]
+  witness_data?: { amount_sat: number; blinding?: number }
+}
+
+/** Native `JsonSendRgbRequest` shape forwarded to RLN by `sendRgbAsset`. */
+export interface SendRgbAssetRequest {
+  donation: boolean
+  /** sat/vB. */
+  fee_rate: number
+  min_confirmations: number
+  recipient_groups: Array<{ asset_id: string; recipients: RgbSendRecipient[] }>
+}
+
+/** Native `JsonRgbInvoiceRequest` shape for `createRgbInvoice`. */
+export interface CreateRgbInvoiceRequest {
+  /** REQUIRED — RLN rejects the request on deserialise if omitted. */
+  min_confirmations: number
+  /** REQUIRED — true = witness (on-chain) receive, false = blinded. */
+  witness: boolean
+  asset_id?: string
+  assignment_kind?: RgbAssignmentKind
+  assignment_amount?: number
+  duration_seconds?: number
+}
+
+// ───────────────────────────────────────────────────────────────────
 // Config
 // ───────────────────────────────────────────────────────────────────
 
@@ -203,6 +249,8 @@ export class NodeRgbLightningBinding implements IRgbLightningBinding {
   shutdown(): void
   static healthcheck(): unknown
   static isInitialized(): boolean
+  static initialize(request: object): void
+  static shutdownGlobal(): void
 }
 
 export class BareRgbLightningBinding implements IRgbLightningBinding {
@@ -217,6 +265,10 @@ export class BareRgbLightningBinding implements IRgbLightningBinding {
   vssStatus(): VssStatus
   apayNew(hostNodeId: string): object
   shutdown(): void
+  static healthcheck(): unknown
+  static isInitialized(): boolean
+  static initialize(request: object): void
+  static shutdownGlobal(): void
 }
 
 // ───────────────────────────────────────────────────────────────────
@@ -288,7 +340,7 @@ export class WalletAccountRgbLightning {
   sendPayment(request: object): Promise<object>
   keysend(request: object): Promise<object>
   listPayments(): Promise<object>
-  getPayment(paymentHashHex: string, paymentType: 'sent' | 'received'): Promise<object>
+  getPayment(paymentHashHex: string, paymentType: RgbPaymentType): Promise<object>
 
   // RGB assets
   listAssets(filterAssetSchemas?: string[]): Promise<object>
@@ -297,9 +349,9 @@ export class WalletAccountRgbLightning {
   listTransfers(assetId?: string): Promise<object>
   refreshTransfers(request: object): Promise<{ ok: true }>
   failTransfers(request: object): Promise<object>
-  createRgbInvoice(request: object): Promise<object>
+  createRgbInvoice(request: CreateRgbInvoiceRequest | object): Promise<object>
   decodeRgbInvoice(invoice: string): Promise<object>
-  sendRgbAsset(request: object): Promise<object>
+  sendRgbAsset(request: SendRgbAssetRequest | object): Promise<object>
   getAssetMedia(digest: string): Promise<object>
   postAssetMedia(request: object): Promise<object>
 
@@ -402,7 +454,12 @@ export interface LnurlPayDiscovery {
 export interface LspBridgeResult {
   lnInvoice: string
   rgbInvoice: string
-  mappingId: string
+  /**
+   * The LSP's bridge mapping id. The raw `LspClient` / helper paths return
+   * it as the LSP sends it (a number); the composed `UtexoLsp` flows coerce
+   * it to a string. Typed as the union to reflect both call paths.
+   */
+  mappingId: string | number
 }
 
 export class LspClient {
@@ -422,18 +479,20 @@ export class LspClient {
   }): Promise<LspBridgeResult>
   lightningReceive(params: {
     lnInvoice: string
-    rgb: { assetId: string; assignment?: unknown; durationSeconds?: number; minConfirmations?: number; witness?: boolean }
+    rgb: { assetId: string; assignment?: string; durationSeconds?: number; minConfirmations?: number; witness?: boolean }
     timeoutMs?: number
   }): Promise<LspBridgeResult>
 }
 
 export class LspError extends Error {
+  constructor(endpoint: string, status: number, body: string, cause?: unknown)
   endpoint: string
   status: number
   body: string
   errorBody: object | null
   errorCode: number | string | null
   errorTag: string | null
+  cause?: unknown
 }
 
 // ───────────────────────────────────────────────────────────────────
@@ -596,5 +655,6 @@ export class LspChannelTimeoutError extends Error {
 
 export class LspSettlementError extends Error {
   step: 'ln_invoice'
-  status: ReceiveStatus
+  /** Only the terminal-failure states ever reach this error. */
+  status: 'Failed' | 'Expired'
 }

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -636,10 +636,10 @@ export default class WalletAccountRgbLightning {
   // Payments — ✅ wired
   // ==========================================================================
 
-  /** @param {Object} request - JsonSendPaymentRequest (invoice, amount_msat, ...) */
+  /** @param {Object} request - JsonSendPaymentRequest (invoice, amt_msat?, asset_id?, ...) */
   async sendPayment (request) { return this._node.sendPayment(request) }
 
-  /** @param {Object} request - JsonKeysendRequest (dest_pubkey, amount_msat, asset_id, ...) */
+  /** @param {Object} request - JsonKeysendRequest (dest_pubkey, amt_msat, asset_id?, ...) */
   async keysend (request) { return this._node.keysend(request) }
 
   async listPayments () { return this._node.listPayments() }
@@ -692,13 +692,46 @@ export default class WalletAccountRgbLightning {
   /** @param {Object} request */
   async failTransfers (request) { return this._node.failTransfers(request) }
 
-  /** @param {Object} request - JsonRgbInvoiceRequest */
+  /**
+   * Create an RGB invoice. Forwarded verbatim to RLN's `rgbInvoice`
+   * (`JsonRgbInvoiceRequest`). REQUIRED fields — RLN rejects the request on
+   * deserialise if either is omitted:
+   *   - `min_confirmations` {number}
+   *   - `witness` {boolean}  true = witness (on-chain) receive, false = blinded
+   * Optional: `asset_id`, `assignment_kind`
+   * (`'Fungible'|'NonFungible'|'InflationRight'|'ReplaceRight'|'Any'`),
+   * `assignment_amount`, `duration_seconds`.
+   * @param {Object} request - JsonRgbInvoiceRequest (see above).
+   */
   async createRgbInvoice (request) { return this._node.rgbInvoice(request) }
 
   /** @param {string} invoice */
   async decodeRgbInvoice (invoice) { return this._node.decodeRgbInvoice(invoice) }
 
-  /** @param {Object} request - JsonSendAssetRequest */
+  /**
+   * Send an RGB asset. Forwarded verbatim to RLN's `sendRgb`
+   * (`JsonSendRgbRequest`):
+   *   {
+   *     donation: boolean,
+   *     fee_rate: number,            // sat/vB
+   *     min_confirmations: number,
+   *     recipient_groups: [{
+   *       asset_id: string,
+   *       recipients: [{
+   *         recipient_id: string,           // from decodeRgbInvoice
+   *         assignment_kind: 'Fungible' | 'NonFungible' | 'InflationRight' | 'ReplaceRight' | 'Any',
+   *         assignment_amount?: number,
+   *         transport_endpoints: string[],  // from decodeRgbInvoice
+   *         witness_data?: { amount_sat: number, blinding?: number }
+   *       }]
+   *     }]
+   *   }
+   * RLN rejects the old flat `{ recipient_id, amount, asset_id }` shape on
+   * deserialise. For a simple amount-based fungible send, prefer the generic
+   * `transfer({ recipient: <rgbInvoice>, amount, token })`, which decodes the
+   * invoice and assembles this request for you.
+   * @param {Object} request - JsonSendRgbRequest (see above).
+   */
   async sendRgbAsset (request) { return this._node.sendRgb(request) }
 
   /** @param {Object} request - JsonInflateRequest */
@@ -927,12 +960,53 @@ export default class WalletAccountRgbLightning {
         return { hash: r?.txid ?? '', fee }
       }
       case 'rgb-invoice': {
-        // RGB on-chain transfer: recipient IS the rgb invoice. Asset id
-        // is encoded in it; RLN parses it server-side.
-        const req = { recipient_id: recipient }
-        if (amount !== undefined && amount !== null) req.amount = Number(amount)
-        if (assetId) req.asset_id = assetId
+        // RGB send. The recipient IS the rgb invoice, which encodes the
+        // recipient_id, the asset, and — crucially — the receiver's
+        // consignment transport endpoints. RLN's `sendRgb` does NOT
+        // re-derive any of these: it requires a nested `recipient_groups`
+        // request with explicit `transport_endpoints` (the flat
+        // `{ recipient_id, amount, asset_id }` shape this used to build is
+        // rejected on deserialise). So decode the invoice and assemble the
+        // request from it, mirroring the working rgb-sdk-rn / wdk-wallet-rgb
+        // sends. transfer() assumes a Fungible assignment (the natural case
+        // for an amount-based transfer); non-fungible or multi-recipient
+        // sends should call sendRgbAsset() with a full SendRgbAssetRequest.
+        if (amount === undefined || amount === null) {
+          throw new Error('transfer(rgb): amount (asset units) is required')
+        }
+        const decoded = await this.decodeRgbInvoice(recipient)
+        const recipientId = decoded?.recipient_id
+        if (!recipientId) {
+          throw new Error('transfer(rgb): could not decode a recipient_id from the RGB invoice')
+        }
+        const contractId = assetId ?? decoded?.asset_id
+        if (!contractId) {
+          throw new Error('transfer(rgb): asset_id missing — pass options.token or use an invoice that encodes the asset')
+        }
+        const endpoints = (Array.isArray(decoded?.transport_endpoints) && decoded.transport_endpoints.length > 0)
+          ? decoded.transport_endpoints
+          : this._defaultTransportEndpoints()
+        if (endpoints.length === 0) {
+          throw new Error('transfer(rgb): the RGB invoice carries no transport endpoints and the wallet has no proxyEndpoint configured')
+        }
+        const feeRate = options.feeRate ?? await this._defaultFeeRate(6)
+        const req = {
+          donation: false,
+          fee_rate: Number(feeRate),
+          min_confirmations: 1,
+          recipient_groups: [{
+            asset_id: contractId,
+            recipients: [{
+              recipient_id: recipientId,
+              assignment_kind: 'Fungible',
+              assignment_amount: Number(amount),
+              transport_endpoints: endpoints
+            }]
+          }]
+        }
         const r = await this.sendRgbAsset(req)
+        // RLN's send response carries the txid; the on-chain fee for an RGB
+        // transfer isn't surfaced separately, so report 0 (unchanged).
         return { hash: r?.txid ?? '', fee: BigInt(0) }
       }
       default:
@@ -1062,6 +1136,20 @@ export default class WalletAccountRgbLightning {
     } catch (_e) {
       return DEFAULT_FEE_RATE_SAT_PER_VB
     }
+  }
+
+  /**
+   * Wallet's configured RGB consignment proxy as a single-element
+   * `transport_endpoints` list — the fallback `transfer()` uses for an RGB
+   * send when the decoded invoice carries no endpoints of its own (a
+   * well-formed invoice always does, so this is defensive). Returns `[]`
+   * when no `proxyEndpoint` was set at construction.
+   * @private
+   * @returns {string[]}
+   */
+  _defaultTransportEndpoints () {
+    const cfg = (this._binding && this._binding._config) || {}
+    return cfg.proxyEndpoint ? [cfg.proxyEndpoint] : []
   }
 
   // ==========================================================================

--- a/tests/transfer-router.test.js
+++ b/tests/transfer-router.test.js
@@ -25,6 +25,13 @@ function makeAccount () {
   account.keysend = jest.fn(async () => ({ payment_hash: 'kh', fee_msat: 11 }))
   account.sendTransaction = jest.fn(async () => ({ txid: 'btctxid' }))
   account.sendRgbAsset = jest.fn(async () => ({ txid: 'rgbtxid' }))
+  // The RGB path decodes the invoice to source recipient_id / asset_id /
+  // transport_endpoints before building the native sendRgb request.
+  account.decodeRgbInvoice = jest.fn(async () => ({
+    recipient_id: 'recip123',
+    asset_id: 'assetFromInvoice',
+    transport_endpoints: ['rpc://proxy.example/json-rpc']
+  }))
   return account
 }
 
@@ -80,11 +87,73 @@ describe('WalletAccountRgbLightning.transfer', () => {
     expect(account.sendTransaction).not.toHaveBeenCalled()
   })
 
-  it('routes an RGB invoice to sendRgbAsset and reports a zero fee', async () => {
+  it('decodes the RGB invoice and sends the nested recipient_groups shape RLN requires', async () => {
     const account = makeAccount()
-    const res = await account.transfer({ recipient: RGB_INVOICE, amount: 5, token: 'asset123' })
-    expect(account.sendRgbAsset).toHaveBeenCalledWith({ recipient_id: RGB_INVOICE, amount: 5, asset_id: 'asset123' })
+    const res = await account.transfer({ recipient: RGB_INVOICE, amount: 5, token: 'asset123', feeRate: 4 })
+    expect(account.decodeRgbInvoice).toHaveBeenCalledWith(RGB_INVOICE)
+    expect(account.sendRgbAsset).toHaveBeenCalledWith({
+      donation: false,
+      fee_rate: 4,
+      min_confirmations: 1,
+      recipient_groups: [{
+        asset_id: 'asset123',
+        recipients: [{
+          recipient_id: 'recip123',
+          assignment_kind: 'Fungible',
+          assignment_amount: 5,
+          transport_endpoints: ['rpc://proxy.example/json-rpc']
+        }]
+      }]
+    })
     expect(res).toEqual({ hash: 'rgbtxid', fee: 0n })
+  })
+
+  it('falls back to the invoice-encoded asset_id when no token is supplied', async () => {
+    const account = makeAccount()
+    await account.transfer({ recipient: RGB_INVOICE, amount: 2, feeRate: 1 })
+    const sent = account.sendRgbAsset.mock.calls[0][0]
+    expect(sent.recipient_groups[0].asset_id).toBe('assetFromInvoice')
+  })
+
+  it('uses a live fee-rate estimate when feeRate is omitted', async () => {
+    const account = makeAccount()
+    account._defaultFeeRate = jest.fn(async () => 9)
+    await account.transfer({ recipient: RGB_INVOICE, amount: 1, token: 'asset123' })
+    expect(account._defaultFeeRate).toHaveBeenCalledWith(6)
+    expect(account.sendRgbAsset.mock.calls[0][0].fee_rate).toBe(9)
+  })
+
+  it('requires an amount on the RGB path', async () => {
+    const account = makeAccount()
+    await expect(account.transfer({ recipient: RGB_INVOICE, token: 'asset123' }))
+      .rejects.toThrow('transfer(rgb): amount (asset units) is required')
+    expect(account.decodeRgbInvoice).not.toHaveBeenCalled()
+    expect(account.sendRgbAsset).not.toHaveBeenCalled()
+  })
+
+  it('throws when the invoice yields no recipient_id', async () => {
+    const account = makeAccount()
+    account.decodeRgbInvoice = jest.fn(async () => ({ asset_id: 'a', transport_endpoints: ['rpc://x'] }))
+    await expect(account.transfer({ recipient: RGB_INVOICE, amount: 5, feeRate: 1 }))
+      .rejects.toThrow('could not decode a recipient_id')
+    expect(account.sendRgbAsset).not.toHaveBeenCalled()
+  })
+
+  it('throws when there are no transport endpoints and no proxy is configured', async () => {
+    const account = makeAccount()
+    account.decodeRgbInvoice = jest.fn(async () => ({ recipient_id: 'r', asset_id: 'a', transport_endpoints: [] }))
+    await expect(account.transfer({ recipient: RGB_INVOICE, amount: 5, feeRate: 1 }))
+      .rejects.toThrow('no transport endpoints')
+    expect(account.sendRgbAsset).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the wallet proxyEndpoint when the invoice carries no transport endpoints', async () => {
+    const account = makeAccount()
+    account._binding._config = { proxyEndpoint: 'rpc://wallet-proxy/json-rpc' }
+    account.decodeRgbInvoice = jest.fn(async () => ({ recipient_id: 'r', asset_id: 'a', transport_endpoints: [] }))
+    await account.transfer({ recipient: RGB_INVOICE, amount: 5, feeRate: 1 })
+    const sent = account.sendRgbAsset.mock.calls[0][0]
+    expect(sent.recipient_groups[0].recipients[0].transport_endpoints).toEqual(['rpc://wallet-proxy/json-rpc'])
   })
 })
 


### PR DESCRIPTION
## What

Fixes the `getPayment` paymentType type Andrea reported, plus a related (higher-severity) RGB send bug found while auditing for similar issues, plus a set of `index.d.ts` accuracy cleanups.

### A1 — `getPayment` paymentType (the reported bug)
`index.d.ts` declared `paymentType: 'sent' | 'received'` — the pre-1.0 HTTP API vocabulary. RLN's C-FFI requires `'Outbound' | 'InboundAutoClaim' | 'InboundHodl'` and errors on anything else (`unknown variant 'received'`). The runtime JSDoc and `getTransactionReceipt` were already corrected in beta.13; only the `.d.ts` type was left stale, so TypeScript callers still autocompleted the wrong values. Now uses an exported `RgbPaymentType`.

### A2 — `transfer()` RGB path (found during the audit)
`transfer({ recipient: <rgbInvoice>, amount, token })` built a flat `{ recipient_id, amount, asset_id }` and passed it to `sendRgb` — but RLN's `JsonSendRgbRequest` needs a nested `recipient_groups` shape plus required `donation` / `fee_rate` / `min_confirmations`, so it was rejected on deserialise (the unit test mocked `sendRgbAsset`, which hid it). It now decodes the invoice to source `recipient_id` / `asset_id` / `transport_endpoints` and assembles the correct request (Fungible assignment; `fee_rate` from `feeRate` or a live estimate; `min_confirmations` 1), modeled on the working `rgb-sdk-rn` and `wdk-wallet-rgb` sends. Falls back to the wallet's `proxyEndpoint` when the invoice carries no transport endpoints.

### A3 — RGB invoice/send docs + types
`createRgbInvoice` JSDoc now documents the required `min_confirmations` / `witness` fields and the `assignment_kind` enum; added `CreateRgbInvoiceRequest` and `SendRgbAssetRequest` interfaces. `sendRgbAsset` JSDoc documents the real `JsonSendRgbRequest` (it was labelled with a nonexistent `JsonSendAssetRequest`).

### B — `index.d.ts` accuracy
`LspBridgeResult.mappingId: string | number` (raw client returns a number, `UtexoLsp` coerces to string); `rgb.assignment: string`; `LspError` declares its `(endpoint, status, body, cause)` constructor and `cause` field; binding classes declare their static methods; `LspSettlementError.status` narrowed to `'Failed' | 'Expired'`; `keysend`/`sendPayment` JSDoc corrected to `amt_msat`.

## Verification
- `npm test` -> 442 pass (was 436). The transfer-router RGB test asserted the rejected flat shape; rewritten to assert the correct nested `recipient_groups` request, plus 6 edge cases (missing amount, undecodable invoice, missing endpoints, proxy fallback, live fee-rate, invoice asset_id fallback).
- `npm run lint` clean.
- `index.d.ts` type-checks under `tsc --strict`; a consumer with `@ts-expect-error` on `getPayment(h, 'sent')` confirms the old values are now compile errors.

## A2 validated against a live rgb-lightning-node (regtest)

A2 is no longer mock-only. It was exercised end-to-end against a running regtest stack (bitcoind / electrs / rgb-proxy / peer RLN), driving the in-process node via the napi binding so this branch's code is what ran. Deterministic across two runs:

- The device received a real NIA asset from the peer, then called `transfer({ recipient: <peerRgbInvoice>, amount, token })`.
- RLN's `send_rgb_from_groups` accepted and parsed the nested `recipient_groups` request (`assignment_kind` `Fungible`, contract id, `transport_endpoints`) and `send_begin` built and broadcast a real RGB transfer tx (a fresh txid each run).

This is the conclusive signal: the old flat shape was serde-rejected before any txid existed (`missing field recipient_groups`); the new shape is accepted and executed. The request-shape bug this PR fixes is gone.

Separate, pre-existing, out of scope for this PR: after the tx is broadcast, the send fails at RLN's external-signer `send_end` step with `Rln(Internal): UnknownTransfer { txid }` (rgb-lib `get_transfer_end_data`, the `*Begin -> sign -> *End` PSBT-split path). It is deterministic, downstream of and independent from the wdk request shape, and is an rgb-lightning-node concern — the device-side RGB send will not fully settle until it is fixed upstream. Tracking that separately with the RLN team.

No version bump in this PR — the beta.14 bump + tag follows.