### PR TITLE
chore(release): prepare v0.1.0-beta.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
Version bump 0.1.0-beta.13 -> 0.1.0-beta.14.

Ships the fixes merged in #21:
- A1: getPayment paymentType type corrected to RgbPaymentType ('Outbound' | 'InboundAutoClaim' | 'InboundHodl'). Closes the issue Andrea reported.
- A2: transfer() RGB path now builds RLN's nested recipient_groups request instead of the rejected flat shape. Validated end-to-end against a live rgb-lightning-node on regtest (request accepted + RGB tx broadcast).
- A3: createRgbInvoice / sendRgbAsset docs + CreateRgbInvoiceRequest / SendRgbAssetRequest types.
- B: index.d.ts accuracy (mappingId, rgb.assignment, LspError ctor/cause, binding statics, LspSettlementError.status, keysend/sendPayment JSDoc).

After merge: tag v0.1.0-beta.14 at the merge commit -> release.yml publishes to npm and creates the GitHub release as Latest.