### PR TITLE
fix: address WDK package review feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,8 +116,9 @@ while pre-`1.0`.
   default, and never resolve an external domain as a same-named LSP user.
 - Removed the binding `node` getter in favor of consistent `ensureNode()`
   access. Bare and Node bindings now retain signer seeds in zeroizable
-  buffers and wipe both current and #26 legacy-fallback material during
-  replacement, successful unlock, and shutdown failure paths.
+  buffers, wipe fallback material when it is superseded or no longer needed,
+  wipe replaced primary material after fallback recovery, and wipe all retained
+  material during shutdown even when native cleanup fails.
 - `waitForOutboundLiquidity()` now throws `LspLiquidityTimeoutError` when
   its deadline expires instead of resolving without the requested capacity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ while pre-`1.0`.
   Parity with `rgb-sdk-rn`'s `createHodlInvoice`.
 - TS declarations extended for all of the above (`UtexoLsp`, `LspPeer`,
   `WaitOptions`, `ReceiveStatus`, `ChannelReadyInfo`,
-  `CreateHodlInvoiceParams`, the two new error classes, etc.).
+  `CreateHodlInvoiceParams`, the LSP timeout/settlement error classes, etc.).
 - **`virtualPeerPubkeys` config** — plumbed through manager → binding →
   init request (`virtual_peer_pubkeys`). Required (together with
   `enableVirtualChannelsV0`) for async-payments against a production
@@ -108,6 +108,18 @@ while pre-`1.0`.
 - Removed a duplicate `apayNew` method definition in both
   `node-binding.js` and `bare-binding.js` (the shadowed first copy
   used `this.node`, which throws pre-unlock).
+- Consolidated LSP wire-shape and uint conversion helpers. Fractional,
+  unsafe, negative, and overflowing uint values now fail predictably;
+  `lightningReceive()` sends the documented default RGB assignment `Any`.
+- Hardened Lightning Address resolution: generic flows reuse the shared
+  LNURL implementation, constrain callbacks to the discovery host by
+  default, and never resolve an external domain as a same-named LSP user.
+- Removed the binding `node` getter in favor of consistent `ensureNode()`
+  access. Bare and Node bindings now retain signer seeds in zeroizable
+  buffers and wipe both current and #26 legacy-fallback material during
+  replacement, successful unlock, and shutdown failure paths.
+- `waitForOutboundLiquidity()` now throws `LspLiquidityTimeoutError` when
+  its deadline expires instead of resolving without the requested capacity.
 
 ### Changed
 - README: tightened the *"Why a separate module from `wdk-wallet-rgb`?"*

--- a/README.md
+++ b/README.md
@@ -318,13 +318,17 @@ Key methods: `connect()`, `waitForChannel(assetId, opts?)`,
 `receiveAsset(opts)`, `awaitReceiveSettlement(lnInvoice, opts?)`,
 `waitForOutboundLiquidity(minMsat, opts?)`, `sendAsset(opts)`,
 `payAddress(opts)`, `enableLightningAddress()`, `claimPendingPayments()`.
-Timeouts throw `LspChannelTimeoutError` / `LspSettlementError`.
+Channel and liquidity wait timeouts throw `LspChannelTimeoutError` and
+`LspLiquidityTimeoutError`; terminal settlement failures throw
+`LspSettlementError`.
 
 ### LNURL / Lightning Address helpers
 
 `parseLightningAddress`, `fetchDiscovery`, `resolveAddressToInvoice`
 (LNURL-pay), and the account-bound helpers `payLightningAddress`,
 `requestLspRgbDeposit`, `payRgbViaLsp` are also exported from the root.
+LNURL callbacks are restricted to the discovery host by default; delegated
+cross-host callbacks require the explicit `allowCrossHostCallback: true` opt-in.
 
 ## VSS cloud backup
 
@@ -375,7 +379,9 @@ the wallet's behalf. Against a production LSP this requires
   keeps the LDK node identity stable across restarts.
 - **All channel-state crypto runs in-process** through
   [`vls-protocol-signer`][vls]. The signer's lifecycle is tied to the
-  binding and is destroyed on `manager.dispose()`.
+  binding and is destroyed on `manager.dispose()`. Retained seed copies use
+  zeroizable buffers and are erased with `sodium_memzero` on successful
+  fallback resolution and shutdown, including cleanup failure paths.
 - **VSS payloads are client-side encrypted** (see above); the server only
   ever holds ciphertext.
 - **Plain `http://` is rejected by default** for VSS and LSP endpoints; opt

--- a/index-bare.js
+++ b/index-bare.js
@@ -53,6 +53,7 @@ export {
 export {
   UtexoLsp,
   LspChannelTimeoutError,
+  LspLiquidityTimeoutError,
   LspSettlementError,
   peerUri,
   normalizeReceiveStatus

--- a/index-node.js
+++ b/index-node.js
@@ -53,6 +53,7 @@ export {
 export {
   UtexoLsp,
   LspChannelTimeoutError,
+  LspLiquidityTimeoutError,
   LspSettlementError,
   peerUri,
   normalizeReceiveStatus

--- a/index.d.ts
+++ b/index.d.ts
@@ -647,6 +647,8 @@ export interface PayAddressOptions {
   address: string
   amtMsat: bigint | number | string
   asset?: { assetId: string; assetAmount: bigint | number | string }
+  /** Opt in to following a delegated LNURL callback on a different host. */
+  allowCrossHostCallback?: boolean
 }
 
 export interface LightningAddressInfo {

--- a/index.d.ts
+++ b/index.d.ts
@@ -243,7 +243,6 @@ export interface IRgbLightningBinding {
   ensureNode(): unknown
   attachExternalSigner(seedHex: string, fallbackSeedHex?: string): void
   unlock(unlockRequest: object): void
-  readonly node: unknown
   bootstrap(): object
   clearVssFence(password: string): void
   vssBackup(): { version: number }
@@ -257,7 +256,6 @@ export class NodeRgbLightningBinding implements IRgbLightningBinding {
   ensureNode(): unknown
   attachExternalSigner(seedHex: string, fallbackSeedHex?: string): void
   unlock(unlockRequest: object): void
-  readonly node: unknown
   bootstrap(): object
   clearVssFence(password: string): void
   vssBackup(): { version: number }
@@ -275,7 +273,6 @@ export class BareRgbLightningBinding implements IRgbLightningBinding {
   ensureNode(): unknown
   attachExternalSigner(seedHex: string, fallbackSeedHex?: string): void
   unlock(unlockRequest: object): void
-  readonly node: unknown
   bootstrap(): object
   clearVssFence(password: string): void
   vssBackup(): { version: number }
@@ -495,14 +492,14 @@ export class LspClient {
   health(opts?: { timeoutMs?: number }): Promise<object>
   getInfo(opts?: { timeoutMs?: number }): Promise<object>
   lnurlDiscovery(username: string, opts?: { timeoutMs?: number }): Promise<LnurlPayDiscovery>
-  lnurlCallback(username: string, amountMsat: bigint | number, opts?: { assetId?: string; assetAmount?: number; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[] }>
+  lnurlCallback(username: string, amountMsat: bigint | number | string, opts?: { assetId?: string; assetAmount?: bigint | number | string; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[] }>
   /** Full LUD-06 resolution routed through this LSP's baseUrl (discovery + callback). */
-  resolveAddress(username: string, amountMsat: bigint | number, opts?: { assetId?: string; assetAmount?: bigint | number; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[]; status?: string; reason?: string }>
+  resolveAddress(username: string, amountMsat: bigint | number | string, opts?: { assetId?: string; assetAmount?: bigint | number | string; timeoutMs?: number }): Promise<{ pr: string; routes?: unknown[]; status?: string; reason?: string }>
   /** Resolve the auto-assigned Lightning Address for a node pubkey (post-apayNew). */
   getLightningAddressByPubkey(peerPubkey: string, opts?: { timeoutMs?: number }): Promise<{ username: string; domain: string }>
   onchainSend(params: {
     rgbInvoice: string
-    ln: { amtMsat: bigint | number; expirySec: number; assetId?: string; assetAmount?: number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+    ln: { amtMsat: bigint | number | string; expirySec: number; assetId?: string; assetAmount?: bigint | number | string; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
     timeoutMs?: number
   }): Promise<LspBridgeResult>
   lightningReceive(params: {
@@ -528,8 +525,19 @@ export class LspError extends Error {
 // ───────────────────────────────────────────────────────────────────
 
 export function parseLightningAddress(addr: string, opts?: { allowHttp?: boolean }): { username: string; host: string; discoveryUrl: string }
-export function fetchDiscovery(addr: string, opts?: { fetch?: typeof fetch; timeoutMs?: number; allowHttp?: boolean }): Promise<LnurlPayDiscovery>
-export function resolveAddressToInvoice(addr: string, amountMsat: bigint | number, opts?: { fetch?: typeof fetch; timeoutMs?: number; allowHttp?: boolean; comment?: string }): Promise<{ pr: string; routes?: unknown[]; discovery: LnurlPayDiscovery; callbackUrl: string }>
+export interface LnurlPayOptions {
+  fetch?: typeof fetch
+  timeoutMs?: number
+  allowHttp?: boolean
+  /** Opt in to following a callback on a different host than discovery. */
+  allowCrossHostCallback?: boolean
+  comment?: string
+  assetId?: string
+  assetAmount?: bigint | number | string
+}
+
+export function fetchDiscovery(addr: string, opts?: Pick<LnurlPayOptions, 'fetch' | 'timeoutMs' | 'allowHttp'>): Promise<LnurlPayDiscovery>
+export function resolveAddressToInvoice(addr: string, amountMsat: bigint | number | string, opts?: LnurlPayOptions): Promise<{ pr: string; routes?: unknown[]; discovery: LnurlPayDiscovery; callbackUrl: string }>
 
 export class LnurlPayError extends Error {
   status?: number
@@ -540,13 +548,9 @@ export class LnurlPayError extends Error {
 // LSP helpers (account + LSP combined flows)
 // ───────────────────────────────────────────────────────────────────
 
-export interface PayLightningAddressOptions {
-  fetch?: typeof fetch
-  timeoutMs?: number
-  allowHttp?: boolean
-  comment?: string
+export interface PayLightningAddressOptions extends LnurlPayOptions {
   skipAmount?: boolean
-  beforePay?: (invoice: string, ctx: { discovery: LnurlPayDiscovery; callbackUrl: string }) => void | Promise<void>
+  beforePay?: (invoice: string, discovery: LnurlPayDiscovery) => void | Promise<void>
 }
 
 export interface PayLightningAddressResult {
@@ -569,7 +573,7 @@ export type LspRgbDepositResult = LspBridgeResult
 export interface PayRgbViaLspArgs {
   lsp: string | LspClient
   rgbInvoice: string
-  ln: { amtMsat: bigint | number; expirySec: number; assetId?: string; assetAmount?: number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+  ln: { amtMsat: bigint | number | string; expirySec: number; assetId?: string; assetAmount?: bigint | number | string; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
   lspOpts?: { timeoutMs?: number }
 }
 
@@ -577,7 +581,7 @@ export interface PayRgbViaLspResult extends LspBridgeResult {
   sendResult: object
 }
 
-export function payLightningAddress(account: WalletAccountRgbLightning, addr: string, amountMsat: bigint | number, opts?: PayLightningAddressOptions): Promise<PayLightningAddressResult>
+export function payLightningAddress(account: WalletAccountRgbLightning, addr: string, amountMsat: bigint | number | string, opts?: PayLightningAddressOptions): Promise<PayLightningAddressResult>
 export function requestLspRgbDeposit(account: WalletAccountRgbLightning, args: RequestLspRgbDepositArgs): Promise<LspRgbDepositResult>
 export function payRgbViaLsp(account: WalletAccountRgbLightning, args: PayRgbViaLspArgs): Promise<PayRgbViaLspResult>
 
@@ -632,7 +636,7 @@ export interface ReceiveAssetResult {
 
 export interface SendAssetOptions {
   rgbInvoice: string
-  ln?: { amtMsat?: bigint | number; expirySec?: number; assetId?: string; assetAmount?: bigint | number; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
+  ln?: { amtMsat?: bigint | number | string; expirySec?: number; assetId?: string; assetAmount?: bigint | number | string; descriptionHash?: string; paymentHash?: string; minFinalCltvExpiryDelta?: number }
 }
 
 export interface SendAssetResult extends LspBridgeResult {
@@ -641,8 +645,8 @@ export interface SendAssetResult extends LspBridgeResult {
 
 export interface PayAddressOptions {
   address: string
-  amtMsat: bigint | number
-  asset?: { assetId: string; assetAmount: number }
+  amtMsat: bigint | number | string
+  asset?: { assetId: string; assetAmount: bigint | number | string }
 }
 
 export interface LightningAddressInfo {
@@ -677,11 +681,20 @@ export function peerUri(peer: LspPeer): string
 export function normalizeReceiveStatus(raw: string | { status?: string } | null | undefined): ReceiveStatus
 
 export class LspChannelTimeoutError extends Error {
+  constructor(assetId: string, elapsedMs: number)
   assetId: string
   elapsedMs: number
 }
 
+export class LspLiquidityTimeoutError extends Error {
+  constructor(minMsat: number, elapsedMs: number, peerPubkey: string)
+  minMsat: number
+  elapsedMs: number
+  peerPubkey: string
+}
+
 export class LspSettlementError extends Error {
+  constructor(step: 'ln_invoice', status: 'Failed' | 'Expired')
   step: 'ln_invoice'
   /** Only the terminal-failure states ever reach this error. */
   status: 'Failed' | 'Expired'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@tetherto/wdk-wallet": "1.0.0-beta.14",
         "bare-node-runtime": "1.2.0",
-        "bip39": "3.1.0"
+        "bip39": "3.1.0",
+        "sodium-universal": "5.0.1"
       },
       "devDependencies": {
         "cross-env": "7.0.3",
@@ -7628,6 +7629,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8385,6 +8417,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "license": "Apache-2.0"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@tetherto/wdk-wallet": "1.0.0-beta.14",
     "bare-node-runtime": "1.2.0",
-    "bip39": "3.1.0"
+    "bip39": "3.1.0",
+    "sodium-universal": "5.0.1"
   },
   "peerDependencies": {
     "@utexo/rgb-lightning-node-bare": ">=0.1.0-beta.14 <0.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "<rootDir>/jest.setup.js"
     ],
     "moduleNameMapper": {
-      "^@utexo/rgb-lightning-node-nodejs$": "<rootDir>/tests/__mocks__/rgb-lightning-node-nodejs.mjs"
+      "^@utexo/rgb-lightning-node-nodejs$": "<rootDir>/tests/__mocks__/rgb-lightning-node-nodejs.mjs",
+      "^@utexo/rgb-lightning-node-bare$": "<rootDir>/tests/__mocks__/rgb-lightning-node-bare.mjs"
     }
   },
   "exports": {

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -24,6 +24,7 @@
 //   restarts.
 
 import rln from '@utexo/rgb-lightning-node-bare'
+import { retainSecret, revealSecret, secretMatches, wipeSecret } from './secret-buffer.js'
 
 const {
   SdkNode,
@@ -47,6 +48,7 @@ function isExternalSignerIdentityMismatch (message) {
  * @property {number} [ldkPeerListeningPort=0]
  * @property {number} [maxMediaUploadSizeMb=5]
  * @property {boolean} [enableVirtualChannelsV0=false]
+ * @property {string[]} [virtualPeerPubkeys] - trusted virtual-channel peer node IDs
  * @property {boolean} [permissiveSignerPolicy=true] - VLS policy filter;
  *   pass `false` to enforce the full simple policy. Defaults to
  *   permissive for in-process use.
@@ -68,7 +70,7 @@ function isExternalSignerIdentityMismatch (message) {
  *   2. `binding.attachExternalSigner(seedHex)`   - builds the signer
  *   3. `binding.unlock(unlockRequest)`           - first call: init+unlock
  *                                                  next:        attach+unlock
- *   4. `binding.node`                            - SdkNode (after unlock)
+ *   4. `binding.ensureNode()`                    - cached SdkNode handle
  *   5. `binding.shutdown()`                      - idempotent stop
  */
 export class BareRgbLightningBinding {
@@ -110,6 +112,10 @@ export class BareRgbLightningBinding {
     this._node = null
     /** @type {NativeExternalSigner | null} */
     this._signer = null
+    /** @type {Buffer | undefined} Zeroizable retained copy for idempotency checks. */
+    this._seedHex = undefined
+    /** @type {Buffer | undefined} Temporary legacy seed retained until first unlock. */
+    this._fallbackSeedHex = undefined
     /** @type {boolean} */
     this._sdkInitDone = false
     /** @type {number | null} Snapshot version returned by the most recent vssBackup(). */
@@ -139,13 +145,16 @@ export class BareRgbLightningBinding {
    */
   attachExternalSigner (seedHex, fallbackSeedHex) {
     if (this._signer) {
-      if (this._seedHex && this._seedHex !== seedHex) {
+      if (this._seedHex && !secretMatches(this._seedHex, seedHex)) {
         throw new Error(
           'attachExternalSigner: a different signer is already attached. ' +
           'Shut down the binding before re-attaching with a new seed.'
         )
       }
-      if (fallbackSeedHex) this._fallbackSeedHex = fallbackSeedHex
+      if (fallbackSeedHex) {
+        wipeSecret(this._fallbackSeedHex)
+        this._fallbackSeedHex = retainSecret(fallbackSeedHex)
+      }
       return
     }
     this._signer = NativeExternalSigner.create(
@@ -153,8 +162,10 @@ export class BareRgbLightningBinding {
       this._config.network,
       this._config.permissiveSignerPolicy ?? true
     )
-    this._seedHex = seedHex
-    this._fallbackSeedHex = fallbackSeedHex
+    wipeSecret(this._seedHex)
+    wipeSecret(this._fallbackSeedHex)
+    this._seedHex = retainSecret(seedHex)
+    this._fallbackSeedHex = retainSecret(fallbackSeedHex)
   }
 
   /**
@@ -188,6 +199,7 @@ export class BareRgbLightningBinding {
     }
     try {
       node.unlockWithNativeExternalSigner(this._signer, unlockRequest)
+      wipeSecret(this._fallbackSeedHex)
       this._fallbackSeedHex = undefined
     } catch (error) {
       const message = String(error && error.message ? error.message : error)
@@ -195,22 +207,19 @@ export class BareRgbLightningBinding {
         throw error
       }
 
-      this._signer.destroy()
-      this._signer = NativeExternalSigner.create(
-        this._fallbackSeedHex,
+      const fallbackSeed = this._fallbackSeedHex
+      const fallbackSigner = NativeExternalSigner.create(
+        revealSecret(fallbackSeed),
         this._config.network,
         this._config.permissiveSignerPolicy ?? true
       )
-      this._seedHex = this._fallbackSeedHex
+      this._signer.destroy()
+      this._signer = fallbackSigner
+      wipeSecret(this._seedHex)
+      this._seedHex = fallbackSeed
       this._fallbackSeedHex = undefined
       node.unlockWithNativeExternalSigner(this._signer, unlockRequest)
     }
-  }
-
-  /** @returns {SdkNode} */
-  get node () {
-    if (!this._node) throw new Error('SdkNode not created — call unlock() first')
-    return this._node
   }
 
   /**
@@ -247,7 +256,8 @@ export class BareRgbLightningBinding {
    * @returns {{version: number}}
    */
   vssBackup () {
-    const r = this.node.vssBackup()
+    const node = this.ensureNode()
+    const r = node.vssBackup()
     if (r && typeof r.version === 'number') this._lastVssVersion = r.version
     return r
   }
@@ -292,17 +302,31 @@ export class BareRgbLightningBinding {
 
   /** Best-effort shutdown. Idempotent. */
   shutdown () {
+    let failure
     if (this._node) {
-      this._node.shutdown()
-      this._node = null
+      try {
+        this._node.shutdown()
+      } catch (error) {
+        failure = error
+      } finally {
+        this._node = null
+      }
     }
     if (this._signer) {
-      this._signer.destroy()
-      this._signer = null
+      try {
+        this._signer.destroy()
+      } catch (error) {
+        failure ??= error
+      } finally {
+        this._signer = null
+      }
     }
     this._sdkInitDone = false
+    wipeSecret(this._seedHex)
+    wipeSecret(this._fallbackSeedHex)
     this._seedHex = undefined
     this._fallbackSeedHex = undefined
+    if (failure) throw failure
   }
 
   /** @returns {string} */

--- a/src/bare-binding.js
+++ b/src/bare-binding.js
@@ -213,7 +213,19 @@ export class BareRgbLightningBinding {
         this._config.network,
         this._config.permissiveSignerPolicy ?? true
       )
-      this._signer.destroy()
+      try {
+        this._signer.destroy()
+      } catch (primaryDestroyError) {
+        try {
+          fallbackSigner.destroy()
+        } catch (fallbackDestroyError) {
+          throw new AggregateError(
+            [primaryDestroyError, fallbackDestroyError],
+            'unlock: failed to destroy both the primary and fallback signers'
+          )
+        }
+        throw primaryDestroyError
+      }
       this._signer = fallbackSigner
       wipeSecret(this._seedHex)
       this._seedHex = fallbackSeed

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -74,8 +74,6 @@
  * @property {(unlockRequest: object) => void}          unlock
  *   First call: init+unlock against a fresh dataDir. Later calls swallow
  *   the expected `Rln(Conflict)` from init and proceed with unlock.
- * @property {unknown}                                  node
- *   The `SdkNode` handle (getter). Throws if `unlock()` has not run.
  * @property {() => object}                             bootstrap
  *   Returns the signer's bootstrap payload (node_id, xpubs, master_fp).
  * @property {(password: string) => void}               clearVssFence
@@ -108,4 +106,4 @@
  *   Idempotent stop — releases the node handle + destroys the signer.
  */
 
-export const __SHAPE_ONLY = true
+export {}

--- a/src/errors.js
+++ b/src/errors.js
@@ -15,14 +15,15 @@
 // verbatim (so any existing substring checks keep working) and the
 // underlying error as `cause`.
 //
-// Mirrors the shape of `LspError` (see lsp-client.js): a base class
-// with `name`/`code`/`cause` + `toJSON()` for structured logging, and
-// purpose-specific subclasses for the boundaries we wrap.
+// This hierarchy is independent from the HTTP-specific `LspError` in
+// lsp-client.js. It adds a stable SDK `code` and structured `toJSON()`
+// contract for RLN-backed account operations.
 
 /**
- * Base class for all errors raised by this SDK. Carries a stable
- * machine-readable `code`, the optional originating `cause`, and a
- * `toJSON()` for structured logging.
+ * Base class for typed RLN account-operation errors. HTTP/LNURL errors use
+ * their protocol-specific `LspError` and `LnurlPayError` classes instead.
+ * Carries a stable machine-readable `code`, the optional originating
+ * `cause`, and a `toJSON()` for structured logging.
  */
 export class RgbLightningError extends Error {
   /**

--- a/src/lnurl-pay.js
+++ b/src/lnurl-pay.js
@@ -4,6 +4,8 @@
 // you may not use this file except in compliance with the License.
 'use strict'
 
+import { toUint64String } from './lsp-utils.js'
+
 // Generic LUD-06 (Lightning Address) client. NOT utexo-lsp specific:
 // any LNURL-pay server that follows the spec works. We split this out
 // from LspClient so a wallet can pay an external Lightning Address
@@ -113,9 +115,7 @@ export async function fetchDiscovery (addr, opts = {}) {
   if (typeof fetcher !== 'function') {
     throw new LnurlPayError('fetchDiscovery: no global fetch; pass opts.fetch')
   }
-  const url = addr.startsWith('http://') || addr.startsWith('https://')
-    ? addr
-    : parseLightningAddress(addr, opts).discoveryUrl
+  const url = discoveryUrlFor(addr, opts)
 
   const data = await fetchJson(fetcher, url, {
     signal: timeoutSignal(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
@@ -137,7 +137,13 @@ export async function fetchDiscovery (addr, opts = {}) {
  * @param {typeof fetch} [opts.fetch]
  * @param {number} [opts.timeoutMs]
  * @param {boolean} [opts.allowHttp]
+ * @param {boolean} [opts.allowCrossHostCallback=false]
+ *   Permit a callback on a host other than the discovery endpoint.
+ *   Disabled by default to prevent a discovery document from redirecting
+ *   the wallet's authenticated network access to an unrelated host.
  * @param {string} [opts.comment]   LUD-12 comment (server-policy gated).
+ * @param {string} [opts.assetId]   Optional RGB asset extension.
+ * @param {bigint|number|string} [opts.assetAmount]
  * @returns {Promise<{ pr:string, routes:Array, discovery:LnurlPayDiscovery, callbackUrl:string }>}
  */
 export async function resolveAddressToInvoice (addr, amountMsat, opts = {}) {
@@ -146,12 +152,16 @@ export async function resolveAddressToInvoice (addr, amountMsat, opts = {}) {
     throw new LnurlPayError('resolveAddressToInvoice: no global fetch; pass opts.fetch')
   }
 
-  const discovery = await fetchDiscovery(addr, opts)
-  const amount = toIntString(amountMsat, 'amountMsat')
+  const discoveryUrl = discoveryUrlFor(addr, opts)
+  const discovery = await fetchDiscovery(discoveryUrl, opts)
+  assertCallbackOrigin(discovery.callback, discoveryUrl, opts)
+  const amount = asUint64String(amountMsat, 'amountMsat')
   enforceRange(amount, discovery)
 
   const callbackUrl = appendQuery(discovery.callback, {
     amount,
+    ...(opts.assetId !== undefined ? { asset_id: String(opts.assetId) } : {}),
+    ...(opts.assetAmount !== undefined ? { asset_amount: asUint64String(opts.assetAmount, 'assetAmount') } : {}),
     ...(opts.comment ? { comment: opts.comment } : {})
   })
 
@@ -207,12 +217,21 @@ function validateDiscovery (data, url) {
   if (data.tag !== 'payRequest') {
     throw new LnurlPayError(`LUD-06 discovery: expected tag='payRequest', got '${data.tag}'`)
   }
-  if (typeof data.callback !== 'string' || !/^https?:\/\//i.test(data.callback)) {
+  if (typeof data.callback !== 'string' || !isHttpUrl(data.callback)) {
     throw new LnurlPayError(`LUD-06 discovery: invalid callback '${data.callback}'`)
   }
-  const min = numOrNull(data.minSendable)
-  const max = numOrNull(data.maxSendable)
-  if (min == null || max == null || min > max || min <= 0) {
+  let min
+  let max
+  try {
+    min = BigInt(toUint64String(data.minSendable, 'minSendable'))
+    max = BigInt(toUint64String(data.maxSendable, 'maxSendable'))
+  } catch (cause) {
+    throw new LnurlPayError(
+      `LUD-06 discovery: invalid sendable range min=${data.minSendable} max=${data.maxSendable}`,
+      { cause }
+    )
+  }
+  if (min > max || min === 0n) {
     throw new LnurlPayError(`LUD-06 discovery: invalid sendable range min=${data.minSendable} max=${data.maxSendable}`)
   }
   if (typeof data.metadata !== 'string') {
@@ -223,32 +242,64 @@ function validateDiscovery (data, url) {
 function enforceRange (amountStr, d) {
   // Compare as BigInt to avoid 2^53 truncation on large msat values.
   const amount = BigInt(amountStr)
-  if (amount < BigInt(d.minSendable) || amount > BigInt(d.maxSendable)) {
+  const min = BigInt(asUint64String(d.minSendable, 'minSendable'))
+  const max = BigInt(asUint64String(d.maxSendable, 'maxSendable'))
+  if (amount < min || amount > max) {
     throw new LnurlPayError(`amount ${amountStr} outside server range [${d.minSendable}, ${d.maxSendable}]`)
   }
 }
 
 function appendQuery (url, params) {
-  const sep = url.includes('?') ? '&' : '?'
-  const enc = new URLSearchParams()
-  for (const [k, v] of Object.entries(params)) enc.set(k, String(v))
-  return `${url}${sep}${enc.toString()}`
+  const callback = new URL(url)
+  for (const [key, value] of Object.entries(params)) callback.searchParams.set(key, String(value))
+  return callback.toString()
 }
 
-function toIntString (v, field) {
-  if (typeof v === 'bigint') {
-    if (v < 0n) throw new LnurlPayError(`${field} must be ≥ 0`)
-    return v.toString()
+function discoveryUrlFor (addr, opts) {
+  if (typeof addr !== 'string' || !/^https?:\/\//i.test(addr)) {
+    return parseLightningAddress(addr, opts).discoveryUrl
   }
-  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) return Math.trunc(v).toString()
-  if (typeof v === 'string' && /^\d+$/.test(v)) return v
-  throw new LnurlPayError(`${field} must be a non-negative integer`)
+
+  let url
+  try {
+    url = new URL(addr)
+  } catch (cause) {
+    throw new LnurlPayError(`invalid discovery URL '${addr}'`, { cause })
+  }
+  if (url.protocol === 'http:' && opts.allowHttp !== true && !isLoopback(url.host) && !url.hostname.endsWith('.onion')) {
+    throw new LnurlPayError(`plain HTTP discovery is not allowed for '${url.host}'`)
+  }
+  return url.toString()
 }
 
-function numOrNull (v) {
-  if (typeof v === 'number' && Number.isFinite(v)) return v
-  if (typeof v === 'string' && /^\d+$/.test(v)) return Number(v)
-  return null
+function assertCallbackOrigin (callbackUrl, discoveryUrl, opts) {
+  const callback = new URL(callbackUrl)
+  const discovery = new URL(discoveryUrl)
+  if (callback.protocol === 'http:' && opts.allowHttp !== true && !isLoopback(callback.host) && !callback.hostname.endsWith('.onion')) {
+    throw new LnurlPayError(`LUD-06 callback uses disallowed plain HTTP origin '${callback.origin}'`)
+  }
+  if (opts.allowCrossHostCallback !== true && callback.host !== discovery.host) {
+    throw new LnurlPayError(
+      `LUD-06 callback host '${callback.host}' does not match discovery host '${discovery.host}'`
+    )
+  }
+}
+
+function isHttpUrl (value) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function asUint64String (value, field) {
+  try {
+    return toUint64String(value, field)
+  } catch (cause) {
+    throw new LnurlPayError(cause.message, { cause })
+  }
 }
 
 function timeoutSignal (ms) {

--- a/src/lnurl-pay.js
+++ b/src/lnurl-pay.js
@@ -140,7 +140,7 @@ export async function fetchDiscovery (addr, opts = {}) {
  * @param {boolean} [opts.allowCrossHostCallback=false]
  *   Permit a callback on a host other than the discovery endpoint.
  *   Disabled by default to prevent a discovery document from redirecting
- *   the wallet's authenticated network access to an unrelated host.
+ *   the follow-up callback request to an unrelated host.
  * @param {string} [opts.comment]   LUD-12 comment (server-policy gated).
  * @param {string} [opts.assetId]   Optional RGB asset extension.
  * @param {bigint|number|string} [opts.assetAmount]

--- a/src/lsp-client.js
+++ b/src/lsp-client.js
@@ -4,6 +4,13 @@
 // you may not use this file except in compliance with the License.
 'use strict'
 
+import {
+  camelCaseLspResponse,
+  snakeCaseLnParams,
+  snakeCaseRgbParams,
+  toUint64String
+} from './lsp-utils.js'
+
 // Thin typed wrapper around utexo-lsp's HTTP API. Side-effect free:
 // methods build URLs, send JSON, validate response status, and return
 // parsed JSON DTOs. Anything that combines an LSP call with a local
@@ -187,9 +194,9 @@ export class LspClient {
   lnurlCallback (username, amountMsat, opts = {}) {
     if (!isNonEmptyString(username)) throw new TypeError('LspClient.lnurlCallback: username required')
     const params = new URLSearchParams()
-    params.set('amount', toIntString(amountMsat, 'amountMsat'))
+    params.set('amount', toUint64String(amountMsat, 'amountMsat'))
     if (opts.assetId !== undefined) params.set('asset_id', String(opts.assetId))
-    if (opts.assetAmount !== undefined) params.set('asset_amount', toIntString(opts.assetAmount, 'assetAmount'))
+    if (opts.assetAmount !== undefined) params.set('asset_amount', toUint64String(opts.assetAmount, 'assetAmount'))
     return this._req('GET', `/pay/callback/${encodeURIComponent(username)}?${params.toString()}`, undefined, opts)
   }
 
@@ -222,9 +229,9 @@ export class LspClient {
     }
     const cbPath = this._rewriteCallbackToPath(meta.callback)
     const params = new URLSearchParams()
-    params.set('amount', toIntString(amountMsat, 'amountMsat'))
+    params.set('amount', toUint64String(amountMsat, 'amountMsat'))
     if (opts.assetId !== undefined) params.set('asset_id', String(opts.assetId))
-    if (opts.assetAmount !== undefined) params.set('asset_amount', toIntString(opts.assetAmount, 'assetAmount'))
+    if (opts.assetAmount !== undefined) params.set('asset_amount', toUint64String(opts.assetAmount, 'assetAmount'))
     const sep = cbPath.includes('?') ? '&' : '?'
     return this._req('GET', `${cbPath}${sep}${params.toString()}`, undefined, opts)
   }
@@ -419,85 +426,6 @@ export class LspClient {
 function wait (ms) { return new Promise((resolve) => setTimeout(resolve, ms)) }
 function backoffMs (attempt) { return RETRY_BASE_MS * Math.pow(2, attempt) }
 
-// ---------------------------------------------------------------------------
-// Shape adapters
-// ---------------------------------------------------------------------------
-
-/**
- * The LSP returns snake_case JSON (`{rgb_invoice, ln_invoice,
- * mapping_id}`). Map it to camelCase to match this module's public
- * API style + the helpers in lsp-helpers.js. Other keys pass through
- * unchanged for forward compatibility.
- */
-function camelCaseLspResponse (raw) {
-  if (!raw || typeof raw !== 'object') return raw
-  const out = { ...raw }
-  if ('rgb_invoice' in raw) out.rgbInvoice = raw.rgb_invoice
-  if ('ln_invoice' in raw) out.lnInvoice = raw.ln_invoice
-  if ('mapping_id' in raw) out.mappingId = raw.mapping_id
-  return out
-}
-
-function snakeCaseLnParams (ln) {
-  const out = {}
-  if (ln.amtMsat !== undefined) out.amt_msat = toUint64Json(ln.amtMsat, 'ln.amtMsat')
-  if (ln.expirySec !== undefined) out.expiry_sec = toUint32(ln.expirySec, 'ln.expirySec')
-  if (ln.assetId !== undefined) out.asset_id = String(ln.assetId)
-  if (ln.assetAmount !== undefined) out.asset_amount = toUint64Json(ln.assetAmount, 'ln.assetAmount')
-  if (ln.descriptionHash !== undefined) out.description_hash = String(ln.descriptionHash)
-  if (ln.paymentHash !== undefined) out.payment_hash = String(ln.paymentHash)
-  if (ln.minFinalCltvExpiryDelta !== undefined) {
-    out.min_final_cltv_expiry_delta = toUint32(ln.minFinalCltvExpiryDelta, 'ln.minFinalCltvExpiryDelta')
-  }
-  return out
-}
-
-function snakeCaseRgbParams (rgb) {
-  const out = {
-    asset_id: rgb.assetId,
-    min_confirmations: rgb.minConfirmations !== undefined ? toUint32(rgb.minConfirmations, 'rgb.minConfirmations') : 1,
-    witness: !!rgb.witness
-  }
-  if (rgb.assignment !== undefined) out.assignment = String(rgb.assignment)
-  if (rgb.durationSeconds !== undefined) out.duration_seconds = toUint32(rgb.durationSeconds, 'rgb.durationSeconds')
-  return out
-}
-
 function isNonEmptyString (v) {
   return typeof v === 'string' && v.length > 0
-}
-
-function toIntString (v, field) {
-  if (typeof v === 'bigint' && v >= 0n) return v.toString()
-  if (typeof v === 'number' && Number.isFinite(v) && v >= 0) return Math.trunc(v).toString()
-  if (typeof v === 'string' && /^\d+$/.test(v)) return v
-  throw new TypeError(`${field} must be a non-negative integer`)
-}
-
-/**
- * The Go side uses uint64 fields. JS numbers lose precision above 2^53.
- * Emit bigint values as numeric JSON (rgb-lightning-node accepts both
- * 1234 and "1234" but we prefer numeric for amt_msat to match the
- * canonical shape). For values above 2^53 we drop to strings — RLN
- * tolerates this on amt_msat (see daemon JsonLnInvoiceRequest).
- */
-function toUint64Json (v, field) {
-  if (typeof v === 'number') {
-    if (!Number.isFinite(v) || v < 0) throw new TypeError(`${field} must be ≥ 0`)
-    return Math.trunc(v)
-  }
-  if (typeof v === 'bigint') {
-    if (v < 0n) throw new TypeError(`${field} must be ≥ 0`)
-    return v <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(v) : v.toString()
-  }
-  if (typeof v === 'string' && /^\d+$/.test(v)) return v
-  throw new TypeError(`${field} must be a non-negative integer`)
-}
-
-function toUint32 (v, field) {
-  const n = typeof v === 'bigint' ? Number(v) : Number(v)
-  if (!Number.isFinite(n) || n < 0 || n > 0xffffffff || !Number.isInteger(n)) {
-    throw new TypeError(`${field} must fit in uint32`)
-  }
-  return n
 }

--- a/src/lsp-helpers.js
+++ b/src/lsp-helpers.js
@@ -16,6 +16,7 @@
 
 import { LspClient } from './lsp-client.js'
 import { resolveAddressToInvoice } from './lnurl-pay.js'
+import { toUint64 } from './lsp-utils.js'
 
 /**
  * Pay a Lightning Address end-to-end.
@@ -31,7 +32,10 @@ import { resolveAddressToInvoice } from './lnurl-pay.js'
  * @param {typeof fetch} [opts.fetch]
  * @param {number} [opts.timeoutMs]
  * @param {boolean} [opts.allowHttp]        Allow http on non-loopback hosts (regtest).
+ * @param {boolean} [opts.allowCrossHostCallback]
  * @param {string} [opts.comment]           LUD-12 comment.
+ * @param {string} [opts.assetId]           Optional RGB asset extension.
+ * @param {bigint|number|string} [opts.assetAmount]
  * @param {boolean} [opts.skipAmount]       Don't pass `amt_msat` to sendPayment.
  * @param {(invoice:string, discovery:object) => void|Promise<void>} [opts.beforePay]
  *                                          Hook to inspect the LSP-issued invoice
@@ -162,13 +166,6 @@ function pickInvoiceMinter (account) {
   if (typeof account.createInvoice === 'function') return account.createInvoice.bind(account)
   if (typeof account.lnInvoice === 'function') return account.lnInvoice.bind(account)
   throw new TypeError('requestLspRgbDeposit: account must expose createInvoice or lnInvoice')
-}
-
-function toUint64 (v) {
-  if (typeof v === 'bigint') return v <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(v) : v.toString()
-  if (typeof v === 'number') return Math.trunc(v)
-  if (typeof v === 'string' && /^\d+$/.test(v)) return v
-  throw new TypeError(`amountMsat must be a non-negative integer; got ${typeof v}`)
 }
 
 function truncate (s) { return s.length > 200 ? s.slice(0, 197) + '…' : s }

--- a/src/lsp-utils.js
+++ b/src/lsp-utils.js
@@ -1,0 +1,89 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// Pure LSP wire-shape and integer adapters. Keeping these below both the
+// HTTP client and composed flows avoids a lsp-client <-> lsp-helpers cycle.
+
+const UINT64_MAX = (1n << 64n) - 1n
+
+/**
+ * Convert a JS integer to the JSON representation accepted by uint64 fields.
+ * Safe numbers stay numbers; larger bigint values and numeric strings stay
+ * strings so JSON serialization cannot lose precision.
+ */
+export function toUint64 (value, field = 'value') {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) throw uint64TypeError(field)
+    return value
+  }
+  if (typeof value === 'bigint') {
+    if (value < 0n || value > UINT64_MAX) throw uint64TypeError(field)
+    return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : value.toString()
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    if (BigInt(value) > UINT64_MAX) throw uint64TypeError(field)
+    return value
+  }
+  throw uint64TypeError(field)
+}
+
+export function toUint64String (value, field = 'value') {
+  return String(toUint64(value, field))
+}
+
+export function toUint32 (value, field = 'value') {
+  let number
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    number = Number(value)
+  } else if (typeof value === 'string' && /^\d+$/.test(value)) {
+    number = Number(value)
+  } else {
+    throw new TypeError(`${field} must fit in uint32`)
+  }
+  if (!Number.isInteger(number) || number < 0 || number > 0xffffffff) {
+    throw new TypeError(`${field} must fit in uint32`)
+  }
+  return number
+}
+
+/** Map the LSP's snake_case response keys onto the public camelCase shape. */
+export function camelCaseLspResponse (raw) {
+  if (!raw || typeof raw !== 'object') return raw
+  const out = { ...raw }
+  if ('rgb_invoice' in raw) out.rgbInvoice = raw.rgb_invoice
+  if ('ln_invoice' in raw) out.lnInvoice = raw.ln_invoice
+  if ('mapping_id' in raw) out.mappingId = raw.mapping_id
+  return out
+}
+
+export function snakeCaseLnParams (ln) {
+  const out = {}
+  if (ln.amtMsat !== undefined) out.amt_msat = toUint64(ln.amtMsat, 'ln.amtMsat')
+  if (ln.expirySec !== undefined) out.expiry_sec = toUint32(ln.expirySec, 'ln.expirySec')
+  if (ln.assetId !== undefined) out.asset_id = String(ln.assetId)
+  if (ln.assetAmount !== undefined) out.asset_amount = toUint64(ln.assetAmount, 'ln.assetAmount')
+  if (ln.descriptionHash !== undefined) out.description_hash = String(ln.descriptionHash)
+  if (ln.paymentHash !== undefined) out.payment_hash = String(ln.paymentHash)
+  if (ln.minFinalCltvExpiryDelta !== undefined) {
+    out.min_final_cltv_expiry_delta = toUint32(ln.minFinalCltvExpiryDelta, 'ln.minFinalCltvExpiryDelta')
+  }
+  return out
+}
+
+export function snakeCaseRgbParams (rgb) {
+  const out = {
+    asset_id: rgb.assetId,
+    assignment: String(rgb.assignment ?? 'Any'),
+    min_confirmations: rgb.minConfirmations !== undefined ? toUint32(rgb.minConfirmations, 'rgb.minConfirmations') : 1,
+    witness: !!rgb.witness
+  }
+  if (rgb.durationSeconds !== undefined) out.duration_seconds = toUint32(rgb.durationSeconds, 'rgb.durationSeconds')
+  return out
+}
+
+function uint64TypeError (field) {
+  return new TypeError(`${field} must be a non-negative integer that fits in uint64`)
+}

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -140,7 +140,19 @@ export class NodeRgbLightningBinding {
         this._config.network,
         this._config.permissiveSignerPolicy ?? true
       )
-      this._signer.destroy()
+      try {
+        this._signer.destroy()
+      } catch (primaryDestroyError) {
+        try {
+          fallbackSigner.destroy()
+        } catch (fallbackDestroyError) {
+          throw new AggregateError(
+            [primaryDestroyError, fallbackDestroyError],
+            'unlock: failed to destroy both the primary and fallback signers'
+          )
+        }
+        throw primaryDestroyError
+      }
       this._signer = fallbackSigner
       wipeSecret(this._seedHex)
       this._seedHex = fallbackSeed

--- a/src/node-binding.js
+++ b/src/node-binding.js
@@ -11,6 +11,7 @@
 // runtimes — see binding-interface.js for the contract.
 
 import rln from '@utexo/rgb-lightning-node-nodejs'
+import { retainSecret, revealSecret, secretMatches, wipeSecret } from './secret-buffer.js'
 
 const {
   SdkNode,
@@ -65,6 +66,10 @@ export class NodeRgbLightningBinding {
     this._node = null
     /** @type {unknown | null} */
     this._signer = null
+    /** @type {Buffer | undefined} Zeroizable retained copy for idempotency checks. */
+    this._seedHex = undefined
+    /** @type {Buffer | undefined} Temporary legacy seed retained until first unlock. */
+    this._fallbackSeedHex = undefined
     /** @type {boolean} */
     this._sdkInitDone = false
     /** @type {number | null} Snapshot version returned by the most recent vssBackup(). */
@@ -81,13 +86,16 @@ export class NodeRgbLightningBinding {
   /** @param {string} seedHex */
   attachExternalSigner (seedHex, fallbackSeedHex) {
     if (this._signer) {
-      if (this._seedHex && this._seedHex !== seedHex) {
+      if (this._seedHex && !secretMatches(this._seedHex, seedHex)) {
         throw new Error(
           'attachExternalSigner: a different signer is already attached. ' +
           'Shut down the binding before re-attaching with a new seed.'
         )
       }
-      if (fallbackSeedHex) this._fallbackSeedHex = fallbackSeedHex
+      if (fallbackSeedHex) {
+        wipeSecret(this._fallbackSeedHex)
+        this._fallbackSeedHex = retainSecret(fallbackSeedHex)
+      }
       return
     }
     this._signer = NativeExternalSigner.create(
@@ -95,8 +103,10 @@ export class NodeRgbLightningBinding {
       this._config.network,
       this._config.permissiveSignerPolicy ?? true
     )
-    this._seedHex = seedHex
-    this._fallbackSeedHex = fallbackSeedHex
+    wipeSecret(this._seedHex)
+    wipeSecret(this._fallbackSeedHex)
+    this._seedHex = retainSecret(seedHex)
+    this._fallbackSeedHex = retainSecret(fallbackSeedHex)
   }
 
   /** @param {object} unlockRequest */
@@ -116,6 +126,7 @@ export class NodeRgbLightningBinding {
     }
     try {
       node.unlockWithNativeExternalSigner(this._signer, unlockRequest)
+      wipeSecret(this._fallbackSeedHex)
       this._fallbackSeedHex = undefined
     } catch (error) {
       const message = String(error && error.message ? error.message : error)
@@ -123,21 +134,19 @@ export class NodeRgbLightningBinding {
         throw error
       }
 
-      this._signer.destroy()
-      this._signer = NativeExternalSigner.create(
-        this._fallbackSeedHex,
+      const fallbackSeed = this._fallbackSeedHex
+      const fallbackSigner = NativeExternalSigner.create(
+        revealSecret(fallbackSeed),
         this._config.network,
         this._config.permissiveSignerPolicy ?? true
       )
-      this._seedHex = this._fallbackSeedHex
+      this._signer.destroy()
+      this._signer = fallbackSigner
+      wipeSecret(this._seedHex)
+      this._seedHex = fallbackSeed
       this._fallbackSeedHex = undefined
       node.unlockWithNativeExternalSigner(this._signer, unlockRequest)
     }
-  }
-
-  get node () {
-    if (!this._node) throw new Error('SdkNode not created — call unlock() first')
-    return this._node
   }
 
   bootstrap () {
@@ -167,7 +176,8 @@ export class NodeRgbLightningBinding {
    * @returns {{version: number}}
    */
   vssBackup () {
-    const r = this.node.vssBackup()
+    const node = this.ensureNode()
+    const r = node.vssBackup()
     if (r && typeof r.version === 'number') this._lastVssVersion = r.version
     return r
   }
@@ -206,17 +216,31 @@ export class NodeRgbLightningBinding {
   }
 
   shutdown () {
+    let failure
     if (this._node) {
-      this._node.shutdown()
-      this._node = null
+      try {
+        this._node.shutdown()
+      } catch (error) {
+        failure = error
+      } finally {
+        this._node = null
+      }
     }
     if (this._signer) {
-      this._signer.destroy()
-      this._signer = null
+      try {
+        this._signer.destroy()
+      } catch (error) {
+        failure ??= error
+      } finally {
+        this._signer = null
+      }
     }
     this._sdkInitDone = false
+    wipeSecret(this._seedHex)
+    wipeSecret(this._fallbackSeedHex)
     this._seedHex = undefined
     this._fallbackSeedHex = undefined
+    if (failure) throw failure
   }
 
   static healthcheck () { return uniffiHealthcheck() }

--- a/src/secret-buffer.js
+++ b/src/secret-buffer.js
@@ -1,0 +1,31 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+// eslint-disable-next-line camelcase
+import { sodium_memcmp, sodium_memzero } from 'sodium-universal'
+
+/** Retain a zeroizable copy instead of keeping an immutable JS string. */
+export function retainSecret (value) {
+  return value === undefined ? undefined : Buffer.from(value, 'utf8')
+}
+
+/** Compare against a temporary copy and erase that copy before returning. */
+export function secretMatches (retained, candidate) {
+  const candidateBuffer = retainSecret(candidate)
+  try {
+    return retained.length === candidateBuffer.length && sodium_memcmp(retained, candidateBuffer)
+  } finally {
+    wipeSecret(candidateBuffer)
+  }
+}
+
+export function revealSecret (retained) {
+  return retained.toString('utf8')
+}
+
+export function wipeSecret (retained) {
+  if (retained && ArrayBuffer.isView(retained)) sodium_memzero(retained)
+}

--- a/src/utexo-lsp.js
+++ b/src/utexo-lsp.js
@@ -19,6 +19,7 @@
 // absorbed here so the public method names + semantics match.
 
 import { LspClient } from './lsp-client.js'
+import { parseLightningAddress, resolveAddressToInvoice } from './lnurl-pay.js'
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 
@@ -29,6 +30,17 @@ export class LspChannelTimeoutError extends Error {
     this.name = 'LspChannelTimeoutError'
     this.assetId = assetId
     this.elapsedMs = elapsedMs
+  }
+}
+
+/** Outbound liquidity on the LSP channel stayed below the requested floor. */
+export class LspLiquidityTimeoutError extends Error {
+  constructor (minMsat, elapsedMs, peerPubkey) {
+    super(`Outbound liquidity for ${peerPubkey} stayed below ${minMsat} msat after ${Math.round(elapsedMs / 1000)}s`)
+    this.name = 'LspLiquidityTimeoutError'
+    this.minMsat = minMsat
+    this.elapsedMs = elapsedMs
+    this.peerPubkey = peerPubkey
   }
 }
 
@@ -217,6 +229,7 @@ export class UtexoLsp {
    * Poll until outbound balance on the LSP channel ≥ `minMsat`.
    * @param {number} minMsat
    * @param {object} [opts]  WaitOptions.
+   * @throws {LspLiquidityTimeoutError}
    */
   async waitForOutboundLiquidity (minMsat, opts = {}) {
     const timeoutMs = opts.timeoutMs ?? DEFAULT_CHANNEL_TIMEOUT_MS
@@ -236,6 +249,7 @@ export class UtexoLsp {
       if (outbound >= minMsat) return
       await this._sleep(pollIntervalMs, opts.signal)
     }
+    throw new LspLiquidityTimeoutError(minMsat, timeoutMs, this.peer.peerPubkey)
   }
 
   // ── 6. Send RGB via LSP (POST /onchain_send) ──────────────────────────────────
@@ -267,10 +281,11 @@ export class UtexoLsp {
   // ── 7. Pay a Lightning Address ────────────────────────────────────────────────
 
   /**
-   * Resolve a Lightning Address and pay it. Tries this LSP's
-   * `resolveAddress` first (handles internal/emulator host rewriting),
-   * then falls back to host-agnostic LUD-06 discovery on the address's
-   * own domain.
+   * Resolve a Lightning Address and pay it. Addresses on this LSP's host
+   * use `resolveAddress` first (for internal/emulator host rewriting) and
+   * fall back to the shared LNURL resolver. External hosts go directly
+   * through the shared resolver so a same-named LSP user cannot be paid
+   * by mistake.
    *
    * @param {object} opts
    * @param {string} opts.address          `user@host`.
@@ -280,29 +295,33 @@ export class UtexoLsp {
    */
   async payAddress (opts = {}) {
     const address = opts.address
-    if (typeof address !== 'string' || !address.includes('@')) {
+    let parsed
+    try {
+      parsed = parseLightningAddress(address, { allowHttp: this.peer.allowHttp === true })
+    } catch {
       throw new TypeError(`UtexoLsp.payAddress: invalid Lightning Address "${address}"`)
     }
-    const [username, domain] = address.split('@')
-    if (!username || !domain) throw new TypeError(`UtexoLsp.payAddress: invalid Lightning Address "${address}"`)
 
     let invoice
-    try {
-      const cb = await this.http.resolveAddress(
-        username, opts.amtMsat, { assetId: opts.asset?.assetId, assetAmount: opts.asset?.assetAmount }
-      )
-      invoice = cb?.pr
-    } catch {
-      // Fall back to standard LNURL discovery on the address's own host.
-      const fetcher = globalThis.fetch
-      if (typeof fetcher !== 'function') throw new Error('UtexoLsp.payAddress: no global fetch for LNURL fallback')
-      const meta = await fetcher(`https://${domain}/.well-known/lnurlp/${encodeURIComponent(username)}`).then((r) => r.json())
-      if (!meta?.callback) throw new Error('UtexoLsp.payAddress: missing callback in LNURL response')
-      let url = `${meta.callback}${meta.callback.includes('?') ? '&' : '?'}amount=${opts.amtMsat}`
-      if (opts.asset?.assetId) url += `&asset_id=${encodeURIComponent(opts.asset.assetId)}`
-      if (opts.asset?.assetAmount !== undefined) url += `&asset_amount=${opts.asset.assetAmount}`
-      const cb = await fetcher(url).then((r) => r.json())
-      invoice = cb?.pr
+    let useStandardResolver = parsed.host !== new URL(this.http.baseUrl ?? this.peer.baseUrl).host.toLowerCase()
+    if (!useStandardResolver) {
+      try {
+        const cb = await this.http.resolveAddress(
+          parsed.username, opts.amtMsat, { assetId: opts.asset?.assetId, assetAmount: opts.asset?.assetAmount }
+        )
+        invoice = cb?.pr
+      } catch {
+        useStandardResolver = true
+      }
+    }
+
+    if (useStandardResolver) {
+      const resolved = await resolveAddressToInvoice(address, opts.amtMsat, {
+        allowHttp: this.peer.allowHttp === true,
+        assetId: opts.asset?.assetId,
+        assetAmount: opts.asset?.assetAmount
+      })
+      invoice = resolved.pr
     }
 
     if (typeof invoice !== 'string' || invoice.length === 0) {

--- a/src/utexo-lsp.js
+++ b/src/utexo-lsp.js
@@ -289,8 +289,10 @@ export class UtexoLsp {
    *
    * @param {object} opts
    * @param {string} opts.address          `user@host`.
-   * @param {bigint|number} opts.amtMsat
+   * @param {bigint|number|string} opts.amtMsat
    * @param {object} [opts.asset]          `{ assetId, assetAmount }`.
+   * @param {boolean} [opts.allowCrossHostCallback=false]
+   *   Permit a delegated LNURL callback on a different host.
    * @returns {Promise<{ invoice:string, sendResult:any }>}
    */
   async payAddress (opts = {}) {
@@ -318,6 +320,7 @@ export class UtexoLsp {
     if (useStandardResolver) {
       const resolved = await resolveAddressToInvoice(address, opts.amtMsat, {
         allowHttp: this.peer.allowHttp === true,
+        allowCrossHostCallback: opts.allowCrossHostCallback === true,
         assetId: opts.asset?.assetId,
         assetAmount: opts.asset?.assetAmount
       })

--- a/src/wallet-account-read-only-rgb-lightning.js
+++ b/src/wallet-account-read-only-rgb-lightning.js
@@ -77,7 +77,7 @@ export function createReadOnlyRgbLightningAdapter (binding) {
   if (!binding) throw new TypeError('A RGB Lightning binding is required')
 
   const callNode = (method, ...args) => {
-    const node = binding.node
+    const node = binding.ensureNode()
     if (!node || typeof node[method] !== 'function') {
       throw new Error(
         `The installed RGB Lightning native binding does not expose ${method}(). ` +

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -60,7 +60,7 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
 
   /** @private */
   get _node () {
-    return this._binding.node
+    return this._binding.ensureNode()
   }
 
   // ==========================================================================

--- a/tests/__mocks__/rgb-lightning-node-bare.mjs
+++ b/tests/__mocks__/rgb-lightning-node-bare.mjs
@@ -1,0 +1,32 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Jest replacement for the optional Bare native addon. It preserves the
+// exported shape while keeping binding lifecycle tests platform-independent.
+
+const SdkNode = {
+  create: () => ({})
+}
+
+const NativeExternalSigner = {
+  create: () => ({
+    bootstrap: () => ({}),
+    destroy: () => {}
+  })
+}
+
+const uniffiHealthcheck = () => true
+const uniffiIsInitialized = () => false
+const sdkInitialize = () => {}
+const sdkShutdown = () => {}
+
+export default {
+  SdkNode,
+  NativeExternalSigner,
+  uniffiHealthcheck,
+  uniffiIsInitialized,
+  sdkInitialize,
+  sdkShutdown
+}

--- a/tests/bare-binding-methods.test.js
+++ b/tests/bare-binding-methods.test.js
@@ -1,0 +1,328 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+import { jest } from '@jest/globals'
+import rln from '@utexo/rgb-lightning-node-bare'
+import { BareRgbLightningBinding } from '../src/bare-binding.js'
+
+function makeBinding (overrides = {}) {
+  return new BareRgbLightningBinding({ network: 'regtest', dataDir: '/d', ...overrides })
+}
+
+function fakeNode () {
+  return {
+    initWithNativeExternalSigner: jest.fn(),
+    unlockWithNativeExternalSigner: jest.fn(),
+    vssClearFence: jest.fn(),
+    vssBackup: jest.fn(() => ({ version: 7 })),
+    apayNew: jest.fn(() => ({ order_id: 'order-1' })),
+    shutdown: jest.fn()
+  }
+}
+
+function fakeSigner () {
+  return {
+    bootstrap: jest.fn(() => ({ node_id: '03beef' })),
+    destroy: jest.fn()
+  }
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('BareRgbLightningBinding', () => {
+  it('maps config and caches the native node handle', () => {
+    const node = fakeNode()
+    const createSpy = jest.spyOn(rln.SdkNode, 'create').mockReturnValue(node)
+    const binding = makeBinding({
+      virtualPeerPubkeys: ['02lsp'],
+      vssUrl: 'https://vss.example',
+      vssAllowEmptyRestore: true,
+      lspBaseUrl: 'https://lsp.example',
+      lspBearerToken: 'token'
+    })
+
+    expect(binding.ensureNode()).toBe(node)
+    expect(binding.ensureNode()).toBe(node)
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({
+      storage_dir_path: '/d',
+      network: 'regtest',
+      reuse_addresses: true,
+      virtual_peer_pubkeys: ['02lsp'],
+      vss_url: 'https://vss.example',
+      vss_allow_empty_restore: true,
+      lsp_base_url: 'https://lsp.example',
+      lsp_bearer_token: 'token'
+    }))
+    expect(makeBinding({ virtualPeerPubkeys: [] })._initRequest).not.toHaveProperty('virtual_peer_pubkeys')
+  })
+
+  it('retains primary and fallback seeds without constructing the fallback eagerly', () => {
+    const signer = fakeSigner()
+    const createSpy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(signer)
+    const binding = makeBinding({ permissiveSignerPolicy: false })
+
+    binding.attachExternalSigner('seed-v2', 'seed-v1')
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledWith('seed-v2', 'regtest', false)
+    expect(binding._signer).toBe(signer)
+    expect(binding._seedHex.toString()).toBe('seed-v2')
+    expect(binding._fallbackSeedHex.toString()).toBe('seed-v1')
+  })
+
+  it('keeps same-seed attachment idempotent and rejects a wallet swap', () => {
+    const signer = fakeSigner()
+    const createSpy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(signer)
+    const binding = makeBinding()
+
+    binding.attachExternalSigner('seed-v2', 'seed-old')
+    const oldFallback = binding._fallbackSeedHex
+    binding.attachExternalSigner('seed-v2', 'seed-v1')
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledWith('seed-v2', 'regtest', true)
+    expect(binding._fallbackSeedHex.toString()).toBe('seed-v1')
+    expect(oldFallback.every((byte) => byte === 0)).toBe(true)
+    expect(() => binding.attachExternalSigner('seed-v3')).toThrow('a different signer is already attached')
+
+    const externallyAttached = makeBinding()
+    externallyAttached._signer = signer
+    expect(() => externallyAttached.attachExternalSigner('unknown-seed')).not.toThrow()
+    expect(externallyAttached._seedHex).toBeUndefined()
+  })
+
+  it('requires a signer before unlock and bootstrap', () => {
+    const binding = makeBinding()
+    binding._node = fakeNode()
+
+    expect(() => binding.unlock({})).toThrow('attachExternalSigner')
+    expect(() => binding.bootstrap()).toThrow('attachExternalSigner')
+  })
+
+  it('initializes once and wipes an unused fallback after primary unlock', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    const fallbackSeed = Buffer.from('seed-v1')
+    binding._node = node
+    binding._signer = signer
+    binding._fallbackSeedHex = fallbackSeed
+
+    binding.unlock({ rpc: true })
+    binding.unlock({ rpc: true })
+
+    expect(node.initWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(2)
+    expect(binding._fallbackSeedHex).toBeUndefined()
+    expect(fallbackSeed.every((byte) => byte === 0)).toBe(true)
+  })
+
+  it('accepts an existing SDK init but rethrows unrelated init failures', () => {
+    const existing = makeBinding()
+    const existingNode = fakeNode()
+    existingNode.initWithNativeExternalSigner.mockImplementation(() => {
+      throw new Error('Conflict: already initialized')
+    })
+    existing._node = existingNode
+    existing._signer = fakeSigner()
+
+    expect(() => existing.unlock({})).not.toThrow()
+    expect(existingNode.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+
+    const failing = makeBinding()
+    const failingNode = fakeNode()
+    // eslint-disable-next-line no-throw-literal
+    failingNode.initWithNativeExternalSigner.mockImplementation(() => { throw 'init failed' })
+    failing._node = failingNode
+    failing._signer = fakeSigner()
+
+    expect(() => failing.unlock({})).toThrow('init failed')
+    expect(failingNode.unlockWithNativeExternalSigner).not.toHaveBeenCalled()
+    expect(failing._sdkInitDone).toBe(false)
+  })
+
+  it('replaces a mismatched primary signer with the legacy signer', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const primarySigner = fakeSigner()
+    const fallbackSigner = fakeSigner()
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    node.unlockWithNativeExternalSigner
+      .mockImplementationOnce(() => {
+        throw new Error('external signer identity does not match persisted key_source.json')
+      })
+      .mockImplementationOnce(() => undefined)
+    jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
+    binding._node = node
+    binding._signer = primarySigner
+    binding._seedHex = primarySeed
+    binding._fallbackSeedHex = fallbackSeed
+
+    binding.unlock({ rpc: true })
+
+    expect(primarySigner.destroy).toHaveBeenCalledTimes(1)
+    expect(binding._signer).toBe(fallbackSigner)
+    expect(binding._seedHex).toBe(fallbackSeed)
+    expect(binding._fallbackSeedHex).toBeUndefined()
+    expect(primarySeed.every((byte) => byte === 0)).toBe(true)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenLastCalledWith(fallbackSigner, { rpc: true })
+  })
+
+  it('destroys the fallback signer if the primary signer cannot be released', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const primarySigner = fakeSigner()
+    const fallbackSigner = fakeSigner()
+    const destroyError = new Error('primary signer destroy failed')
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    primarySigner.destroy.mockImplementation(() => { throw destroyError })
+    node.unlockWithNativeExternalSigner.mockImplementation(() => {
+      throw new Error('Rln(ExternalSignerMismatch): identity mismatch')
+    })
+    jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
+    binding._node = node
+    binding._signer = primarySigner
+    binding._seedHex = primarySeed
+    binding._fallbackSeedHex = fallbackSeed
+
+    expect(() => binding.unlock({})).toThrow(destroyError)
+    expect(fallbackSigner.destroy).toHaveBeenCalledTimes(1)
+    expect(binding._signer).toBe(primarySigner)
+    expect(binding._seedHex).toBe(primarySeed)
+    expect(binding._fallbackSeedHex).toBe(fallbackSeed)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not replace the signer for an unrelated unlock failure', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    // eslint-disable-next-line no-throw-literal
+    node.unlockWithNativeExternalSigner.mockImplementation(() => { throw 'backend unavailable' })
+    binding._node = node
+    binding._signer = signer
+    binding._fallbackSeedHex = Buffer.from('seed-v1')
+
+    expect(() => binding.unlock({})).toThrow('backend unavailable')
+    expect(binding._signer).toBe(signer)
+    expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports both signer cleanup failures without replacing binding state', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const primarySigner = fakeSigner()
+    const fallbackSigner = fakeSigner()
+    const primaryError = new Error('primary signer destroy failed')
+    const fallbackError = new Error('fallback signer destroy failed')
+    primarySigner.destroy.mockImplementation(() => { throw primaryError })
+    fallbackSigner.destroy.mockImplementation(() => { throw fallbackError })
+    node.unlockWithNativeExternalSigner.mockImplementation(() => {
+      throw new Error('Rln(ExternalSignerMismatch): identity mismatch')
+    })
+    jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
+    binding._node = node
+    binding._signer = primarySigner
+    binding._seedHex = Buffer.from('seed-v2')
+    binding._fallbackSeedHex = Buffer.from('seed-v1')
+
+    let thrown
+    try {
+      binding.unlock({})
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    expect(thrown.message).toBe('unlock: failed to destroy both the primary and fallback signers')
+    expect(thrown.errors).toEqual([primaryError, fallbackError])
+    expect(binding._signer).toBe(primarySigner)
+  })
+
+  it('forwards the remaining native instance methods', () => {
+    const binding = makeBinding({ vssUrl: 'https://vss.example', vssAllowHttp: true })
+    const node = fakeNode()
+    const signer = fakeSigner()
+    binding._node = node
+    binding._signer = signer
+
+    expect(binding.bootstrap()).toEqual({ node_id: '03beef' })
+    binding.clearVssFence('pw')
+    expect(binding.vssBackup()).toEqual({ version: 7 })
+    expect(binding.vssStatus()).toEqual({
+      configured: true,
+      url: 'https://vss.example',
+      allowHttp: true,
+      lastBackupVersion: 7
+    })
+    expect(binding.apayNew('02host')).toEqual({ order_id: 'order-1' })
+    expect(node.vssClearFence).toHaveBeenCalledWith({ password: 'pw' })
+    expect(node.apayNew).toHaveBeenCalledWith('02host')
+
+    node.vssBackup.mockReturnValueOnce({ version: 'unknown' }).mockReturnValueOnce(null)
+    expect(binding.vssBackup()).toEqual({ version: 'unknown' })
+    expect(binding.vssBackup()).toBeNull()
+    expect(binding.vssStatus().lastBackupVersion).toBe(7)
+    expect(makeBinding().vssStatus()).toEqual({
+      configured: false,
+      url: null,
+      allowHttp: false,
+      lastBackupVersion: null
+    })
+  })
+
+  it('cleans up the signer and retained seeds when node shutdown fails', () => {
+    const binding = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    node.shutdown.mockImplementation(() => { throw new Error('node shutdown failed') })
+    binding._node = node
+    binding._signer = signer
+    binding._seedHex = primarySeed
+    binding._fallbackSeedHex = fallbackSeed
+
+    expect(() => binding.shutdown()).toThrow('node shutdown failed')
+    expect(signer.destroy).toHaveBeenCalledTimes(1)
+    expect(binding._node).toBeNull()
+    expect(binding._signer).toBeNull()
+    expect(primarySeed.every((byte) => byte === 0)).toBe(true)
+    expect(fallbackSeed.every((byte) => byte === 0)).toBe(true)
+  })
+
+  it('wipes retained seeds when signer destruction fails', () => {
+    const binding = makeBinding()
+    const signer = fakeSigner()
+    const primarySeed = Buffer.from('seed-v2')
+    signer.destroy.mockImplementation(() => { throw new Error('signer destroy failed') })
+    binding._signer = signer
+    binding._seedHex = primarySeed
+
+    expect(() => binding.shutdown()).toThrow('signer destroy failed')
+    expect(binding._signer).toBeNull()
+    expect(primarySeed.every((byte) => byte === 0)).toBe(true)
+  })
+
+  it('is safe to shut down before any native handles are created', () => {
+    const binding = makeBinding()
+
+    expect(() => binding.shutdown()).not.toThrow()
+    expect(binding._node).toBeNull()
+    expect(binding._signer).toBeNull()
+  })
+
+  it('exposes the native module lifecycle passthroughs', () => {
+    expect(BareRgbLightningBinding.healthcheck()).toBe(true)
+    expect(BareRgbLightningBinding.isInitialized()).toBe(false)
+    expect(() => BareRgbLightningBinding.initialize({})).not.toThrow()
+    expect(() => BareRgbLightningBinding.shutdownGlobal()).not.toThrow()
+  })
+})

--- a/tests/lnurl-pay.test.js
+++ b/tests/lnurl-pay.test.js
@@ -26,7 +26,7 @@ function makeResponse ({ ok = true, status = 200, body = {}, raw } = {}) {
 function discoveryDoc (overrides = {}) {
   return {
     tag: 'payRequest',
-    callback: 'https://pay.example/lnurlp/cb',
+    callback: 'https://b.com/lnurlp/cb',
     minSendable: 1000,
     maxSendable: 100000,
     metadata: '[["text/plain","pay alice"]]',
@@ -144,6 +144,14 @@ describe('fetchDiscovery', () => {
     expect(fetch.mock.calls[0][0]).toBe(url)
   })
 
+  it('rejects malformed and disallowed plain-HTTP discovery URLs before fetching', async () => {
+    const fetch = jest.fn()
+    await expect(fetchDiscovery('http://[invalid', { fetch })).rejects.toThrow(/invalid discovery URL/)
+    await expect(fetchDiscovery('http://public.example/lnurlp/alice', { fetch }))
+      .rejects.toThrow(/plain HTTP discovery is not allowed/)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('throws when no usable fetch is available', async () => {
     // `opts.fetch ?? globalThis.fetch` only falls back on null/undefined,
     // so a non-function value reaches the typeof guard.
@@ -197,6 +205,9 @@ describe('fetchDiscovery', () => {
   it('throws when the callback is not an http(s) URL', async () => {
     const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ callback: 'ftp://x' }) }))
     await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/invalid callback/)
+
+    const malformed = jest.fn(async () => makeResponse({ body: discoveryDoc({ callback: 'https://[invalid' }) }))
+    await expect(fetchDiscovery('a@b.com', { fetch: malformed })).rejects.toThrow(/invalid callback/)
   })
 
   it('throws when the sendable range is missing, inverted, or non-positive', async () => {
@@ -234,6 +245,17 @@ describe('fetchDiscovery', () => {
     await expect(fetchDiscovery('a@b.com', { fetch })).resolves.toMatchObject({ tag: 'payRequest' })
   })
 
+  it('wraps fractional sendable bounds as LnurlPayError instead of leaking RangeError', async () => {
+    const fetch = jest.fn(async () => makeResponse({
+      body: discoveryDoc({ minSendable: 1000.5 })
+    }))
+    const error = await fetchDiscovery('a@b.com', { fetch }).catch((cause) => cause)
+    expect(error).toBeInstanceOf(LnurlPayError)
+    expect(error).not.toBeInstanceOf(RangeError)
+    expect(error.message).toMatch(/invalid sendable range/)
+    expect(error.cause).toBeInstanceOf(TypeError)
+  })
+
   it('throws when metadata is not a string', async () => {
     const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc({ metadata: 123 }) }))
     await expect(fetchDiscovery('a@b.com', { fetch })).rejects.toThrow(/missing metadata string/)
@@ -253,14 +275,14 @@ describe('resolveAddressToInvoice', () => {
   it('resolves an in-range amount to the bolt11 invoice plus context', async () => {
     const discovery = discoveryDoc()
     const fetch = twoStepFetch(discovery, { pr: 'lnbc1...', routes: [{ a: 1 }] })
-    const out = await resolveAddressToInvoice('alice@getalby.com', 5000n, { fetch })
+    const out = await resolveAddressToInvoice('alice@b.com', 5000n, { fetch })
     expect(out.pr).toBe('lnbc1...')
     expect(out.routes).toEqual([{ a: 1 }])
     expect(out.discovery).toEqual(discovery)
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=5000')
     // discovery + callback = exactly two fetches.
     expect(fetch).toHaveBeenCalledTimes(2)
-    expect(fetch.mock.calls[1][0]).toBe('https://pay.example/lnurlp/cb?amount=5000')
+    expect(fetch.mock.calls[1][0]).toBe('https://b.com/lnurlp/cb?amount=5000')
   })
 
   it('defaults routes to an empty array when the callback omits them', async () => {
@@ -269,23 +291,67 @@ describe('resolveAddressToInvoice', () => {
     expect(out.routes).toEqual([])
   })
 
-  it('accepts a numeric amount and truncates it to an integer string', async () => {
+  it('rejects a fractional numeric amount instead of silently truncating it', async () => {
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
-    const out = await resolveAddressToInvoice('a@b.com', 4999.9, { fetch })
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=4999')
+    await expect(resolveAddressToInvoice('a@b.com', 4999.9, { fetch }))
+      .rejects.toBeInstanceOf(LnurlPayError)
+    expect(fetch).toHaveBeenCalledTimes(1)
   })
 
   it('accepts an integer string amount', async () => {
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', '2500', { fetch })
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=2500')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=2500')
+  })
+
+  it('rejects a callback on a different host before making the second request', async () => {
+    const fetch = twoStepFetch(
+      discoveryDoc({ callback: 'https://attacker.example/collect' }),
+      { pr: 'must-not-be-reached' }
+    )
+    await expect(resolveAddressToInvoice('a@b.com', 2500, { fetch }))
+      .rejects.toThrow(/callback host .* does not match discovery host/)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a plain-HTTP callback on a public host', async () => {
+    const fetch = twoStepFetch(
+      discoveryDoc({ callback: 'http://b.com/cb' }),
+      { pr: 'must-not-be-reached' }
+    )
+    await expect(resolveAddressToInvoice('a@b.com', 2500, { fetch }))
+      .rejects.toThrow(/disallowed plain HTTP/)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows an explicitly opted-in cross-host callback for delegated services', async () => {
+    const fetch = twoStepFetch(
+      discoveryDoc({ callback: 'https://delegate.example/cb' }),
+      { pr: 'lnbc-delegated' }
+    )
+    const out = await resolveAddressToInvoice('a@b.com', 2500, {
+      fetch,
+      allowCrossHostCallback: true
+    })
+    expect(out.pr).toBe('lnbc-delegated')
+    expect(out.callbackUrl).toBe('https://delegate.example/cb?amount=2500')
+  })
+
+  it('forwards validated RGB extension parameters through the shared resolver', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc-rgb' })
+    const out = await resolveAddressToInvoice('a@b.com', 2500, {
+      fetch,
+      assetId: 'rgb:asset',
+      assetAmount: 7n
+    })
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=2500&asset_id=rgb%3Aasset&asset_amount=7')
   })
 
   it('appends a LUD-12 comment with & when the callback already has a query', async () => {
-    const discovery = discoveryDoc({ callback: 'https://pay.example/cb?token=xyz' })
+    const discovery = discoveryDoc({ callback: 'https://b.com/cb?token=xyz' })
     const fetch = twoStepFetch(discovery, { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch, comment: 'hi there' })
-    expect(out.callbackUrl).toBe('https://pay.example/cb?token=xyz&amount=5000&comment=hi+there')
+    expect(out.callbackUrl).toBe('https://b.com/cb?token=xyz&amount=5000&comment=hi+there')
   })
 
   it('uses ? for the first param and & between params when the callback has no query', async () => {
@@ -294,8 +360,8 @@ describe('resolveAddressToInvoice', () => {
     // for the comment branch independently of the already-has-query test above.
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch, comment: 'hi there' })
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000&comment=hi+there')
-    expect(fetch.mock.calls[1][0]).toBe('https://pay.example/lnurlp/cb?amount=5000&comment=hi+there')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=5000&comment=hi+there')
+    expect(fetch.mock.calls[1][0]).toBe('https://b.com/lnurlp/cb?amount=5000&comment=hi+there')
   })
 
   it('omits the comment param entirely when no comment is supplied', async () => {
@@ -303,7 +369,7 @@ describe('resolveAddressToInvoice', () => {
     // callback URL carries amount only and NO comment key.
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', 5000, { fetch })
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=5000')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=5000')
     expect(out.callbackUrl).not.toContain('comment')
   })
 
@@ -333,7 +399,7 @@ describe('resolveAddressToInvoice', () => {
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', 1000, { fetch })
     expect(out.pr).toBe('lnbc1...')
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=1000')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=1000')
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
@@ -344,7 +410,7 @@ describe('resolveAddressToInvoice', () => {
     const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', 100000, { fetch })
     expect(out.pr).toBe('lnbc1...')
-    expect(out.callbackUrl).toBe('https://pay.example/lnurlp/cb?amount=100000')
+    expect(out.callbackUrl).toBe('https://b.com/lnurlp/cb?amount=100000')
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
@@ -367,7 +433,7 @@ describe('resolveAddressToInvoice', () => {
   it('throws on a negative bigint amount', async () => {
     const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
     await expect(resolveAddressToInvoice('a@b.com', -1n, { fetch }))
-      .rejects.toThrow(/must be ≥ 0/)
+      .rejects.toThrow(/non-negative integer/)
   })
 
   it('throws on a non-integer / negative amount', async () => {
@@ -453,7 +519,7 @@ describe('resolveAddressToInvoice', () => {
     const discovery = discoveryDoc({ minSendable: '1000', maxSendable: big })
     const fetch = twoStepFetch(discovery, { pr: 'lnbc1...' })
     const out = await resolveAddressToInvoice('a@b.com', BigInt(big), { fetch })
-    expect(out.callbackUrl).toBe(`https://pay.example/lnurlp/cb?amount=${big}`)
+    expect(out.callbackUrl).toBe(`https://b.com/lnurlp/cb?amount=${big}`)
   })
 })
 

--- a/tests/lsp-client.test.js
+++ b/tests/lsp-client.test.js
@@ -278,6 +278,7 @@ describe('GET endpoint methods', () => {
   it('lnurlCallback() rejects a non-integer amount', () => {
     const { client } = makeClient()
     expect(() => client.lnurlCallback('alice', -1)).toThrow(/non-negative integer/)
+    expect(() => client.lnurlCallback('alice', 1.5)).toThrow(/non-negative integer/)
     expect(() => client.lnurlCallback('alice', 'abc')).toThrow(/non-negative integer/)
   })
 
@@ -407,7 +408,7 @@ describe('POST endpoint methods', () => {
     const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
     expect(body).toEqual({
       ln_invoice: 'lnbc',
-      rgb_invoice: { asset_id: 'rgb:a', min_confirmations: 1, witness: false }
+      rgb_invoice: { asset_id: 'rgb:a', assignment: 'Any', min_confirmations: 1, witness: false }
     })
   })
 
@@ -677,13 +678,40 @@ describe('numeric coercion edge cases (via public API)', () => {
   it('rejects a negative bigint amount', async () => {
     const { client } = makeClient()
     await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: -1n } }))
-      .rejects.toThrow(/must be ≥ 0/)
+      .rejects.toThrow(/non-negative integer/)
+  })
+
+  it('rejects fractional and unsafe number inputs instead of truncating them', async () => {
+    const { client } = makeClient()
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: 1.5 } }))
+      .rejects.toThrow(/non-negative integer/)
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: Number.MAX_SAFE_INTEGER + 1 } }))
+      .rejects.toThrow(/fits in uint64/)
+  })
+
+  it('rejects bigint and string values above uint64 max', async () => {
+    const { client } = makeClient()
+    const overflow = 1n << 64n
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: overflow } }))
+      .rejects.toThrow(/fits in uint64/)
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { amtMsat: overflow.toString() } }))
+      .rejects.toThrow(/fits in uint64/)
   })
 
   it('rejects a uint32 field that overflows', async () => {
     const { client } = makeClient()
     await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { expirySec: 0x1ffffffff } }))
       .rejects.toThrow(/must fit in uint32/)
+    await expect(client.onchainSend({ rgbInvoice: 'rgb:x', ln: { expirySec: null } }))
+      .rejects.toThrow(/must fit in uint32/)
+  })
+
+  it('accepts a numeric-string uint32 field', async () => {
+    const fetchImpl = fetchReturning(makeRes({ json: {} }))
+    const { client } = makeClient({ fetch: fetchImpl })
+    await client.onchainSend({ rgbInvoice: 'rgb:x', ln: { expirySec: '60' } })
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(body.lninvoice.expiry_sec).toBe(60)
   })
 
   it('passes a numeric-string amtMsat through unchanged (uint64 string path)', async () => {

--- a/tests/lsp-helpers.test.js
+++ b/tests/lsp-helpers.test.js
@@ -77,7 +77,7 @@ describe('payLightningAddress', () => {
     const fetch = makeLnurlFetch({ routes: [{ a: 1 }] })
     const account = { sendPayment: jest.fn(async () => ({ payment_hash: 'ph' })) }
 
-    const out = await payLightningAddress(account, 'alice@host.example', 5000, { fetch, allowHttp: true })
+    const out = await payLightningAddress(account, 'alice@host.example', 5000, { fetch })
 
     expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 5000 })
     expect(out).toEqual({
@@ -159,6 +159,14 @@ describe('payLightningAddress', () => {
     await expect(
       payLightningAddress(account, 'g@host.example', {}, { fetch })
     ).rejects.toThrow('amountMsat must be a non-negative integer')
+    expect(account.sendPayment).not.toHaveBeenCalled()
+  })
+
+  it('rejects a fractional amount without paying', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({})) }
+    await expect(payLightningAddress(account, 'g@host.example', 1.5, { fetch }))
+      .rejects.toThrow('amountMsat must be a non-negative integer')
     expect(account.sendPayment).not.toHaveBeenCalled()
   })
 })

--- a/tests/node-binding-methods.test.js
+++ b/tests/node-binding-methods.test.js
@@ -82,17 +82,11 @@ describe('ensureNode', () => {
   })
 })
 
-describe('node getter', () => {
-  it("throws 'SdkNode not created' when no node exists", () => {
+describe('binding surface', () => {
+  it('uses ensureNode() as the only node accessor', () => {
     const b = makeBinding()
-    expect(() => b.node).toThrow('SdkNode not created')
-  })
-
-  it('returns the node when one is present', () => {
-    const b = makeBinding()
-    const node = fakeNode()
-    b._node = node
-    expect(b.node).toBe(node)
+    expect('node' in b).toBe(false)
+    expect(typeof b.ensureNode).toBe('function')
   })
 })
 
@@ -102,7 +96,7 @@ describe('attachExternalSigner', () => {
     expect(b._signer).toBeNull()
     b.attachExternalSigner('seed-a')
     expect(b._signer).toBeTruthy()
-    expect(b._seedHex).toBe('seed-a')
+    expect(b._seedHex.toString()).toBe('seed-a')
   })
 
   it('records an optional legacy fallback seed without constructing it eagerly', () => {
@@ -111,7 +105,7 @@ describe('attachExternalSigner', () => {
     try {
       const b = makeBinding()
       b.attachExternalSigner('seed-v2', 'seed-v1')
-      expect(b._fallbackSeedHex).toBe('seed-v1')
+      expect(b._fallbackSeedHex.toString()).toBe('seed-v1')
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith('seed-v2', 'regtest', true)
     } finally {
@@ -160,11 +154,13 @@ describe('attachExternalSigner', () => {
 
   it('records a newly supplied fallback seed on the idempotent same-seed path', () => {
     const b = makeBinding()
-    b.attachExternalSigner('seed-v2')
+    b.attachExternalSigner('seed-v2', 'seed-old')
     const signer = b._signer
+    const oldFallback = b._fallbackSeedHex
     b.attachExternalSigner('seed-v2', 'seed-v1')
     expect(b._signer).toBe(signer)
-    expect(b._fallbackSeedHex).toBe('seed-v1')
+    expect(b._fallbackSeedHex.toString()).toBe('seed-v1')
+    expect(oldFallback.every((byte) => byte === 0)).toBe(true)
   })
 
   it('throws when a different seed is already attached', () => {
@@ -173,8 +169,8 @@ describe('attachExternalSigner', () => {
     expect(() => b.attachExternalSigner('seed-b')).toThrow('a different signer is already attached')
   })
 
-  // Kills the mutant that drops the `this._seedHex &&` short-circuit
-  // (`if (this._seedHex !== seedHex)`). When a signer is attached
+  // Preserve the `this._seedHex &&` short-circuit around the retained-secret
+  // comparison. When a signer is attached
   // out-of-band with NO _seedHex recorded, re-attaching must return
   // silently (the falsy guard wins). Dropping the short-circuit would
   // make `undefined !== 'seed-x'` true and wrongly throw.
@@ -203,13 +199,15 @@ describe('unlock', () => {
     const signer = fakeSigner()
     b._node = node
     b._signer = signer
-    b._fallbackSeedHex = 'seed-v1'
+    const fallbackSeed = Buffer.from('seed-v1')
+    b._fallbackSeedHex = fallbackSeed
     const req = { mnemonic: 'm' }
     b.unlock(req)
     expect(node.initWithNativeExternalSigner).toHaveBeenCalledWith(signer)
     expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledWith(signer, req)
     expect(b._sdkInitDone).toBe(true)
     expect(b._fallbackSeedHex).toBeUndefined()
+    expect(fallbackSeed.every((byte) => byte === 0)).toBe(true)
   })
 
   it('swallows a Conflict init error and still proceeds to unlock', () => {
@@ -258,14 +256,18 @@ describe('unlock', () => {
     const createSpy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
     b._node = node
     b._signer = primarySigner
-    b._seedHex = 'seed-v2'
-    b._fallbackSeedHex = 'seed-v1'
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    b._seedHex = primarySeed
+    b._fallbackSeedHex = fallbackSeed
     try {
       expect(() => b.unlock({ rpc: true })).not.toThrow()
       expect(primarySigner.destroy).toHaveBeenCalledTimes(1)
       expect(createSpy).toHaveBeenCalledWith('seed-v1', 'regtest', true)
       expect(node.unlockWithNativeExternalSigner).toHaveBeenLastCalledWith(fallbackSigner, { rpc: true })
-      expect(b._seedHex).toBe('seed-v1')
+      expect(b._seedHex).toBe(fallbackSeed)
+      expect(b._seedHex.toString()).toBe('seed-v1')
+      expect(primarySeed.every((byte) => byte === 0)).toBe(true)
       expect(b._fallbackSeedHex).toBeUndefined()
     } finally {
       createSpy.mockRestore()
@@ -278,7 +280,7 @@ describe('unlock', () => {
     node.unlockWithNativeExternalSigner.mockImplementation(() => { throw new Error('backend unavailable') })
     b._node = node
     b._signer = fakeSigner()
-    b._fallbackSeedHex = 'seed-v1'
+    b._fallbackSeedHex = Buffer.from('seed-v1')
     expect(() => b.unlock({})).toThrow('backend unavailable')
     expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
   })
@@ -302,7 +304,7 @@ describe('unlock', () => {
     node.unlockWithNativeExternalSigner.mockImplementation(() => { throw 'backend unavailable' })
     b._node = node
     b._signer = fakeSigner()
-    b._fallbackSeedHex = 'seed-v1'
+    b._fallbackSeedHex = Buffer.from('seed-v1')
     expect(() => b.unlock({})).toThrow('backend unavailable')
     expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
   })
@@ -414,9 +416,12 @@ describe('vssBackup', () => {
     expect(b._lastVssVersion).toBeNull()
   })
 
-  it('throws via the node getter when no node has been created', () => {
+  it('lazily obtains the node through ensureNode()', () => {
     const b = makeBinding()
-    expect(() => b.vssBackup()).toThrow('SdkNode not created')
+    const node = fakeNode()
+    const ensureSpy = jest.spyOn(b, 'ensureNode').mockReturnValue(node)
+    expect(b.vssBackup()).toEqual({ version: 7 })
+    expect(ensureSpy).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -465,8 +470,10 @@ describe('shutdown', () => {
     b._node = node
     b._signer = signer
     b._sdkInitDone = true
-    b._seedHex = 'seed-v2'
-    b._fallbackSeedHex = 'seed-v1'
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    b._seedHex = primarySeed
+    b._fallbackSeedHex = fallbackSeed
     b.shutdown()
     expect(node.shutdown).toHaveBeenCalledTimes(1)
     expect(signer.destroy).toHaveBeenCalledTimes(1)
@@ -475,6 +482,8 @@ describe('shutdown', () => {
     expect(b._sdkInitDone).toBe(false)
     expect(b._seedHex).toBeUndefined()
     expect(b._fallbackSeedHex).toBeUndefined()
+    expect(primarySeed.every((byte) => byte === 0)).toBe(true)
+    expect(fallbackSeed.every((byte) => byte === 0)).toBe(true)
   })
 
   it('is idempotent when nothing is attached', () => {
@@ -482,6 +491,39 @@ describe('shutdown', () => {
     expect(() => b.shutdown()).not.toThrow()
     expect(b._node).toBeNull()
     expect(b._signer).toBeNull()
+  })
+
+  it('destroys the signer and wipes both seeds even when node shutdown fails', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const signer = fakeSigner()
+    node.shutdown.mockImplementation(() => { throw new Error('node shutdown failed') })
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    b._node = node
+    b._signer = signer
+    b._seedHex = primarySeed
+    b._fallbackSeedHex = fallbackSeed
+
+    expect(() => b.shutdown()).toThrow('node shutdown failed')
+    expect(signer.destroy).toHaveBeenCalledTimes(1)
+    expect(b._node).toBeNull()
+    expect(b._signer).toBeNull()
+    expect(primarySeed.every((byte) => byte === 0)).toBe(true)
+    expect(fallbackSeed.every((byte) => byte === 0)).toBe(true)
+  })
+
+  it('still wipes retained seeds when signer destruction fails', () => {
+    const b = makeBinding()
+    const signer = fakeSigner()
+    signer.destroy.mockImplementation(() => { throw new Error('signer destroy failed') })
+    const seed = Buffer.from('seed-v2')
+    b._signer = signer
+    b._seedHex = seed
+
+    expect(() => b.shutdown()).toThrow('signer destroy failed')
+    expect(b._signer).toBeNull()
+    expect(seed.every((byte) => byte === 0)).toBe(true)
   })
 })
 

--- a/tests/node-binding-methods.test.js
+++ b/tests/node-binding-methods.test.js
@@ -274,6 +274,69 @@ describe('unlock', () => {
     }
   })
 
+  it('destroys a newly created fallback signer when the primary signer cannot be released', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const primarySigner = fakeSigner()
+    const fallbackSigner = fakeSigner()
+    const destroyError = new Error('primary signer destroy failed')
+    primarySigner.destroy.mockImplementation(() => { throw destroyError })
+    node.unlockWithNativeExternalSigner.mockImplementation(() => {
+      throw new Error('Rln(ExternalSignerMismatch): External signer identity does not match persisted node identity')
+    })
+    const createSpy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
+    const primarySeed = Buffer.from('seed-v2')
+    const fallbackSeed = Buffer.from('seed-v1')
+    b._node = node
+    b._signer = primarySigner
+    b._seedHex = primarySeed
+    b._fallbackSeedHex = fallbackSeed
+    try {
+      expect(() => b.unlock({})).toThrow(destroyError)
+      expect(fallbackSigner.destroy).toHaveBeenCalledTimes(1)
+      expect(b._signer).toBe(primarySigner)
+      expect(b._seedHex).toBe(primarySeed)
+      expect(b._fallbackSeedHex).toBe(fallbackSeed)
+      expect(node.unlockWithNativeExternalSigner).toHaveBeenCalledTimes(1)
+    } finally {
+      createSpy.mockRestore()
+    }
+  })
+
+  it('reports both native cleanup failures during fallback replacement', () => {
+    const b = makeBinding()
+    const node = fakeNode()
+    const primarySigner = fakeSigner()
+    const fallbackSigner = fakeSigner()
+    const primaryError = new Error('primary signer destroy failed')
+    const fallbackError = new Error('fallback signer destroy failed')
+    primarySigner.destroy.mockImplementation(() => { throw primaryError })
+    fallbackSigner.destroy.mockImplementation(() => { throw fallbackError })
+    node.unlockWithNativeExternalSigner.mockImplementation(() => {
+      throw new Error('Rln(ExternalSignerMismatch): External signer identity does not match persisted node identity')
+    })
+    const createSpy = jest.spyOn(rln.NativeExternalSigner, 'create').mockReturnValue(fallbackSigner)
+    b._node = node
+    b._signer = primarySigner
+    b._seedHex = Buffer.from('seed-v2')
+    b._fallbackSeedHex = Buffer.from('seed-v1')
+    try {
+      let thrown
+      try {
+        b.unlock({})
+      } catch (error) {
+        thrown = error
+      }
+      expect(thrown).toBeInstanceOf(AggregateError)
+      expect(thrown.message).toBe('unlock: failed to destroy both the primary and fallback signers')
+      expect(thrown.errors).toEqual([primaryError, fallbackError])
+      expect(fallbackSigner.destroy).toHaveBeenCalledTimes(1)
+      expect(b._signer).toBe(primarySigner)
+    } finally {
+      createSpy.mockRestore()
+    }
+  })
+
   it('does not retry a generic unlock failure with the legacy signer', () => {
     const b = makeBinding()
     const node = fakeNode()

--- a/tests/not-implemented.test.js
+++ b/tests/not-implemented.test.js
@@ -13,7 +13,7 @@ import { NotImplementedError } from '../src/errors.js'
 function makeAccount () {
   return new WalletAccountRgbLightning({
     binding: {
-      node: { verifyMessage: () => ({ valid: true }) }
+      ensureNode: () => ({ verifyMessage: () => ({ valid: true }) })
     }
   })
 }

--- a/tests/types-contract.ts
+++ b/tests/types-contract.ts
@@ -6,6 +6,7 @@ import type {
   IRgbLightningBinding,
   LnurlPayOptions,
   LspLiquidityTimeoutError,
+  PayAddressOptions,
   WalletAccountReadOnlyRgbLightning,
   WalletAccountRgbLightning
 } from '../index.js'
@@ -28,11 +29,17 @@ const lnurlOptions: LnurlPayOptions = {
   allowCrossHostCallback: true,
   assetAmount: 1n
 }
+const payAddressOptions: PayAddressOptions = {
+  address: 'alice@example.com',
+  amtMsat: '1000',
+  allowCrossHostCallback: true
+}
 const minimumLiquidity: number = liquidityError.minMsat
 
 binding.ensureNode()
-// @ts-expect-error The review removed the inconsistent node getter.
+// @ts-expect-error IRgbLightningBinding exposes ensureNode(), not a node property.
 binding.node
 
 void lnurlOptions
+void payAddressOptions
 void minimumLiquidity

--- a/tests/types-contract.ts
+++ b/tests/types-contract.ts
@@ -3,6 +3,9 @@ import type { IWalletAccount, IWalletAccountReadOnly } from '@tetherto/wdk-walle
 
 import type WalletManagerRgbLightning from '../index.js'
 import type {
+  IRgbLightningBinding,
+  LnurlPayOptions,
+  LspLiquidityTimeoutError,
   WalletAccountReadOnlyRgbLightning,
   WalletAccountRgbLightning
 } from '../index.js'
@@ -10,6 +13,8 @@ import type {
 declare const manager: WalletManagerRgbLightning
 declare const account: WalletAccountRgbLightning
 declare const readOnlyAccount: WalletAccountReadOnlyRgbLightning
+declare const binding: IRgbLightningBinding
+declare const liquidityError: LspLiquidityTimeoutError
 
 const managerContract: WalletManager = manager
 const accountContract: IWalletAccount = account
@@ -18,3 +23,16 @@ const readOnlyContract: IWalletAccountReadOnly = readOnlyAccount
 void managerContract
 void accountContract
 void readOnlyContract
+
+const lnurlOptions: LnurlPayOptions = {
+  allowCrossHostCallback: true,
+  assetAmount: 1n
+}
+const minimumLiquidity: number = liquidityError.minMsat
+
+binding.ensureNode()
+// @ts-expect-error The review removed the inconsistent node getter.
+binding.node
+
+void lnurlOptions
+void minimumLiquidity

--- a/tests/utexo-lsp.test.js
+++ b/tests/utexo-lsp.test.js
@@ -14,6 +14,7 @@
 import { jest } from '@jest/globals'
 import {
   LspChannelTimeoutError,
+  LspLiquidityTimeoutError,
   LspSettlementError,
   peerUri,
   normalizeReceiveStatus,
@@ -57,6 +58,20 @@ function makeLsp (account, peer = PEER) {
     getLightningAddressByPubkey: jest.fn(async () => ({ username: 'alice', domain: 'lsp.example.io' }))
   }
   return lsp
+}
+
+function lnurlResponse (body) {
+  return { ok: true, status: 200, text: async () => JSON.stringify(body) }
+}
+
+function lnurlDiscovery (callback) {
+  return {
+    tag: 'payRequest',
+    callback,
+    minSendable: 1,
+    maxSendable: 100000,
+    metadata: '[["text/plain","pay"]]'
+  }
 }
 
 beforeEach(() => {
@@ -125,6 +140,18 @@ describe('LspSettlementError', () => {
     expect(e.step).toBe('ln_invoice')
     expect(e.status).toBe('Failed')
     expect(e.message).toBe('Settlement ended with status "Failed" at step ln_invoice')
+  })
+})
+
+describe('LspLiquidityTimeoutError', () => {
+  it('carries the requested floor, elapsed time, and LSP peer', () => {
+    const e = new LspLiquidityTimeoutError(5000, 120000, PEER.peerPubkey)
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('LspLiquidityTimeoutError')
+    expect(e.minMsat).toBe(5000)
+    expect(e.elapsedMs).toBe(120000)
+    expect(e.peerPubkey).toBe(PEER.peerPubkey)
+    expect(e.message).toContain('below 5000 msat after 120s')
   })
 })
 
@@ -475,11 +502,12 @@ describe('waitForOutboundLiquidity', () => {
     expect(onProgress).toHaveBeenCalledWith('outbound: 9000 msat (need 1)')
   })
 
-  it('keeps polling and returns (without throwing) when liquidity never arrives', async () => {
+  it('throws a typed timeout when liquidity never arrives', async () => {
     const account = makeAccount({ listChannels: jest.fn(async () => []) })
     const lsp = makeLsp(account)
-    await expect(lsp.waitForOutboundLiquidity(10000, { timeoutMs: 5, pollIntervalMs: 1 }))
-      .resolves.toBeUndefined()
+    const error = await lsp.waitForOutboundLiquidity(10000, { timeoutMs: 5, pollIntervalMs: 1 }).catch((cause) => cause)
+    expect(error).toBeInstanceOf(LspLiquidityTimeoutError)
+    expect(error).toMatchObject({ minMsat: 10000, elapsedMs: 5, peerPubkey: PEER.peerPubkey })
   })
 
   it('IGNORES a peer-matching channel that is not usable (the is_usable conjunct)', async () => {
@@ -492,7 +520,8 @@ describe('waitForOutboundLiquidity', () => {
     const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
     const lsp = makeLsp(account)
     const onProgress = jest.fn()
-    await lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress })
+    await expect(lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress }))
+      .rejects.toBeInstanceOf(LspLiquidityTimeoutError)
     expect(onProgress).toHaveBeenCalledWith('outbound: 0 msat (need 5000)')
     expect(onProgress).not.toHaveBeenCalledWith(expect.stringContaining('9999'))
   })
@@ -504,7 +533,8 @@ describe('waitForOutboundLiquidity', () => {
     const account = makeAccount({ listChannels: jest.fn(async () => [channel]) })
     const lsp = makeLsp(account)
     const onProgress = jest.fn()
-    await lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress })
+    await expect(lsp.waitForOutboundLiquidity(5000, { timeoutMs: 5, pollIntervalMs: 1, onProgress }))
+      .rejects.toBeInstanceOf(LspLiquidityTimeoutError)
     expect(onProgress).toHaveBeenCalledWith('outbound: 0 msat (need 5000)')
     expect(onProgress).not.toHaveBeenCalledWith(expect.stringContaining('9999'))
   })
@@ -573,20 +603,20 @@ describe('payAddress', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled()
   })
 
-  it('falls back to LNURL discovery on the address domain when the LSP resolve fails', async () => {
+  it('uses the shared LNURL resolver directly for an external address', async () => {
     const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'fb' })) })
     const lsp = makeLsp(account)
-    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('lsp resolve down') })
     globalThis.fetch = jest.fn()
-      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://other.test/cb?x=1' }) })
-      .mockResolvedValueOnce({ json: async () => ({ pr: 'lnbcrt-lnurl' }) })
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://other.test/cb?x=1')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-lnurl' }))
 
     const out = await lsp.payAddress({
       address: 'bob@other.test',
       amtMsat: 3000,
       asset: { assetId: 'assetY', assetAmount: 9 }
     })
-    expect(globalThis.fetch).toHaveBeenNthCalledWith(1, 'https://other.test/.well-known/lnurlp/bob')
+    expect(globalThis.fetch.mock.calls[0][0]).toBe('https://other.test/.well-known/lnurlp/bob')
+    expect(lsp.http.resolveAddress).not.toHaveBeenCalled()
     const secondUrl = globalThis.fetch.mock.calls[1][0]
     expect(secondUrl).toContain('https://other.test/cb?x=1')
     expect(secondUrl).toContain('&amount=3000')
@@ -597,28 +627,37 @@ describe('payAddress', () => {
 
   it('uses a ? separator in the fallback callback when none is present', async () => {
     const lsp = makeLsp(makeAccount())
-    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
     globalThis.fetch = jest.fn()
-      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://other.test/cb' }) })
-      .mockResolvedValueOnce({ json: async () => ({ pr: 'lnbcrt-q' }) })
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://other.test/cb')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-q' }))
     await lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 })
     expect(globalThis.fetch.mock.calls[1][0]).toContain('https://other.test/cb?amount=1')
   })
 
   it('throws when no global fetch is available for the fallback', async () => {
     const lsp = makeLsp(makeAccount())
-    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
     delete globalThis.fetch
     await expect(lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 }))
-      .rejects.toThrow('no global fetch for LNURL fallback')
+      .rejects.toThrow('no global fetch')
   })
 
   it('throws when the LNURL response has no callback', async () => {
     const lsp = makeLsp(makeAccount())
-    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('down') })
-    globalThis.fetch = jest.fn().mockResolvedValueOnce({ json: async () => ({}) })
+    globalThis.fetch = jest.fn().mockResolvedValueOnce(lnurlResponse(lnurlDiscovery(undefined)))
     await expect(lsp.payAddress({ address: 'bob@other.test', amtMsat: 1 }))
-      .rejects.toThrow('missing callback in LNURL response')
+      .rejects.toThrow('invalid callback')
+  })
+
+  it('falls back to the shared resolver when the same-host LSP path fails', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('LSP unavailable') })
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://lsp.example.io/cb')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-fallback' }))
+    await expect(lsp.payAddress({ address: 'alice@lsp.example.io', amtMsat: 2 }))
+      .resolves.toMatchObject({ invoice: 'lnbcrt-fallback' })
+    expect(lsp.http.resolveAddress).toHaveBeenCalledTimes(1)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('throws when no invoice is returned from either path', async () => {

--- a/tests/utexo-lsp.test.js
+++ b/tests/utexo-lsp.test.js
@@ -625,6 +625,37 @@ describe('payAddress', () => {
     expect(out).toEqual({ invoice: 'lnbcrt-lnurl', sendResult: { payment_hash: 'fb' } })
   })
 
+  it('rejects a delegated callback by default', async () => {
+    const account = makeAccount()
+    const lsp = makeLsp(account)
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://delegate.test/cb')))
+
+    await expect(lsp.payAddress({ address: 'bob@other.test', amtMsat: 3000 }))
+      .rejects.toThrow("callback host 'delegate.test' does not match discovery host 'other.test'")
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(account.sendPayment).not.toHaveBeenCalled()
+  })
+
+  it('forwards the explicit delegated-callback opt-in', async () => {
+    const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'delegated' })) })
+    const lsp = makeLsp(account)
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://delegate.test/cb')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-delegated' }))
+
+    await expect(lsp.payAddress({
+      address: 'bob@other.test',
+      amtMsat: '3000',
+      allowCrossHostCallback: true
+    })).resolves.toEqual({
+      invoice: 'lnbcrt-delegated',
+      sendResult: { payment_hash: 'delegated' }
+    })
+    expect(globalThis.fetch.mock.calls[1][0]).toBe('https://delegate.test/cb?amount=3000')
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: 'lnbcrt-delegated' })
+  })
+
   it('uses a ? separator in the fallback callback when none is present', async () => {
     const lsp = makeLsp(makeAccount())
     globalThis.fetch = jest.fn()

--- a/tests/wallet-account-surface.test.js
+++ b/tests/wallet-account-surface.test.js
@@ -5,8 +5,8 @@
 
 // Surface coverage for WalletAccountRgbLightning + the read-only façade
 // it returns from toReadOnlyAccount(). Most methods are 1-line
-// passthroughs to this._node.<x>() (the _node getter returns
-// this._binding.node) or this._binding.<x>(); these tests assert each
+// passthroughs to this._node.<x>() (the _node getter calls
+// this._binding.ensureNode()) or this._binding.<x>(); these tests assert each
 // account method forwards to the right node/binding method with the
 // right args and maps the result as documented.
 //
@@ -83,21 +83,20 @@ function makeNode (overrides = {}) {
   }
 }
 
-// Build a fake binding around a node. node-level overrides go via
-// `node`; binding-level overrides spread on top.
+// Build a fake binding around a node. Node-level overrides go via `node`;
+// the binding exposes it through ensureNode(), matching the native wrappers.
 function makeBinding (overrides = {}) {
-  const node = overrides.node ?? makeNode()
+  const { node: nodeOverride, ...bindingOverrides } = overrides
+  const node = nodeOverride ?? makeNode()
   const binding = {
+    ensureNode: jest.fn(() => node),
     unlock: jest.fn(() => undefined),
     bootstrap: jest.fn(() => ({ node_id: 'aa'.repeat(33) })),
     shutdown: jest.fn(() => undefined),
     apayNew: jest.fn(() => ({ order_id: 'o1' })),
     vssStatus: jest.fn(() => ({ configured: false, url: null, allowHttp: false, lastBackupVersion: null })),
-    ...overrides
+    ...bindingOverrides
   }
-  // Ensure the binding's `node` getter target is the resolved node even
-  // when overrides supplied one (or none).
-  binding.node = node
   return binding
 }
 
@@ -111,10 +110,11 @@ describe('construction', () => {
     expect(() => new WalletAccountRgbLightning({})).toThrow(/requires a BareRgbLightningBinding/)
   })
 
-  it('exposes the node via the _binding.node getter', () => {
+  it('exposes the cached node through binding.ensureNode()', () => {
     const node = makeNode()
     const account = makeAccount({ node })
     expect(account._node).toBe(node)
+    expect(account._binding.ensureNode).toHaveBeenCalledTimes(1)
   })
 
   it('follows the current WDK inheritance chain through the concrete read-only account', () => {
@@ -281,9 +281,7 @@ describe('getAddress', () => {
 
   it('classifies an uncreated native node as locked', async () => {
     const binding = makeBinding()
-    Object.defineProperty(binding, 'node', {
-      get: () => { throw new Error('SdkNode not created — call unlock() first') }
-    })
+    binding.ensureNode.mockImplementation(() => { throw new Error('SdkNode not created — call unlock() first') })
     const account = new WalletAccountRgbLightning({ binding })
     await expect(account.getAddress()).rejects.toBeInstanceOf(AccountLockedError)
     await expect(account.getBalance()).resolves.toBe(0n)

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -24,7 +24,7 @@ class FakeBinding {
     this.shutdown = jest.fn()
     this.bootstrap = jest.fn(() => ({ node_id: '02' + '11'.repeat(32) }))
     this.vssStatus = jest.fn(() => ({ configured: false, url: null, allowHttp: false, lastBackupVersion: null }))
-    this.node = {}
+    this.ensureNode = jest.fn(() => ({}))
     FakeBinding.instances.push(this)
   }
 }


### PR DESCRIPTION
## Summary

Addresses all 17 unresolved WDK team review threads from the review-only snapshot in #25 on a fresh branch based on current `main`, including merged read-only account PR #26.

This PR keeps the newer WDK account and binding architecture intact, hardens LNURL/LSP handling, makes outbound-liquidity timeout behavior explicit, and ensures retained seed material is zeroized throughout the binding lifecycle.

## Review feedback addressed

### LSP utilities and request shaping

- [x] Remove the duplicate `toUint64` implementation from `lsp-client.js`.
- [x] Move shared conversion and request-shaping utilities into an acyclic utility module.
- [x] Default RGB assignment to `Any` when it is omitted.
- [x] Replace the permissive `toUint32` branch with strict unsigned-integer validation.

### Binding contract and secret lifecycle

- [x] Remove the unused `__SHAPE_ONLY` export.
- [x] Document `virtualPeerPubkeys` in the Bare binding configuration.
- [x] Declare retained seed state explicitly in both bindings.
- [x] Remove both binding `node` getters and route node access through `ensureNode()`.
- [x] Zeroize both bindings' retained seed buffers with `sodium_memzero`.

### Errors, LNURL, and composed flows

- [x] Correct the account error documentation so it no longer claims parity with `LspError`.
- [x] Validate LNURL amount bounds through the shared uint helper and normalize failures as `LnurlPayError`.
- [x] Restrict LNURL callback hosts to the discovery host by default, with an explicit delegation opt-in.
- [x] Reuse the shared LNURL-pay implementation from `UtexoLsp`.
- [x] Throw a typed `LspLiquidityTimeoutError` when outbound liquidity does not arrive before the deadline.

## Follow-up hardening

- [x] Expose and forward `allowCrossHostCallback` through `UtexoLsp.payAddress()` and `PayAddressOptions`.
- [x] Destroy a newly created fallback signer if the primary signer cannot be released.
- [x] Preserve the primary native error when fallback cleanup succeeds and report both failures with `AggregateError` when both cleanup calls fail.
- [x] Execute the Bare binding under Jest with a dedicated native-addon mock and cover `bare-binding.js` at 100% for statements, branches, functions, and lines.
- [x] Replace review-process residue and inaccurate security/lifecycle wording with durable package documentation.

## Architecture notes

- Shared pure utilities live in `src/lsp-utils.js`, rather than importing them from `lsp-helpers.js`. This satisfies the ownership and deduplication feedback without introducing a `lsp-client.js <-> lsp-helpers.js` dependency cycle.
- Signer replacement is transactional: binding state changes only after the primary signer is released; an unused fallback signer is explicitly destroyed on failure.
- The read-only account added in #26 is preserved. Its adapter and the writable account use the binding's `ensureNode()` contract.
- Generic Lightning Addresses use the shared LNURL resolver. Direct LSP lookup is limited to same-host addresses, with same-host failures falling back to LNURL.
- Cross-host LNURL callbacks remain disabled by default and require `allowCrossHostCallback: true`.
- Package version and native binding peer floors are unchanged. The only dependency addition remains exact `sodium-universal@5.0.1`, matching sibling WDK wallet modules.

## Verification

- [x] `npm ci` (0 vulnerabilities)
- [x] `npm run lint`
- [x] `npm run check:types`
- [x] `npm test -- --runInBand`: 14 suites, 513 tests passed
- [x] `npm run test:coverage -- --runInBand`
- [x] `npm pack --dry-run --json`
- [x] `git diff --check`

Coverage:

| Metric | Result |
| --- | ---: |
| Statements | 99.22% |
| Branches | 96.14% |
| Functions | 98.82% |
| Lines | 99.62% |

`bare-binding.js` and `node-binding.js` are both at 100% across all four metrics.

## Review provenance

PR #25 remains untouched as requested. This separate draft carries the fixes on top of merged PR #26 and is intended for a fresh WDK review.

