### PR TITLE
Add coherent dual-keychain wallet refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ while pre-`1.0`.
   shape.
 
 ### Fixed
+- Wallet snapshot validation now canonicalizes only recognized legacy native
+  network casing (for example, `Regtest` to `regtest`) before enforcing the
+  strict v1 contract. This keeps source-PR installs compatible with published
+  beta.14 native prebuilds while unknown network names still fail closed.
 - WDK conformance for `index`, `path`, `keyPair`, `sign()`, `getBalance()`,
   `getTokenBalance()`, `sendTransaction()`, quotes, and confirmed receipt
   semantics. Balance failures are no longer silently converted to zero unless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ while pre-`1.0`.
 ## [Unreleased]
 
 ### Added
+- **Versioned wallet refresh contract:** `account.refreshWalletSnapshot()`
+  serializes/coalesces refreshes, explicitly FullSyncs or recovery FullScans
+  both native keychains, validates bounded BigInt-safe snapshot DTOs, retries
+  one moving-tip capture, and reports partial sync, native, contract, and
+  coherence failures through `WalletSyncError` / `WalletSnapshotError`.
 - **First-class read-only account:** exported
   `WalletAccountReadOnlyRgbLightning extends WalletAccountReadOnly`, with
   all seven mandatory WDK reads plus node, channel, peer, invoice, payment,

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ and a regtest stack via Docker Compose — lives in
 | `virtualPeerPubkeys` | — | Trust list of peer node_ids allowed to open `trusted_no_broadcast` virtual channels (the LSP's node_id for APay). |
 | `permissiveSignerPolicy` | `true` | Loosen the VLS policy filter for in-process single-user use. |
 | `nodeSeedDerivation` | `auto` | New nodes use WDK's normalized BIP-39 seed directly; existing beta nodes retry the legacy identity only on an exact persisted-identity mismatch. Use `wdk-seed-v2` or `legacy-v1` to disable auto-detection. |
+| `autoUnlockRequest` | — | Optional typed node request for integrations that load `getAddress()` before exposing account extensions, including WDK React Native Core. Concurrent activation is coalesced and only the real native address is returned. Omit it for explicit/manual unlock. |
 | `vssUrl` / `vssAllowHttp` / `vssAllowEmptyRestore` | — | VSS cloud backup; see [below](#vss-cloud-backup). |
 | `lspBaseUrl` / `lspBearerToken` | — | LSP wiring for APay and the LSP client; see [below](#lsp-integration). |
 
@@ -216,7 +217,9 @@ Notes:
   it rejects with `AccountLockedError`; UI loaders can call
   `getAddressState()` for `{ status: 'locked', address: null }`. The WDK
   bindings initialize RLN with address reuse enabled so reads stay stable;
-  `rotateAddress()` is the explicit mutating operation for advancing it.
+  `rotateAddress()` is the explicit mutating operation for advancing it. A full
+  account configured with `autoUnlockRequest` first coalesces native activation
+  and then retries the real address; the read-only account contract is unchanged.
 - **`sendTransaction()` uses WDK's `{ to, value, feeRate?,
   confirmationTarget? }` input and `{ hash, fee }` result.** `sendBtc()` is
   the explicit low-level escape hatch for RLN's native request format.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ are async and forward to the active binding.
 | Group | Methods |
 |-------|---------|
 | Lifecycle | `unlock(request)`, `getBootstrap()`, `shutdown()`, `dispose()` |
-| Node info | `getNodeInfo()`, `getNetworkInfo()`, `sync()`, `getAddress()`, `getAddressState()`, `rotateAddress()` |
+| Node info | `getNodeInfo()`, `getNetworkInfo()`, `refreshWalletSnapshot(options?)`, `sync()` (legacy), `getAddress()`, `getAddressState()`, `rotateAddress()` |
 | Peers | `connectPeer(pubkey@host:port)`, `disconnectPeer(request)`, `listPeers()` |
 | Channels | `openChannel(request)`, `closeChannel(request)`, `listChannels()`, `getChannelId(tempIdHex)` |
 | Invoices | `createInvoice(request)`, `createLightningInvoice(request)`, `decodeInvoice(invoice)`, `getInvoiceStatus(invoice)` |
@@ -187,6 +187,18 @@ are async and forward to the active binding.
 | APay / LSP | `apayNew(hostNodeId)`, `bootstrapLsp({ peerPubkeyAndAddr, hostNodeId? })`, `getLspConfig()`, `createLsp(peer?)` |
 
 Notes:
+
+- **`refreshWalletSnapshot()` is the production balance/history refresh.** It
+  serializes native refreshes, coalesces identical requests, FullSyncs both
+  Vanilla and Colored keychains in `routine` mode, and FullScans both only in
+  explicit `recovery` mode. It validates the complete version-1 response,
+  preserves all monetary values as decimal strings, and retries one capture
+  if the chain tip changes between its before/after observations. The legacy
+  `sync()` remains for compatibility but only performs RLN's old Colored
+  FastSync and must not drive portfolio state.
+- **Lightning claimable value is not routing capacity.** The snapshot keeps
+  aggregate/per-channel claimable satoshis separate from inbound and outbound
+  capacity. Consumers must not relabel either capacity as wallet-owned value.
 
 - **`createInvoice` / `createLightningInvoice`** accept either RLN's native
   snake_case request or a camelCase convenience shape

--- a/index-bare.js
+++ b/index-bare.js
@@ -28,6 +28,8 @@ export {
   VssError,
   VssNotConfiguredError,
   ApayError,
+  WalletSyncError,
+  WalletSnapshotError,
   NotImplementedError
 } from './src/errors.js'
 

--- a/index-node.js
+++ b/index-node.js
@@ -30,6 +30,8 @@ export {
   VssError,
   VssNotConfiguredError,
   ApayError,
+  WalletSyncError,
+  WalletSnapshotError,
   NotImplementedError
 } from './src/errors.js'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export interface WalletSnapshotOptions {
 }
 
 export interface WalletSnapshotNetwork {
-  network: string
+  network: Network
   height: number
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,169 @@ import WalletManager, { WalletAccountReadOnly } from '@tetherto/wdk-wallet'
 
 export type Network = 'mainnet' | 'testnet' | 'regtest' | 'signet'
 
+/** Integer encoded as base-10 text so values never cross JS's safe-number boundary. */
+export type DecimalString = `${bigint}`
+
+export type WalletSyncMode = 'routine' | 'recovery'
+
+export type WalletSyncKeychainResult =
+  | { status: 'succeeded' }
+  | { status: 'failed'; error_code: string }
+
+export interface WalletSyncResponse {
+  contract_version: 1
+  mode: WalletSyncMode
+  vanilla: WalletSyncKeychainResult
+  colored: WalletSyncKeychainResult
+}
+
+export interface WalletSnapshotOptions {
+  mode?: WalletSyncMode
+  assetIds?: string[]
+  maxAssets?: number
+  maxChannels?: number
+  maxActivityItems?: number
+  includeActivity?: boolean
+}
+
+export interface WalletSnapshotNetwork {
+  network: string
+  height: number
+}
+
+export interface WalletSnapshotBalance {
+  settled: DecimalString
+  future: DecimalString
+  spendable: DecimalString
+}
+
+export interface WalletSnapshotBtc {
+  vanilla: WalletSnapshotBalance
+  colored: WalletSnapshotBalance
+}
+
+export interface WalletSnapshotAssetBalance extends WalletSnapshotBalance {
+  offchain_outbound: DecimalString
+  offchain_inbound: DecimalString
+}
+
+export interface WalletSnapshotAsset {
+  asset_id: string
+  ticker: string
+  name: string
+  precision: number
+  balance: WalletSnapshotAssetBalance
+}
+
+export interface WalletSnapshotNode {
+  pubkey: string
+  num_channels: DecimalString
+  num_usable_channels: DecimalString
+  claimable_onchain_sat: DecimalString
+  eventual_close_fees_sat: DecimalString
+  pending_outbound_payments_sat: DecimalString
+  num_peers: DecimalString
+  latest_rgs_snapshot_timestamp: DecimalString | null
+}
+
+export interface WalletSnapshotChannel {
+  channel_id: string
+  peer_pubkey: string
+  status: 'Opening' | 'Opened' | 'Closing'
+  ready: boolean
+  capacity_sat: DecimalString
+  claimable_onchain_sat: DecimalString
+  outbound_capacity_msat: DecimalString
+  inbound_capacity_msat: DecimalString
+  next_outbound_htlc_limit_msat: DecimalString
+  next_outbound_htlc_minimum_msat: DecimalString
+  is_usable: boolean
+  public: boolean
+  funding_txid: string | null
+  peer_alias: string | null
+  short_channel_id: DecimalString | null
+  asset_id: string | null
+  asset_local_amount: DecimalString | null
+  asset_remote_amount: DecimalString | null
+  virtual_open_mode: string | null
+}
+
+export interface WalletSnapshotBlockTime {
+  height: number
+  timestamp: DecimalString
+}
+
+export interface WalletSnapshotTransaction {
+  transaction_type: 'RgbSend' | 'Drain' | 'CreateUtxos' | 'SendBtc' | 'Incoming'
+  txid: string
+  received: DecimalString
+  sent: DecimalString
+  fee: DecimalString
+  confirmation_time: WalletSnapshotBlockTime | null
+}
+
+export interface WalletSnapshotPayment {
+  amt_msat: DecimalString | null
+  asset_amount: DecimalString | null
+  asset_id: string | null
+  payment_hash: string
+  payment_type: 'Outbound' | 'InboundAutoClaim' | 'InboundHodl'
+  status: 'Pending' | 'Claimable' | 'Claiming' | 'Succeeded' | 'Cancelled' | 'Failed'
+  created_at: DecimalString
+  updated_at: DecimalString
+  payee_pubkey: string
+}
+
+export interface WalletSnapshotTransferEndpoint {
+  endpoint: string
+  transport_type: string
+  used: boolean
+}
+
+export interface WalletSnapshotTransfer {
+  idx: number
+  created_at: DecimalString
+  updated_at: DecimalString
+  status: string
+  requested_assignment: string | null
+  assignments: string[]
+  kind: string
+  txid: string | null
+  recipient_id: string | null
+  receive_utxo: string | null
+  change_utxo: string | null
+  expiration: DecimalString | null
+  transport_endpoints: WalletSnapshotTransferEndpoint[]
+}
+
+export interface WalletSnapshotAssetTransfers {
+  asset_id: string
+  transfers: WalletSnapshotTransfer[]
+}
+
+export interface WalletSnapshotResponse {
+  contract_version: 1
+  native_source: 'rgb-lightning-node-v0.9.0-beta.3+utexo-wallet-v1'
+  capture_sequence: DecimalString
+  started_at_ms: DecimalString
+  completed_at_ms: DecimalString
+  network_before: WalletSnapshotNetwork
+  network_after: WalletSnapshotNetwork
+  node: WalletSnapshotNode
+  btc: WalletSnapshotBtc
+  assets: WalletSnapshotAsset[]
+  channels: WalletSnapshotChannel[]
+  transactions?: WalletSnapshotTransaction[]
+  payments?: WalletSnapshotPayment[]
+  transfers?: WalletSnapshotAssetTransfers[]
+}
+
+export interface WalletRefreshResult {
+  contractVersion: 1
+  sync: WalletSyncResponse
+  snapshot: WalletSnapshotResponse
+}
+
 export interface Transaction {
   to: string
   value: number | bigint
@@ -366,7 +529,9 @@ export class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbLightning
   // Node info / network / sync
   getNodeInfo(): Promise<object>
   getNetworkInfo(): Promise<object>
+  /** @deprecated Uses the legacy Colored-only FastSync. */
   sync(): Promise<{ ok: true }>
+  refreshWalletSnapshot(options?: WalletSnapshotOptions): Promise<WalletRefreshResult>
 
   // Channels
   openChannel(request: OpenChannelRequest | object): Promise<object>
@@ -442,16 +607,19 @@ export default class WalletManagerRgbLightning extends WalletManager {
 // ───────────────────────────────────────────────────────────────────
 
 export class RgbLightningError extends Error {
-  constructor(message: string, opts?: { code?: string; cause?: unknown })
+  constructor(message: string, opts?: { code?: string; cause?: unknown; details?: unknown })
   code: string
   cause?: unknown
-  toJSON(): { name: string; code: string; message: string; cause: unknown }
+  details?: unknown
+  toJSON(): { name: string; code: string; message: string; details: unknown; cause: unknown }
 }
 export class UnlockError extends RgbLightningError {}
 export class AccountLockedError extends RgbLightningError {}
 export class VssError extends RgbLightningError {}
 export class VssNotConfiguredError extends VssError {}
 export class ApayError extends RgbLightningError {}
+export class WalletSyncError extends RgbLightningError {}
+export class WalletSnapshotError extends RgbLightningError {}
 export class NotImplementedError extends RgbLightningError {}
 
 // ───────────────────────────────────────────────────────────────────

--- a/index.d.ts
+++ b/index.d.ts
@@ -388,6 +388,12 @@ export interface RgbLightningWalletConfig extends RgbLightningBindingConfig {
    * the legacy beta derivation only for an existing signer-identity mismatch.
    */
   nodeSeedDerivation?: 'auto' | 'wdk-seed-v2' | 'legacy-v1'
+  /**
+   * Optional node request used to activate the full account when an integration
+   * (including WDK React Native Core) loads its address before exposing account
+   * extension methods. The account returns only the real native address.
+   */
+  autoUnlockRequest?: RgbLightningNodeUnlockRequest
   bitcoindRpcUsername?: string
   bitcoindRpcPassword?: string
   bitcoindRpcHost?: string
@@ -398,6 +404,17 @@ export interface RgbLightningWalletConfig extends RgbLightningBindingConfig {
   announceAlias?: string
 }
 
+export interface RgbLightningNodeUnlockRequest {
+  bitcoind_rpc_username: string
+  bitcoind_rpc_password: string
+  bitcoind_rpc_host: string
+  bitcoind_rpc_port: number
+  indexer_url: string
+  proxy_endpoint: string
+  announce_addresses: string[]
+  announce_alias: string
+}
+
 // ───────────────────────────────────────────────────────────────────
 // Bindings (low-level; usually not constructed directly)
 // ───────────────────────────────────────────────────────────────────
@@ -405,7 +422,7 @@ export interface RgbLightningWalletConfig extends RgbLightningBindingConfig {
 export interface IRgbLightningBinding {
   ensureNode(): unknown
   attachExternalSigner(seedHex: string, fallbackSeedHex?: string): void
-  unlock(unlockRequest: object): void
+  unlock(unlockRequest: RgbLightningNodeUnlockRequest): void
   bootstrap(): object
   clearVssFence(password: string): void
   vssBackup(): { version: number }
@@ -490,14 +507,17 @@ export class WalletAccountReadOnlyRgbLightning extends WalletAccountReadOnly {
 }
 
 export class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbLightning {
-  constructor(bindings: { binding: IRgbLightningBinding })
+  constructor(bindings: {
+    binding: IRgbLightningBinding
+    autoUnlockRequest?: RgbLightningNodeUnlockRequest
+  })
 
   readonly index: 0
   readonly path: 'm'
   readonly keyPair: KeyPair
 
   // Lifecycle
-  unlock(unlockRequest: object): Promise<{ ok: true }>
+  unlock(unlockRequest: RgbLightningNodeUnlockRequest): Promise<{ ok: true }>
   getBootstrap(): Promise<object>
   shutdown(): Promise<{ ok: true }>
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -28,7 +28,7 @@
 export class RgbLightningError extends Error {
   /**
    * @param {string} message
-   * @param {{ code?: string, cause?: unknown }} [opts]
+   * @param {{ code?: string, cause?: unknown, details?: unknown }} [opts]
    */
   constructor (message, opts = {}) {
     super(message)
@@ -36,6 +36,7 @@ export class RgbLightningError extends Error {
     /** Stable, machine-readable error code. */
     this.code = opts.code ?? 'RGB_LIGHTNING_ERROR'
     if (opts.cause !== undefined) this.cause = opts.cause
+    if (opts.details !== undefined) this.details = opts.details
   }
 
   toJSON () {
@@ -43,6 +44,7 @@ export class RgbLightningError extends Error {
       name: this.name,
       code: this.code,
       message: this.message,
+      details: this.details ?? null,
       cause: this.cause instanceof Error
         ? { name: this.cause.name, message: this.cause.message }
         : (this.cause ?? null)
@@ -106,6 +108,30 @@ export class ApayError extends RgbLightningError {
   constructor (message, opts = {}) {
     super(message, { code: opts.code ?? 'APAY_ERROR', cause: opts.cause })
     this.name = 'ApayError'
+  }
+}
+
+/** Raised when either native wallet keychain fails an explicit sync. */
+export class WalletSyncError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, {
+      code: opts.code ?? 'WALLET_SYNC_FAILED',
+      cause: opts.cause,
+      details: opts.details
+    })
+    this.name = 'WalletSyncError'
+  }
+}
+
+/** Raised when the native snapshot is unavailable, malformed, or incoherent. */
+export class WalletSnapshotError extends RgbLightningError {
+  constructor (message, opts = {}) {
+    super(message, {
+      code: opts.code ?? 'WALLET_SNAPSHOT_FAILED',
+      cause: opts.cause,
+      details: opts.details
+    })
+    this.name = 'WalletSnapshotError'
   }
 }
 

--- a/src/node-unlock-request.js
+++ b/src/node-unlock-request.js
@@ -1,0 +1,60 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+const REQUIRED_STRING_FIELDS = Object.freeze([
+  'bitcoind_rpc_username',
+  'bitcoind_rpc_password',
+  'bitcoind_rpc_host',
+  'indexer_url',
+  'proxy_endpoint',
+  'announce_alias'
+])
+
+/**
+ * Validate and defensively copy the request retained for automatic account
+ * activation. Error messages identify fields without echoing credential data.
+ *
+ * @param {unknown} value
+ * @returns {object | undefined}
+ */
+export function normalizeAutoUnlockRequest (value) {
+  if (value === undefined) return undefined
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('autoUnlockRequest must be an object')
+  }
+
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof value[field] !== 'string' || value[field].length === 0) {
+      throw new TypeError(`autoUnlockRequest.${field} must be a non-empty string`)
+    }
+  }
+
+  if (
+    !Number.isInteger(value.bitcoind_rpc_port) ||
+    value.bitcoind_rpc_port < 1 ||
+    value.bitcoind_rpc_port > 65_535
+  ) {
+    throw new TypeError('autoUnlockRequest.bitcoind_rpc_port must be a valid TCP port')
+  }
+
+  if (
+    !Array.isArray(value.announce_addresses) ||
+    !value.announce_addresses.every((address) => typeof address === 'string' && address.length > 0)
+  ) {
+    throw new TypeError('autoUnlockRequest.announce_addresses must be an array of non-empty strings')
+  }
+
+  return Object.freeze({
+    bitcoind_rpc_username: value.bitcoind_rpc_username,
+    bitcoind_rpc_password: value.bitcoind_rpc_password,
+    bitcoind_rpc_host: value.bitcoind_rpc_host,
+    bitcoind_rpc_port: value.bitcoind_rpc_port,
+    indexer_url: value.indexer_url,
+    proxy_endpoint: value.proxy_endpoint,
+    announce_addresses: Object.freeze([...value.announce_addresses]),
+    announce_alias: value.announce_alias
+  })
+}

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -19,11 +19,13 @@ import {
 } from './lsp-helpers.js'
 import { LspClient } from './lsp-client.js'
 import { UtexoLsp } from './utexo-lsp.js'
+import { normalizeAutoUnlockRequest } from './node-unlock-request.js'
 import WalletAccountReadOnlyRgbLightning, {
   createReadOnlyRgbLightningAdapter,
   PENDING_ADDRESS
 } from './wallet-account-read-only-rgb-lightning.js'
 import {
+  AccountLockedError,
   UnlockError,
   VssError,
   VssNotConfiguredError,
@@ -45,6 +47,28 @@ import {
 
 export { PENDING_ADDRESS }
 
+function sameUnlockRequest (left, right) {
+  if (left === right) return true
+  if (!left || !right || typeof left !== 'object' || typeof right !== 'object') return false
+
+  const leftKeys = Object.keys(left).sort()
+  const rightKeys = Object.keys(right).sort()
+  if (leftKeys.length !== rightKeys.length) return false
+
+  return leftKeys.every((key, index) => {
+    if (key !== rightKeys[index]) return false
+    const leftValue = left[key]
+    const rightValue = right[key]
+    if (Array.isArray(leftValue) || Array.isArray(rightValue)) {
+      return Array.isArray(leftValue) &&
+        Array.isArray(rightValue) &&
+        leftValue.length === rightValue.length &&
+        leftValue.every((value, valueIndex) => value === rightValue[valueIndex])
+    }
+    return leftValue === rightValue
+  })
+}
+
 /**
  * Seed-isolated via RLN's `NativeExternalSigner`: the WDK secret manager
  * owns the BIP-39 mnemonic; the manager derives a 32-byte VLS node
@@ -57,7 +81,7 @@ export { PENDING_ADDRESS }
  */
 export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbLightning {
   /**
-   * @param {{ binding: BareRgbLightningBinding }} bindings
+   * @param {{ binding: BareRgbLightningBinding, autoUnlockRequest?: object }} bindings
    */
   constructor (bindings) {
     if (!bindings || !bindings.binding) {
@@ -65,6 +89,9 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
     }
     super(createReadOnlyRgbLightningAdapter(bindings.binding))
     /** @private */ this._binding = bindings.binding
+    /** @private */ this._autoUnlockRequest = normalizeAutoUnlockRequest(bindings.autoUnlockRequest)
+    /** @private @type {{ request: object, promise: Promise<{ ok: true }> } | null} */
+    this._unlockInFlight = null
     /** @private @type {WalletAccountReadOnlyRgbLightning | null} */
     this._readOnlyAccount = null
     /** @private @type {Promise<void>} */
@@ -90,19 +117,54 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
    * @param {Object} unlockRequest
    */
   async unlock (unlockRequest) {
-    try {
-      this._binding.unlock(unlockRequest)
-    } catch (e) {
-      // Wrap into a typed UnlockError so callers can branch on
-      // `err.name === 'UnlockError'` / `err.code` instead of
-      // substring-matching the RLN message. The original message is
-      // preserved verbatim and attached as `cause`.
-      throw wrapError(e, UnlockError)
+    if (this._unlockInFlight) {
+      if (!sameUnlockRequest(this._unlockInFlight.request, unlockRequest)) {
+        throw new UnlockError('A different RGB Lightning unlock request is already in progress.')
+      }
+      return this._unlockInFlight.promise
     }
-    // Return something non-undefined so the worklet's `safeStringify`
-    // produces a real string. The RN-side response schema rejects
-    // null/undefined results (see wdk-react-native-core schemas).
-    return { ok: true }
+
+    const operation = Promise.resolve().then(() => {
+      try {
+        this._binding.unlock(unlockRequest)
+      } catch (e) {
+        // Wrap into a typed UnlockError so callers can branch on
+        // `err.name === 'UnlockError'` / `err.code` instead of
+        // substring-matching the RLN message. The original message is
+        // preserved verbatim and attached as `cause`.
+        throw wrapError(e, UnlockError)
+      }
+      // Return something non-undefined so the worklet's `safeStringify`
+      // produces a real string. The RN-side response schema rejects
+      // null/undefined results (see wdk-react-native-core schemas).
+      return { ok: true }
+    })
+
+    this._unlockInFlight = { request: unlockRequest, promise: operation }
+    try {
+      return await operation
+    } finally {
+      if (this._unlockInFlight?.promise === operation) this._unlockInFlight = null
+    }
+  }
+
+  /**
+   * WDK React Native Core discovers an account by loading its address before
+   * exposing extension methods. When explicitly configured, activate the full
+   * RGB node at that boundary and then return only the real native address.
+   * Standalone and read-only consumers retain the ordinary locked error.
+   */
+  async getAddress () {
+    try {
+      return await super.getAddress()
+    } catch (error) {
+      if (!(error instanceof AccountLockedError) || !this._autoUnlockRequest) {
+        throw error
+      }
+    }
+
+    await this.unlock(this._autoUnlockRequest)
+    return super.getAddress()
   }
 
   /** ✅ Idempotent shutdown. */

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -28,9 +28,20 @@ import {
   VssError,
   VssNotConfiguredError,
   ApayError,
+  WalletSyncError,
+  WalletSnapshotError,
   NotImplementedError,
   wrapError
 } from './errors.js'
+import {
+  WALLET_SNAPSHOT_CONTRACT_VERSION,
+  WalletSnapshotContractError,
+  isCoherentWalletSnapshot,
+  normalizeWalletSnapshotOptions,
+  validateWalletSnapshotResponse,
+  validateWalletSyncResponse,
+  walletSnapshotRequestKey
+} from './wallet-snapshot-contract.js'
 
 export { PENDING_ADDRESS }
 
@@ -56,6 +67,10 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
     /** @private */ this._binding = bindings.binding
     /** @private @type {WalletAccountReadOnlyRgbLightning | null} */
     this._readOnlyAccount = null
+    /** @private @type {Promise<void>} */
+    this._walletSnapshotQueue = Promise.resolve()
+    /** @private @type {Map<string, Promise<object>>} */
+    this._walletSnapshotInFlight = new Map()
   }
 
   /** @private */
@@ -351,10 +366,174 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
   // Node lifecycle — read methods are inherited from the read-only account
   // ==========================================================================
 
-  /** Force a sync of the on-chain wallet. */
+  /**
+   * Force the legacy Colored-only FastSync.
+   * @deprecated Use `refreshWalletSnapshot()` so both keychains are synced.
+   */
   async sync () {
     this._node.sync()
     return { ok: true }
+  }
+
+  /**
+   * Synchronize both native wallet keychains and capture one versioned,
+   * bounded snapshot. Identical concurrent requests coalesce, while different
+   * requests serialize so FullSync and FullScan cannot race each other.
+   *
+   * A snapshot whose before/after chain tip differs is captured once more.
+   * The method fails closed if the retry is also incoherent.
+   *
+   * @param {object} [options]
+   * @returns {Promise<object>}
+   */
+  refreshWalletSnapshot (options) {
+    const normalized = normalizeWalletSnapshotOptions(options)
+    const key = walletSnapshotRequestKey(normalized)
+    const current = this._walletSnapshotInFlight.get(key)
+    if (current) return current
+
+    const operation = this._walletSnapshotQueue
+      .then(() => this._refreshWalletSnapshot(normalized))
+    this._walletSnapshotQueue = operation.then(
+      () => undefined,
+      () => undefined
+    )
+    this._walletSnapshotInFlight.set(key, operation)
+    operation.then(
+      () => this._clearWalletSnapshotFlight(key, operation),
+      () => this._clearWalletSnapshotFlight(key, operation)
+    )
+    return operation
+  }
+
+  /** @private */
+  _clearWalletSnapshotFlight (key, operation) {
+    if (this._walletSnapshotInFlight.get(key) === operation) {
+      this._walletSnapshotInFlight.delete(key)
+    }
+  }
+
+  /** @private */
+  async _refreshWalletSnapshot (options) {
+    const node = this._node
+    if (
+      typeof node.syncWallet !== 'function' ||
+      typeof node.walletSnapshot !== 'function'
+    ) {
+      throw new WalletSnapshotError(
+        'The installed RGB Lightning native binding does not support wallet snapshot contract v1.',
+        { code: 'WALLET_SNAPSHOT_UNSUPPORTED_BINDING' }
+      )
+    }
+
+    let sync
+    try {
+      sync = validateWalletSyncResponse(
+        await node.syncWallet({ mode: options.mode }),
+        options.mode
+      )
+    } catch (error) {
+      const contractFailure = error instanceof WalletSnapshotContractError
+      throw new WalletSyncError(
+        contractFailure
+          ? 'The native wallet sync response does not match contract v1.'
+          : 'The native wallet synchronization failed.',
+        {
+          code: contractFailure
+            ? 'WALLET_SYNC_CONTRACT_MISMATCH'
+            : 'WALLET_SYNC_NATIVE_FAILURE',
+          cause: error,
+          details: Object.freeze({ mode: options.mode })
+        }
+      )
+    }
+
+    if (sync.vanilla.status !== 'succeeded' || sync.colored.status !== 'succeeded') {
+      throw new WalletSyncError(
+        'The native wallet synchronization did not complete for both keychains.',
+        {
+          code: 'WALLET_SYNC_PARTIAL_FAILURE',
+          details: Object.freeze({
+            mode: options.mode,
+            vanilla: sync.vanilla,
+            colored: sync.colored
+          })
+        }
+      )
+    }
+
+    const first = await this._captureWalletSnapshot(node, options)
+    if (isCoherentWalletSnapshot(first)) {
+      return Object.freeze({
+        contractVersion: WALLET_SNAPSHOT_CONTRACT_VERSION,
+        sync,
+        snapshot: first
+      })
+    }
+
+    const retry = await this._captureWalletSnapshot(node, options)
+    if (BigInt(retry.capture_sequence) <= BigInt(first.capture_sequence)) {
+      throw new WalletSnapshotError(
+        'The native wallet snapshot retry did not advance its capture sequence.',
+        {
+          code: 'WALLET_SNAPSHOT_CONTRACT_MISMATCH',
+          details: Object.freeze({
+            firstCaptureSequence: first.capture_sequence,
+            retryCaptureSequence: retry.capture_sequence
+          })
+        }
+      )
+    }
+    if (!isCoherentWalletSnapshot(retry)) {
+      throw new WalletSnapshotError(
+        'The native wallet snapshot changed chain tip during both capture attempts.',
+        {
+          code: 'WALLET_SNAPSHOT_INCOHERENT',
+          details: Object.freeze({
+            first: Object.freeze({
+              before: first.network_before,
+              after: first.network_after,
+              captureSequence: first.capture_sequence
+            }),
+            retry: Object.freeze({
+              before: retry.network_before,
+              after: retry.network_after,
+              captureSequence: retry.capture_sequence
+            })
+          })
+        }
+      )
+    }
+
+    return Object.freeze({
+      contractVersion: WALLET_SNAPSHOT_CONTRACT_VERSION,
+      sync,
+      snapshot: retry
+    })
+  }
+
+  /** @private */
+  async _captureWalletSnapshot (node, options) {
+    try {
+      return validateWalletSnapshotResponse(
+        await node.walletSnapshot(options.nativeRequest),
+        options
+      )
+    } catch (error) {
+      if (error instanceof WalletSnapshotError) throw error
+      const contractFailure = error instanceof WalletSnapshotContractError
+      throw new WalletSnapshotError(
+        contractFailure
+          ? 'The native wallet snapshot does not match contract v1.'
+          : 'The native wallet snapshot could not be captured.',
+        {
+          code: contractFailure
+            ? 'WALLET_SNAPSHOT_CONTRACT_MISMATCH'
+            : 'WALLET_SNAPSHOT_NATIVE_FAILURE',
+          cause: error
+        }
+      )
+    }
   }
 
   // ==========================================================================

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -426,41 +426,7 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       )
     }
 
-    let sync
-    try {
-      sync = validateWalletSyncResponse(
-        await node.syncWallet({ mode: options.mode }),
-        options.mode
-      )
-    } catch (error) {
-      const contractFailure = error instanceof WalletSnapshotContractError
-      throw new WalletSyncError(
-        contractFailure
-          ? 'The native wallet sync response does not match contract v1.'
-          : 'The native wallet synchronization failed.',
-        {
-          code: contractFailure
-            ? 'WALLET_SYNC_CONTRACT_MISMATCH'
-            : 'WALLET_SYNC_NATIVE_FAILURE',
-          cause: error,
-          details: Object.freeze({ mode: options.mode })
-        }
-      )
-    }
-
-    if (sync.vanilla.status !== 'succeeded' || sync.colored.status !== 'succeeded') {
-      throw new WalletSyncError(
-        'The native wallet synchronization did not complete for both keychains.',
-        {
-          code: 'WALLET_SYNC_PARTIAL_FAILURE',
-          details: Object.freeze({
-            mode: options.mode,
-            vanilla: sync.vanilla,
-            colored: sync.colored
-          })
-        }
-      )
-    }
+    let sync = await this._synchronizeWalletForSnapshot(node, options.mode)
 
     const first = await this._captureWalletSnapshot(node, options)
     if (isCoherentWalletSnapshot(first)) {
@@ -471,6 +437,9 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       })
     }
 
+    // A moving chain tip can leave the first wallet sync behind the retry
+    // capture. Synchronize both keychains again before accepting new-tip data.
+    sync = await this._synchronizeWalletForSnapshot(node, options.mode)
     const retry = await this._captureWalletSnapshot(node, options)
     if (BigInt(retry.capture_sequence) <= BigInt(first.capture_sequence)) {
       throw new WalletSnapshotError(
@@ -510,6 +479,47 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       sync,
       snapshot: retry
     })
+  }
+
+  /** @private */
+  async _synchronizeWalletForSnapshot (node, mode) {
+    let sync
+    try {
+      sync = validateWalletSyncResponse(
+        await node.syncWallet({ mode }),
+        mode
+      )
+    } catch (error) {
+      const contractFailure = error instanceof WalletSnapshotContractError
+      throw new WalletSyncError(
+        contractFailure
+          ? 'The native wallet sync response does not match contract v1.'
+          : 'The native wallet synchronization failed.',
+        {
+          code: contractFailure
+            ? 'WALLET_SYNC_CONTRACT_MISMATCH'
+            : 'WALLET_SYNC_NATIVE_FAILURE',
+          cause: error,
+          details: Object.freeze({ mode })
+        }
+      )
+    }
+
+    if (sync.vanilla.status !== 'succeeded' || sync.colored.status !== 'succeeded') {
+      throw new WalletSyncError(
+        'The native wallet synchronization did not complete for both keychains.',
+        {
+          code: 'WALLET_SYNC_PARTIAL_FAILURE',
+          details: Object.freeze({
+            mode,
+            vanilla: sync.vanilla,
+            colored: sync.colored
+          })
+        }
+      )
+    }
+
+    return sync
   }
 
   /** @private */

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -555,14 +555,19 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       const contractFailure = error instanceof WalletSnapshotContractError
       throw new WalletSyncError(
         contractFailure
-          ? 'The native wallet sync response does not match contract v1.'
+          ? `The native wallet sync response does not match contract v1: ${error.message}.`
           : 'The native wallet synchronization failed.',
         {
           code: contractFailure
             ? 'WALLET_SYNC_CONTRACT_MISMATCH'
             : 'WALLET_SYNC_NATIVE_FAILURE',
           cause: error,
-          details: Object.freeze({ mode })
+          details: Object.freeze({
+            mode,
+            ...(contractFailure
+              ? { contractPath: error.path, contractExpectation: error.expectation }
+              : {})
+          })
         }
       )
     }
@@ -596,13 +601,19 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       const contractFailure = error instanceof WalletSnapshotContractError
       throw new WalletSnapshotError(
         contractFailure
-          ? 'The native wallet snapshot does not match contract v1.'
+          ? `The native wallet snapshot does not match contract v1: ${error.message}.`
           : 'The native wallet snapshot could not be captured.',
         {
           code: contractFailure
             ? 'WALLET_SNAPSHOT_CONTRACT_MISMATCH'
             : 'WALLET_SNAPSHOT_NATIVE_FAILURE',
-          cause: error
+          cause: error,
+          details: contractFailure
+            ? Object.freeze({
+              contractPath: error.path,
+              contractExpectation: error.expectation
+            })
+            : undefined
         }
       )
     }

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -6,6 +6,7 @@
 
 import WalletManager from '@tetherto/wdk-wallet'
 import { mnemonicToSeedSync } from 'bip39'
+import { normalizeAutoUnlockRequest } from './node-unlock-request.js'
 import WalletAccountRgbLightning from './wallet-account-rgb-lightning.js'
 
 const MEMPOOL_SPACE_URL = 'https://mempool.space'
@@ -24,6 +25,7 @@ const MEMPOOL_SPACE_URL = 'https://mempool.space'
  *   proxyEndpoint?: string,
  *   announceAddresses?: string[],
  *   announceAlias?: string,
+ *   autoUnlockRequest?: object,
  *   nodeSeedDerivation?: 'auto'|'wdk-seed-v2'|'legacy-v1'
  * }} RgbLightningWalletConfig
  */
@@ -98,7 +100,8 @@ export default class WalletManagerRgbLightning extends WalletManager {
    * @param {RgbLightningWalletConfig} config
    */
   constructor (seed, config = {}) {
-    super(seed, config)
+    const { autoUnlockRequest, ...managerConfig } = config
+    super(seed, managerConfig)
 
     if (!config.network) throw new Error('network configuration is required.')
     if (!config.dataDir) {
@@ -109,6 +112,7 @@ export default class WalletManagerRgbLightning extends WalletManager {
     }
 
     /** @private */ this._network = config.network
+    /** @private */ this._autoUnlockRequest = normalizeAutoUnlockRequest(autoUnlockRequest)
     /** @private @type {IRgbLightningBinding | null} */
     this._binding = null
   }
@@ -174,7 +178,10 @@ export default class WalletManagerRgbLightning extends WalletManager {
         )
       }
 
-      this._accounts[index] = new WalletAccountRgbLightning({ binding })
+      this._accounts[index] = new WalletAccountRgbLightning({
+        binding,
+        autoUnlockRequest: this._autoUnlockRequest
+      })
     }
     return this._accounts[index]
   }

--- a/src/wallet-snapshot-contract.js
+++ b/src/wallet-snapshot-contract.js
@@ -23,6 +23,7 @@ export const DEFAULT_WALLET_SNAPSHOT_OPTIONS = Object.freeze({
 })
 
 const DECIMAL_TEXT = /^(0|[1-9][0-9]*)$/
+const U64_MAX = 18_446_744_073_709_551_615n
 const HAS_OWN = (value, key) => Object.prototype.hasOwnProperty.call(value, key)
 
 export class WalletSnapshotContractError extends Error {
@@ -70,6 +71,7 @@ function decimal (value, path) {
   if (typeof value !== 'string' || !DECIMAL_TEXT.test(value)) {
     fail(path, 'must be an unsigned base-10 integer string')
   }
+  if (BigInt(value) > U64_MAX) fail(path, 'must fit in an unsigned 64-bit integer')
   return value
 }
 
@@ -203,7 +205,7 @@ export function validateWalletSyncResponse (value, expectedMode) {
 function network (value, path) {
   const item = record(value, path)
   exactKeys(item, ['network', 'height'], [], path)
-  text(item.network, `${path}.network`, 32)
+  oneOf(item.network, ['mainnet', 'testnet', 'regtest', 'signet'], `${path}.network`)
   integer(item.height, `${path}.height`, 0, 0xffffffff)
 }
 
@@ -412,6 +414,10 @@ export function validateWalletSnapshotResponse (value, options) {
     const transfers = array(snapshot.transfers, 'snapshot.transfers', options.maxAssets)
     transfers.forEach((entry, index) => snapshotTransfers(entry, `snapshot.transfers[${index}]`, options))
     assertUnique(transfers, 'asset_id', 'snapshot.transfers')
+    const transferCount = transfers.reduce((count, entry) => count + entry.transfers.length, 0)
+    if (transferCount > options.maxActivityItems) {
+      fail('snapshot.transfers', `must contain at most ${options.maxActivityItems} aggregate entries`)
+    }
   } else {
     for (const field of optional) {
       if (HAS_OWN(snapshot, field)) fail(`snapshot.${field}`, 'must be omitted when includeActivity is false')

--- a/src/wallet-snapshot-contract.js
+++ b/src/wallet-snapshot-contract.js
@@ -25,6 +25,7 @@ export const DEFAULT_WALLET_SNAPSHOT_OPTIONS = Object.freeze({
 const DECIMAL_TEXT = /^(0|[1-9][0-9]*)$/
 const U64_MAX = 18_446_744_073_709_551_615n
 const HAS_OWN = (value, key) => Object.prototype.hasOwnProperty.call(value, key)
+const CANONICAL_NETWORKS = Object.freeze(['mainnet', 'testnet', 'regtest', 'signet'])
 
 export class WalletSnapshotContractError extends Error {
   constructor (path, expectation) {
@@ -206,8 +207,31 @@ export function validateWalletSyncResponse (value, expectedMode) {
 function network (value, path) {
   const item = record(value, path)
   exactKeys(item, ['network', 'height'], [], path)
-  oneOf(item.network, ['mainnet', 'testnet', 'regtest', 'signet'], `${path}.network`)
+  oneOf(item.network, CANONICAL_NETWORKS, `${path}.network`)
   integer(item.height, `${path}.height`, 0, 0xffffffff)
+}
+
+function canonicalNetworkName (value) {
+  if (typeof value !== 'string') return value
+  const canonical = value.toLowerCase()
+  return CANONICAL_NETWORKS.includes(canonical) ? canonical : value
+}
+
+function normalizeLegacyNetworkNames (value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+
+  let normalized = value
+  for (const field of ['network_before', 'network_after']) {
+    const networkInfo = value[field]
+    if (!networkInfo || typeof networkInfo !== 'object' || Array.isArray(networkInfo)) continue
+
+    const networkName = canonicalNetworkName(networkInfo.network)
+    if (networkName === networkInfo.network) continue
+
+    if (normalized === value) normalized = { ...value }
+    normalized[field] = { ...networkInfo, network: networkName }
+  }
+  return normalized
 }
 
 function balance (value, path, includeOffchain) {
@@ -366,7 +390,10 @@ function assertUnique (rows, key, path) {
 }
 
 export function validateWalletSnapshotResponse (value, options) {
-  const snapshot = record(value, 'snapshot')
+  // Native beta.14 artifacts serialize Rust's Network Debug value (for
+  // example, "Regtest"). Normalize only recognized names at this boundary;
+  // strict contract validation below still rejects every unknown value.
+  const snapshot = record(normalizeLegacyNetworkNames(value), 'snapshot')
   const required = [
     'contract_version', 'native_source', 'capture_sequence', 'started_at_ms',
     'completed_at_ms', 'network_before', 'network_after', 'node', 'btc',

--- a/src/wallet-snapshot-contract.js
+++ b/src/wallet-snapshot-contract.js
@@ -1,0 +1,437 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+'use strict'
+
+export const WALLET_SNAPSHOT_CONTRACT_VERSION = 1
+export const WALLET_SNAPSHOT_NATIVE_SOURCE = 'rgb-lightning-node-v0.9.0-beta.3+utexo-wallet-v1'
+
+const NATIVE_LIMITS = Object.freeze({
+  assets: 128,
+  channels: 512,
+  activityItems: 5000
+})
+
+export const DEFAULT_WALLET_SNAPSHOT_OPTIONS = Object.freeze({
+  mode: 'routine',
+  assetIds: Object.freeze([]),
+  maxAssets: NATIVE_LIMITS.assets,
+  maxChannels: NATIVE_LIMITS.channels,
+  maxActivityItems: 1000,
+  includeActivity: false
+})
+
+const DECIMAL_TEXT = /^(0|[1-9][0-9]*)$/
+const HAS_OWN = (value, key) => Object.prototype.hasOwnProperty.call(value, key)
+
+export class WalletSnapshotContractError extends Error {
+  constructor (path, expectation) {
+    super(`${path} ${expectation}`)
+    this.name = 'WalletSnapshotContractError'
+    this.path = path
+  }
+}
+
+function fail (path, expectation) {
+  throw new WalletSnapshotContractError(path, expectation)
+}
+
+function record (value, path) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(path, 'must be an object')
+  }
+  return value
+}
+
+function exactKeys (value, required, optional, path) {
+  const allowed = new Set([...required, ...optional])
+  for (const key of required) {
+    if (!HAS_OWN(value, key)) fail(`${path}.${key}`, 'is required')
+  }
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) fail(`${path}.${key}`, 'is not part of contract v1')
+  }
+}
+
+function text (value, path, maxLength) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) {
+    fail(path, `must be non-empty text no longer than ${maxLength} characters`)
+  }
+  return value
+}
+
+function nullableText (value, path, maxLength) {
+  if (value === null) return null
+  return text(value, path, maxLength)
+}
+
+function decimal (value, path) {
+  if (typeof value !== 'string' || !DECIMAL_TEXT.test(value)) {
+    fail(path, 'must be an unsigned base-10 integer string')
+  }
+  return value
+}
+
+function nullableDecimal (value, path) {
+  if (value === null) return null
+  return decimal(value, path)
+}
+
+function boolean (value, path) {
+  if (typeof value !== 'boolean') fail(path, 'must be a boolean')
+  return value
+}
+
+function integer (value, path, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    fail(path, `must be an integer between ${minimum} and ${maximum}`)
+  }
+  return value
+}
+
+function oneOf (value, values, path) {
+  if (!values.includes(value)) fail(path, `must be one of: ${values.join(', ')}`)
+  return value
+}
+
+function array (value, path, maximum) {
+  if (!Array.isArray(value) || value.length > maximum) {
+    fail(path, `must be an array with at most ${maximum} entries`)
+  }
+  return value
+}
+
+function optionalObjectInput (value) {
+  if (value === undefined) return {}
+  return record(value, 'options')
+}
+
+function inputLimit (value, fallback, maximum, path) {
+  if (value === undefined) return fallback
+  return integer(value, path, 1, maximum)
+}
+
+function uniqueTextArray (value, maximum, path) {
+  if (value === undefined) return []
+  const rows = array(value, path, maximum)
+  const seen = new Set()
+  return rows.map((row, index) => {
+    const item = text(row, `${path}[${index}]`, 256)
+    if (seen.has(item)) fail(`${path}[${index}]`, 'must not duplicate another entry')
+    seen.add(item)
+    return item
+  })
+}
+
+export function normalizeWalletSnapshotOptions (value) {
+  const input = optionalObjectInput(value)
+  exactKeys(
+    input,
+    [],
+    ['mode', 'assetIds', 'maxAssets', 'maxChannels', 'maxActivityItems', 'includeActivity'],
+    'options'
+  )
+
+  const mode = input.mode === undefined
+    ? DEFAULT_WALLET_SNAPSHOT_OPTIONS.mode
+    : oneOf(input.mode, ['routine', 'recovery'], 'options.mode')
+  const maxAssets = inputLimit(
+    input.maxAssets,
+    DEFAULT_WALLET_SNAPSHOT_OPTIONS.maxAssets,
+    NATIVE_LIMITS.assets,
+    'options.maxAssets'
+  )
+  const maxChannels = inputLimit(
+    input.maxChannels,
+    DEFAULT_WALLET_SNAPSHOT_OPTIONS.maxChannels,
+    NATIVE_LIMITS.channels,
+    'options.maxChannels'
+  )
+  const maxActivityItems = inputLimit(
+    input.maxActivityItems,
+    DEFAULT_WALLET_SNAPSHOT_OPTIONS.maxActivityItems,
+    NATIVE_LIMITS.activityItems,
+    'options.maxActivityItems'
+  )
+  const assetIds = uniqueTextArray(input.assetIds, maxAssets, 'options.assetIds')
+  const includeActivity = input.includeActivity === undefined
+    ? DEFAULT_WALLET_SNAPSHOT_OPTIONS.includeActivity
+    : boolean(input.includeActivity, 'options.includeActivity')
+
+  return Object.freeze({
+    mode,
+    assetIds: Object.freeze(assetIds),
+    maxAssets,
+    maxChannels,
+    maxActivityItems,
+    includeActivity,
+    nativeRequest: Object.freeze({
+      asset_ids: Object.freeze([...assetIds]),
+      max_assets: maxAssets,
+      max_channels: maxChannels,
+      max_activity_items: maxActivityItems,
+      include_activity: includeActivity
+    })
+  })
+}
+
+function syncKeychain (value, path) {
+  const item = record(value, path)
+  exactKeys(item, ['status'], ['error_code'], path)
+  oneOf(item.status, ['succeeded', 'failed'], `${path}.status`)
+  if (item.status === 'succeeded' && HAS_OWN(item, 'error_code')) {
+    fail(`${path}.error_code`, 'must be omitted after a successful sync')
+  }
+  if (item.status === 'failed') {
+    text(item.error_code, `${path}.error_code`, 128)
+  }
+}
+
+export function validateWalletSyncResponse (value, expectedMode) {
+  const response = record(value, 'sync')
+  exactKeys(response, ['contract_version', 'mode', 'vanilla', 'colored'], [], 'sync')
+  if (response.contract_version !== WALLET_SNAPSHOT_CONTRACT_VERSION) {
+    fail('sync.contract_version', `must equal ${WALLET_SNAPSHOT_CONTRACT_VERSION}`)
+  }
+  if (response.mode !== expectedMode) fail('sync.mode', `must equal ${expectedMode}`)
+  syncKeychain(response.vanilla, 'sync.vanilla')
+  syncKeychain(response.colored, 'sync.colored')
+  return deepFreeze(response)
+}
+
+function network (value, path) {
+  const item = record(value, path)
+  exactKeys(item, ['network', 'height'], [], path)
+  text(item.network, `${path}.network`, 32)
+  integer(item.height, `${path}.height`, 0, 0xffffffff)
+}
+
+function balance (value, path, includeOffchain) {
+  const item = record(value, path)
+  const fields = includeOffchain
+    ? ['settled', 'future', 'spendable', 'offchain_outbound', 'offchain_inbound']
+    : ['settled', 'future', 'spendable']
+  exactKeys(item, fields, [], path)
+  for (const field of fields) decimal(item[field], `${path}.${field}`)
+}
+
+function snapshotNode (value) {
+  const path = 'snapshot.node'
+  const item = record(value, path)
+  const fields = [
+    'pubkey',
+    'num_channels',
+    'num_usable_channels',
+    'claimable_onchain_sat',
+    'eventual_close_fees_sat',
+    'pending_outbound_payments_sat',
+    'num_peers',
+    'latest_rgs_snapshot_timestamp'
+  ]
+  exactKeys(item, fields, [], path)
+  text(item.pubkey, `${path}.pubkey`, 130)
+  for (const field of fields.slice(1, -1)) decimal(item[field], `${path}.${field}`)
+  nullableDecimal(item.latest_rgs_snapshot_timestamp, `${path}.latest_rgs_snapshot_timestamp`)
+}
+
+function snapshotAsset (value, path) {
+  const item = record(value, path)
+  exactKeys(item, ['asset_id', 'ticker', 'name', 'precision', 'balance'], [], path)
+  text(item.asset_id, `${path}.asset_id`, 256)
+  text(item.ticker, `${path}.ticker`, 32)
+  text(item.name, `${path}.name`, 256)
+  integer(item.precision, `${path}.precision`, 0, 255)
+  balance(item.balance, `${path}.balance`, true)
+}
+
+function snapshotChannel (value, path) {
+  const item = record(value, path)
+  const fields = [
+    'channel_id', 'peer_pubkey', 'status', 'ready', 'capacity_sat',
+    'claimable_onchain_sat', 'outbound_capacity_msat', 'inbound_capacity_msat',
+    'next_outbound_htlc_limit_msat', 'next_outbound_htlc_minimum_msat',
+    'is_usable', 'public', 'funding_txid', 'peer_alias', 'short_channel_id',
+    'asset_id', 'asset_local_amount', 'asset_remote_amount', 'virtual_open_mode'
+  ]
+  exactKeys(item, fields, [], path)
+  text(item.channel_id, `${path}.channel_id`, 128)
+  text(item.peer_pubkey, `${path}.peer_pubkey`, 130)
+  oneOf(item.status, ['Opening', 'Opened', 'Closing'], `${path}.status`)
+  boolean(item.ready, `${path}.ready`)
+  for (const field of fields.slice(4, 10)) decimal(item[field], `${path}.${field}`)
+  boolean(item.is_usable, `${path}.is_usable`)
+  boolean(item.public, `${path}.public`)
+  nullableText(item.funding_txid, `${path}.funding_txid`, 128)
+  nullableText(item.peer_alias, `${path}.peer_alias`, 256)
+  nullableDecimal(item.short_channel_id, `${path}.short_channel_id`)
+  nullableText(item.asset_id, `${path}.asset_id`, 256)
+  nullableDecimal(item.asset_local_amount, `${path}.asset_local_amount`)
+  nullableDecimal(item.asset_remote_amount, `${path}.asset_remote_amount`)
+  nullableText(item.virtual_open_mode, `${path}.virtual_open_mode`, 64)
+}
+
+function blockTime (value, path) {
+  if (value === null) return
+  const item = record(value, path)
+  exactKeys(item, ['height', 'timestamp'], [], path)
+  integer(item.height, `${path}.height`, 0, 0xffffffff)
+  decimal(item.timestamp, `${path}.timestamp`)
+}
+
+function snapshotTransaction (value, path) {
+  const item = record(value, path)
+  exactKeys(item, ['transaction_type', 'txid', 'received', 'sent', 'fee', 'confirmation_time'], [], path)
+  oneOf(item.transaction_type, ['RgbSend', 'Drain', 'CreateUtxos', 'SendBtc', 'Incoming'], `${path}.transaction_type`)
+  text(item.txid, `${path}.txid`, 128)
+  decimal(item.received, `${path}.received`)
+  decimal(item.sent, `${path}.sent`)
+  decimal(item.fee, `${path}.fee`)
+  blockTime(item.confirmation_time, `${path}.confirmation_time`)
+}
+
+function snapshotPayment (value, path) {
+  const item = record(value, path)
+  const fields = [
+    'amt_msat', 'asset_amount', 'asset_id', 'payment_hash', 'payment_type',
+    'status', 'created_at', 'updated_at', 'payee_pubkey'
+  ]
+  exactKeys(item, fields, [], path)
+  nullableDecimal(item.amt_msat, `${path}.amt_msat`)
+  nullableDecimal(item.asset_amount, `${path}.asset_amount`)
+  nullableText(item.asset_id, `${path}.asset_id`, 256)
+  text(item.payment_hash, `${path}.payment_hash`, 128)
+  oneOf(item.payment_type, ['Outbound', 'InboundAutoClaim', 'InboundHodl'], `${path}.payment_type`)
+  oneOf(item.status, ['Pending', 'Claimable', 'Claiming', 'Succeeded', 'Cancelled', 'Failed'], `${path}.status`)
+  decimal(item.created_at, `${path}.created_at`)
+  decimal(item.updated_at, `${path}.updated_at`)
+  text(item.payee_pubkey, `${path}.payee_pubkey`, 130)
+}
+
+function transferEndpoint (value, path) {
+  const item = record(value, path)
+  exactKeys(item, ['endpoint', 'transport_type', 'used'], [], path)
+  text(item.endpoint, `${path}.endpoint`, 4096)
+  text(item.transport_type, `${path}.transport_type`, 64)
+  boolean(item.used, `${path}.used`)
+}
+
+function snapshotTransfer (value, path) {
+  const item = record(value, path)
+  const fields = [
+    'idx', 'created_at', 'updated_at', 'status', 'requested_assignment',
+    'assignments', 'kind', 'txid', 'recipient_id', 'receive_utxo',
+    'change_utxo', 'expiration', 'transport_endpoints'
+  ]
+  exactKeys(item, fields, [], path)
+  integer(item.idx, `${path}.idx`, 0, 0x7fffffff)
+  decimal(item.created_at, `${path}.created_at`)
+  decimal(item.updated_at, `${path}.updated_at`)
+  text(item.status, `${path}.status`, 64)
+  nullableText(item.requested_assignment, `${path}.requested_assignment`, 1024)
+  array(item.assignments, `${path}.assignments`, 1024).forEach((entry, index) => {
+    text(entry, `${path}.assignments[${index}]`, 1024)
+  })
+  text(item.kind, `${path}.kind`, 64)
+  nullableText(item.txid, `${path}.txid`, 128)
+  nullableText(item.recipient_id, `${path}.recipient_id`, 1024)
+  nullableText(item.receive_utxo, `${path}.receive_utxo`, 256)
+  nullableText(item.change_utxo, `${path}.change_utxo`, 256)
+  nullableDecimal(item.expiration, `${path}.expiration`)
+  array(item.transport_endpoints, `${path}.transport_endpoints`, 64).forEach((entry, index) => {
+    transferEndpoint(entry, `${path}.transport_endpoints[${index}]`)
+  })
+}
+
+function snapshotTransfers (value, path, options) {
+  const item = record(value, path)
+  exactKeys(item, ['asset_id', 'transfers'], [], path)
+  const assetId = text(item.asset_id, `${path}.asset_id`, 256)
+  if (!options.assetIds.includes(assetId)) {
+    fail(`${path}.asset_id`, 'must have been requested explicitly')
+  }
+  array(item.transfers, `${path}.transfers`, options.maxActivityItems)
+    .forEach((entry, index) => snapshotTransfer(entry, `${path}.transfers[${index}]`))
+}
+
+function assertUnique (rows, key, path) {
+  const seen = new Set()
+  rows.forEach((row, index) => {
+    if (seen.has(row[key])) fail(`${path}[${index}].${key}`, 'must be unique')
+    seen.add(row[key])
+  })
+}
+
+export function validateWalletSnapshotResponse (value, options) {
+  const snapshot = record(value, 'snapshot')
+  const required = [
+    'contract_version', 'native_source', 'capture_sequence', 'started_at_ms',
+    'completed_at_ms', 'network_before', 'network_after', 'node', 'btc',
+    'assets', 'channels'
+  ]
+  const optional = ['transactions', 'payments', 'transfers']
+  exactKeys(snapshot, required, optional, 'snapshot')
+  if (snapshot.contract_version !== WALLET_SNAPSHOT_CONTRACT_VERSION) {
+    fail('snapshot.contract_version', `must equal ${WALLET_SNAPSHOT_CONTRACT_VERSION}`)
+  }
+  if (snapshot.native_source !== WALLET_SNAPSHOT_NATIVE_SOURCE) {
+    fail('snapshot.native_source', `must equal ${WALLET_SNAPSHOT_NATIVE_SOURCE}`)
+  }
+  decimal(snapshot.capture_sequence, 'snapshot.capture_sequence')
+  if (BigInt(snapshot.capture_sequence) === 0n) fail('snapshot.capture_sequence', 'must be greater than zero')
+  decimal(snapshot.started_at_ms, 'snapshot.started_at_ms')
+  decimal(snapshot.completed_at_ms, 'snapshot.completed_at_ms')
+  if (BigInt(snapshot.completed_at_ms) < BigInt(snapshot.started_at_ms)) {
+    fail('snapshot.completed_at_ms', 'must not precede started_at_ms')
+  }
+  network(snapshot.network_before, 'snapshot.network_before')
+  network(snapshot.network_after, 'snapshot.network_after')
+  snapshotNode(snapshot.node)
+
+  const btc = record(snapshot.btc, 'snapshot.btc')
+  exactKeys(btc, ['vanilla', 'colored'], [], 'snapshot.btc')
+  balance(btc.vanilla, 'snapshot.btc.vanilla', false)
+  balance(btc.colored, 'snapshot.btc.colored', false)
+
+  const assets = array(snapshot.assets, 'snapshot.assets', options.maxAssets)
+  assets.forEach((entry, index) => snapshotAsset(entry, `snapshot.assets[${index}]`))
+  assertUnique(assets, 'asset_id', 'snapshot.assets')
+
+  const channels = array(snapshot.channels, 'snapshot.channels', options.maxChannels)
+  channels.forEach((entry, index) => snapshotChannel(entry, `snapshot.channels[${index}]`))
+  assertUnique(channels, 'channel_id', 'snapshot.channels')
+
+  if (options.includeActivity) {
+    for (const field of optional) {
+      if (!HAS_OWN(snapshot, field)) fail(`snapshot.${field}`, 'is required when includeActivity is true')
+    }
+    array(snapshot.transactions, 'snapshot.transactions', options.maxActivityItems)
+      .forEach((entry, index) => snapshotTransaction(entry, `snapshot.transactions[${index}]`))
+    array(snapshot.payments, 'snapshot.payments', options.maxActivityItems)
+      .forEach((entry, index) => snapshotPayment(entry, `snapshot.payments[${index}]`))
+    const transfers = array(snapshot.transfers, 'snapshot.transfers', options.maxAssets)
+    transfers.forEach((entry, index) => snapshotTransfers(entry, `snapshot.transfers[${index}]`, options))
+    assertUnique(transfers, 'asset_id', 'snapshot.transfers')
+  } else {
+    for (const field of optional) {
+      if (HAS_OWN(snapshot, field)) fail(`snapshot.${field}`, 'must be omitted when includeActivity is false')
+    }
+  }
+
+  return deepFreeze(snapshot)
+}
+
+export function isCoherentWalletSnapshot (snapshot) {
+  return snapshot.network_before.network === snapshot.network_after.network &&
+    snapshot.network_before.height === snapshot.network_after.height
+}
+
+export function walletSnapshotRequestKey (options) {
+  return JSON.stringify([options.mode, options.nativeRequest])
+}
+
+function deepFreeze (value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value
+  for (const child of Object.values(value)) deepFreeze(child)
+  return Object.freeze(value)
+}

--- a/src/wallet-snapshot-contract.js
+++ b/src/wallet-snapshot-contract.js
@@ -31,6 +31,7 @@ export class WalletSnapshotContractError extends Error {
     super(`${path} ${expectation}`)
     this.name = 'WalletSnapshotContractError'
     this.path = path
+    this.expectation = expectation
   }
 }
 

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -13,6 +13,8 @@ import {
   VssError,
   VssNotConfiguredError,
   ApayError,
+  WalletSyncError,
+  WalletSnapshotError,
   NotImplementedError,
   wrapError
 } from '../src/errors.js'
@@ -25,11 +27,21 @@ describe('error hierarchy', () => {
     expect(new VssError('m')).toMatchObject({ name: 'VssError', code: 'VSS_ERROR' })
     expect(new VssNotConfiguredError()).toMatchObject({ name: 'VssNotConfiguredError', code: 'VSS_NOT_CONFIGURED' })
     expect(new ApayError('m')).toMatchObject({ name: 'ApayError', code: 'APAY_ERROR' })
+    expect(new WalletSyncError('m')).toMatchObject({ name: 'WalletSyncError', code: 'WALLET_SYNC_FAILED' })
+    expect(new WalletSnapshotError('m')).toMatchObject({ name: 'WalletSnapshotError', code: 'WALLET_SNAPSHOT_FAILED' })
     expect(new NotImplementedError('m')).toMatchObject({ name: 'NotImplementedError', code: 'NOT_IMPLEMENTED' })
   })
 
   it('keeps every subclass an instanceof the base (and Error)', () => {
-    for (const E of [UnlockError, AccountLockedError, VssError, ApayError, NotImplementedError]) {
+    for (const E of [
+      UnlockError,
+      AccountLockedError,
+      VssError,
+      ApayError,
+      WalletSyncError,
+      WalletSnapshotError,
+      NotImplementedError
+    ]) {
       const e = new E('x')
       expect(e).toBeInstanceOf(Error)
       expect(e).toBeInstanceOf(RgbLightningError)
@@ -48,12 +60,18 @@ describe('error hierarchy', () => {
       name: 'UnlockError',
       code: 'UNLOCK_FAILED',
       message: 'bad creds',
+      details: null,
       cause: { name: 'Error', message: 'root cause' }
     })
   })
 
   it('toJSON reports a null cause when none was provided', () => {
     expect(new VssError('x').toJSON().cause).toBeNull()
+  })
+
+  it('serializes structured error details without dropping them', () => {
+    const details = { vanilla: { status: 'failed' } }
+    expect(new WalletSyncError('x', { details }).toJSON().details).toBe(details)
   })
 })
 

--- a/tests/types-contract.ts
+++ b/tests/types-contract.ts
@@ -7,6 +7,8 @@ import type {
   LnurlPayOptions,
   LspLiquidityTimeoutError,
   PayAddressOptions,
+  WalletRefreshResult,
+  WalletSnapshotOptions,
   WalletAccountReadOnlyRgbLightning,
   WalletAccountRgbLightning
 } from '../index.js'
@@ -35,6 +37,17 @@ const payAddressOptions: PayAddressOptions = {
   allowCrossHostCallback: true
 }
 const minimumLiquidity: number = liquidityError.minMsat
+const walletSnapshotOptions: WalletSnapshotOptions = {
+  mode: 'recovery',
+  assetIds: ['rgb:asset'],
+  includeActivity: true
+}
+const refreshed: Promise<WalletRefreshResult> = account.refreshWalletSnapshot(walletSnapshotOptions)
+
+// @ts-expect-error recovery mode is explicit; arbitrary sync strategies are rejected.
+account.refreshWalletSnapshot({ mode: 'fast' })
+// @ts-expect-error read-only accounts cannot mutate native sync state.
+readOnlyAccount.refreshWalletSnapshot()
 
 binding.ensureNode()
 // @ts-expect-error IRgbLightningBinding exposes ensureNode(), not a node property.
@@ -43,3 +56,4 @@ binding.node
 void lnurlOptions
 void payAddressOptions
 void minimumLiquidity
+void refreshed

--- a/tests/wallet-account-surface.test.js
+++ b/tests/wallet-account-surface.test.js
@@ -24,6 +24,17 @@ import { UnlockError, AccountLockedError, ApayError } from '../src/errors.js'
 import { LspClient } from '../src/lsp-client.js'
 import { UtexoLsp } from '../src/utexo-lsp.js'
 
+const AUTO_UNLOCK_REQUEST = Object.freeze({
+  bitcoind_rpc_username: 'user',
+  bitcoind_rpc_password: 'password',
+  bitcoind_rpc_host: '127.0.0.1',
+  bitcoind_rpc_port: 18443,
+  indexer_url: 'tcp://127.0.0.1:50001',
+  proxy_endpoint: 'rpc://127.0.0.1:3000/json-rpc',
+  announce_addresses: Object.freeze([]),
+  announce_alias: 'wallet-test'
+})
+
 // Build a fake RLN node whose methods are jest.fn returning canned
 // values. Every method the account forwards to is present so we can
 // assert forwarding + arg pass-through.
@@ -100,8 +111,11 @@ function makeBinding (overrides = {}) {
   return binding
 }
 
-function makeAccount (bindingOverrides = {}) {
-  return new WalletAccountRgbLightning({ binding: makeBinding(bindingOverrides) })
+function makeAccount (bindingOverrides = {}, options = {}) {
+  return new WalletAccountRgbLightning({
+    binding: makeBinding(bindingOverrides),
+    ...options
+  })
 }
 
 describe('construction', () => {
@@ -154,6 +168,39 @@ describe('lifecycle', () => {
     expect(err).toBeInstanceOf(UnlockError)
     expect(err.message).toBe('Rln(NotInitialized): bad creds')
     expect(err.code).toBe('UNLOCK_FAILED')
+  })
+
+  it('coalesces concurrent unlock calls at the account boundary', async () => {
+    const unlock = jest.fn()
+    const account = makeAccount({ unlock })
+
+    await expect(Promise.all([
+      account.unlock(AUTO_UNLOCK_REQUEST),
+      account.unlock(AUTO_UNLOCK_REQUEST)
+    ])).resolves.toEqual([{ ok: true }, { ok: true }])
+
+    expect(unlock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a conflicting concurrent unlock request', async () => {
+    let release
+    const pending = new Promise((resolve) => { release = resolve })
+    const unlock = jest.fn(() => pending)
+    const account = makeAccount({ unlock })
+    const first = account.unlock(AUTO_UNLOCK_REQUEST)
+    const conflicting = account.unlock({
+      ...AUTO_UNLOCK_REQUEST,
+      bitcoind_rpc_host: 'other-host'
+    })
+
+    await expect(conflicting).rejects.toMatchObject({
+      name: 'UnlockError',
+      code: 'UNLOCK_FAILED',
+      message: 'A different RGB Lightning unlock request is already in progress.'
+    })
+    release()
+    await expect(first).resolves.toEqual({ ok: true })
+    expect(unlock).toHaveBeenCalledTimes(1)
   })
 
   it('getBootstrap returns the binding bootstrap dictionary verbatim', async () => {
@@ -262,6 +309,44 @@ describe('getAddress', () => {
   it('throws AccountLockedError instead of returning a synthetic address', async () => {
     const account = makeAccount({ node: makeNode({ address: () => { throw new Error('NotInitialized') } }) })
     await expect(account.getAddress()).rejects.toBeInstanceOf(AccountLockedError)
+  })
+
+  it('coalesces configured activation and returns only the real native address', async () => {
+    let unlocked = false
+    const address = jest.fn(() => {
+      if (!unlocked) throw new Error('SdkNode not created — call unlock() first')
+      return { address: 'tb1qactivated' }
+    })
+    const unlock = jest.fn(() => { unlocked = true })
+    const account = makeAccount(
+      { node: makeNode({ address }), unlock },
+      { autoUnlockRequest: AUTO_UNLOCK_REQUEST }
+    )
+
+    await expect(Promise.all([
+      account.getAddress(),
+      account.getAddress()
+    ])).resolves.toEqual(['tb1qactivated', 'tb1qactivated'])
+
+    expect(unlock).toHaveBeenCalledTimes(1)
+    expect(unlock).toHaveBeenCalledWith(AUTO_UNLOCK_REQUEST)
+    expect(address).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not hide an automatic activation failure behind an address marker', async () => {
+    const account = makeAccount(
+      {
+        node: makeNode({ address: () => { throw new Error('LockedNode') } }),
+        unlock: () => { throw new Error('indexer unavailable') }
+      },
+      { autoUnlockRequest: AUTO_UNLOCK_REQUEST }
+    )
+
+    await expect(account.getAddress()).rejects.toMatchObject({
+      name: 'UnlockError',
+      code: 'UNLOCK_FAILED',
+      message: 'indexer unavailable'
+    })
   })
 
   it('returns a non-throwing locked state for pre-unlock UI loaders', async () => {

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -14,6 +14,16 @@ const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abando
 const WDK_SEED_HEX = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
 const NODE_SEED_V2 = WDK_SEED_HEX.slice(0, 64)
 const NODE_SEED_V1 = 'd6560f02547828d8d76fc84ea68e74dcccea5599e735cee1fa5f2742289cda58'
+const AUTO_UNLOCK_REQUEST = {
+  bitcoind_rpc_username: 'user',
+  bitcoind_rpc_password: 'password',
+  bitcoind_rpc_host: '127.0.0.1',
+  bitcoind_rpc_port: 18443,
+  indexer_url: 'tcp://127.0.0.1:50001',
+  proxy_endpoint: 'rpc://127.0.0.1:3000/json-rpc',
+  announce_addresses: [],
+  announce_alias: 'wallet-test'
+}
 
 class FakeBinding {
   static instances = []
@@ -68,6 +78,30 @@ describe('WalletManagerRgbLightning', () => {
     expect(await manager.getAccount()).toBe(account)
     expect(await manager.getAccountByPath('m')).toBe(account)
     expect(FakeBinding.instances).toHaveLength(1)
+  })
+
+  it('validates and isolates the optional automatic activation request', async () => {
+    const manager = new TestManager(MNEMONIC, {
+      network: 'regtest',
+      dataDir: '/wallet',
+      autoUnlockRequest: AUTO_UNLOCK_REQUEST
+    })
+    const account = await manager.getAccount()
+    const binding = FakeBinding.instances[0]
+
+    expect(account._autoUnlockRequest).toEqual(AUTO_UNLOCK_REQUEST)
+    expect(account._autoUnlockRequest).not.toBe(AUTO_UNLOCK_REQUEST)
+    expect(Object.isFrozen(account._autoUnlockRequest)).toBe(true)
+    expect(Object.isFrozen(account._autoUnlockRequest.announce_addresses)).toBe(true)
+    expect(binding._config.autoUnlockRequest).toBeUndefined()
+  })
+
+  it('rejects malformed automatic activation requests without exposing values', () => {
+    expect(() => new TestManager(MNEMONIC, {
+      network: 'regtest',
+      dataDir: '/wallet',
+      autoUnlockRequest: { ...AUTO_UNLOCK_REQUEST, bitcoind_rpc_port: 0 }
+    })).toThrow('autoUnlockRequest.bitcoind_rpc_port must be a valid TCP port')
   })
 
   it('supports explicit v2-only and legacy-only modes', async () => {

--- a/tests/wallet-snapshot-contract.test.js
+++ b/tests/wallet-snapshot-contract.test.js
@@ -193,6 +193,23 @@ describe('wallet snapshot response contract', () => {
       .toThrow('snapshot.extra')
   })
 
+  it('rejects decimal text outside the native u64 domain and unknown networks', () => {
+    const options = normalizeWalletSnapshotOptions()
+    expect(() => validateWalletSnapshotResponse(snapshot({
+      btc: {
+        vanilla: {
+          settled: '18446744073709551616',
+          future: '45',
+          spendable: '40'
+        },
+        colored: { settled: '5', future: '5', spendable: '5' }
+      }
+    }), options)).toThrow('snapshot.btc.vanilla.settled')
+    expect(() => validateWalletSnapshotResponse(snapshot({
+      network_before: { network: 'bitcoin', height: 100 }
+    }), options)).toThrow('snapshot.network_before.network')
+  })
+
   it('requires the bounded activity envelope only when requested', () => {
     const options = normalizeWalletSnapshotOptions({
       includeActivity: true,
@@ -259,6 +276,22 @@ describe('wallet snapshot response contract', () => {
 
     expect(() => validateWalletSnapshotResponse(value, options))
       .toThrow('snapshot.transfers[0].asset_id')
+  })
+
+  it('bounds RGB transfers across every requested asset', () => {
+    const options = normalizeWalletSnapshotOptions({
+      includeActivity: true,
+      assetIds: ['asset-1', 'asset-2'],
+      maxActivityItems: 1
+    })
+    const value = activitySnapshot()
+    value.transfers.push({
+      asset_id: 'asset-2',
+      transfers: [{ ...value.transfers[0].transfers[0], idx: 2 }]
+    })
+
+    expect(() => validateWalletSnapshotResponse(value, options))
+      .toThrow('snapshot.transfers')
   })
 
   it('requires activity fields to be absent when activity was not requested', () => {
@@ -350,8 +383,28 @@ describe('WalletAccountRgbLightning.refreshWalletSnapshot', () => {
         .mockReturnValueOnce(snapshot({ capture_sequence: '8' }))
     }
     const result = await accountWith(node).refreshWalletSnapshot()
+    expect(node.syncWallet).toHaveBeenCalledTimes(2)
     expect(node.walletSnapshot).toHaveBeenCalledTimes(2)
     expect(result.snapshot.capture_sequence).toBe('8')
+  })
+
+  it('fails before the retry capture when re-synchronization fails', async () => {
+    const node = {
+      syncWallet: jest.fn()
+        .mockReturnValueOnce(syncResult())
+        .mockReturnValueOnce(syncResult({
+          vanilla: { status: 'failed', error_code: 'FAILED_BDK_SYNC' }
+        })),
+      walletSnapshot: jest.fn(() => snapshot({
+        capture_sequence: '7',
+        network_after: { network: 'regtest', height: 101 }
+      }))
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(WalletSyncError)
+    expect(error.code).toBe('WALLET_SYNC_PARTIAL_FAILURE')
+    expect(node.walletSnapshot).toHaveBeenCalledTimes(1)
   })
 
   it('fails closed when both capture attempts cross a chain tip', async () => {

--- a/tests/wallet-snapshot-contract.test.js
+++ b/tests/wallet-snapshot-contract.test.js
@@ -210,6 +210,29 @@ describe('wallet snapshot response contract', () => {
     }), options)).toThrow('snapshot.network_before.network')
   })
 
+  it('canonicalizes recognized legacy native network casing without mutating input', () => {
+    const options = normalizeWalletSnapshotOptions()
+    const value = snapshot({
+      network_before: { network: 'Regtest', height: 100 },
+      network_after: { network: 'REGTEST', height: 100 }
+    })
+
+    const result = validateWalletSnapshotResponse(value, options)
+
+    expect(result.network_before.network).toBe('regtest')
+    expect(result.network_after.network).toBe('regtest')
+    expect(value.network_before.network).toBe('Regtest')
+    expect(value.network_after.network).toBe('REGTEST')
+  })
+
+  it('does not reinterpret an unknown mixed-case network', () => {
+    const options = normalizeWalletSnapshotOptions()
+
+    expect(() => validateWalletSnapshotResponse(snapshot({
+      network_before: { network: 'Bitcoin', height: 100 }
+    }), options)).toThrow('snapshot.network_before.network')
+  })
+
   it('requires the bounded activity envelope only when requested', () => {
     const options = normalizeWalletSnapshotOptions({
       includeActivity: true,

--- a/tests/wallet-snapshot-contract.test.js
+++ b/tests/wallet-snapshot-contract.test.js
@@ -458,6 +458,14 @@ describe('WalletAccountRgbLightning.refreshWalletSnapshot', () => {
 
     expect(error).toBeInstanceOf(WalletSyncError)
     expect(error.code).toBe(code)
+    if (code === 'WALLET_SYNC_CONTRACT_MISMATCH') {
+      expect(error.message).toContain('sync.contract_version must equal 1')
+      expect(error.details).toEqual({
+        mode: 'routine',
+        contractPath: 'sync.contract_version',
+        contractExpectation: 'must equal 1'
+      })
+    }
   })
 
   it.each([
@@ -476,6 +484,13 @@ describe('WalletAccountRgbLightning.refreshWalletSnapshot', () => {
 
     expect(error).toBeInstanceOf(WalletSnapshotError)
     expect(error.code).toBe(code)
+    if (code === 'WALLET_SNAPSHOT_CONTRACT_MISMATCH') {
+      expect(error.message).toContain('snapshot.contract_version must equal 1')
+      expect(error.details).toEqual({
+        contractPath: 'snapshot.contract_version',
+        contractExpectation: 'must equal 1'
+      })
+    }
   })
 
   it('coalesces identical refreshes and serializes different modes', async () => {

--- a/tests/wallet-snapshot-contract.test.js
+++ b/tests/wallet-snapshot-contract.test.js
@@ -1,0 +1,477 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+import { jest } from '@jest/globals'
+
+import WalletAccountRgbLightning from '../src/wallet-account-rgb-lightning.js'
+import {
+  WalletSnapshotError,
+  WalletSyncError
+} from '../src/errors.js'
+import {
+  normalizeWalletSnapshotOptions,
+  validateWalletSnapshotResponse,
+  validateWalletSyncResponse
+} from '../src/wallet-snapshot-contract.js'
+
+function syncResult (overrides = {}) {
+  return {
+    contract_version: 1,
+    mode: 'routine',
+    vanilla: { status: 'succeeded' },
+    colored: { status: 'succeeded' },
+    ...overrides
+  }
+}
+
+function snapshot (overrides = {}) {
+  return {
+    contract_version: 1,
+    native_source: 'rgb-lightning-node-v0.9.0-beta.3+utexo-wallet-v1',
+    capture_sequence: '1',
+    started_at_ms: '1000',
+    completed_at_ms: '1001',
+    network_before: { network: 'regtest', height: 100 },
+    network_after: { network: 'regtest', height: 100 },
+    node: {
+      pubkey: '02abc',
+      num_channels: '1',
+      num_usable_channels: '1',
+      claimable_onchain_sat: '9007199254740993',
+      eventual_close_fees_sat: '10',
+      pending_outbound_payments_sat: '0',
+      num_peers: '1',
+      latest_rgs_snapshot_timestamp: null
+    },
+    btc: {
+      vanilla: { settled: '42', future: '45', spendable: '40' },
+      colored: { settled: '5', future: '5', spendable: '5' }
+    },
+    assets: [{
+      asset_id: 'asset-1',
+      ticker: 'USDT',
+      name: 'Tether USD',
+      precision: 2,
+      balance: {
+        settled: '100',
+        future: '100',
+        spendable: '80',
+        offchain_outbound: '20',
+        offchain_inbound: '30'
+      }
+    }],
+    channels: [{
+      channel_id: 'channel-1',
+      peer_pubkey: '03def',
+      status: 'Opened',
+      ready: true,
+      capacity_sat: '100000',
+      claimable_onchain_sat: '60000',
+      outbound_capacity_msat: '59000000',
+      inbound_capacity_msat: '39000000',
+      next_outbound_htlc_limit_msat: '58000000',
+      next_outbound_htlc_minimum_msat: '1000',
+      is_usable: true,
+      public: false,
+      funding_txid: null,
+      peer_alias: null,
+      short_channel_id: null,
+      asset_id: 'asset-1',
+      asset_local_amount: '20',
+      asset_remote_amount: '30',
+      virtual_open_mode: 'trusted_no_broadcast'
+    }],
+    ...overrides
+  }
+}
+
+function activitySnapshot (overrides = {}) {
+  return snapshot({
+    transactions: [{
+      transaction_type: 'Incoming',
+      txid: 'txid-1',
+      received: '42',
+      sent: '0',
+      fee: '0',
+      confirmation_time: { height: 100, timestamp: '1000' }
+    }],
+    payments: [{
+      amt_msat: '1000',
+      asset_amount: null,
+      asset_id: null,
+      payment_hash: 'hash-1',
+      payment_type: 'InboundAutoClaim',
+      status: 'Succeeded',
+      created_at: '1000',
+      updated_at: '1001',
+      payee_pubkey: '02abc'
+    }],
+    transfers: [{
+      asset_id: 'asset-1',
+      transfers: [{
+        idx: 1,
+        created_at: '1000',
+        updated_at: '1001',
+        status: 'Settled',
+        requested_assignment: null,
+        assignments: ['100'],
+        kind: 'ReceiveWitness',
+        txid: 'txid-1',
+        recipient_id: null,
+        receive_utxo: null,
+        change_utxo: null,
+        expiration: null,
+        transport_endpoints: []
+      }]
+    }],
+    ...overrides
+  })
+}
+
+function accountWith (node) {
+  return new WalletAccountRgbLightning({
+    binding: {
+      ensureNode: jest.fn(() => node),
+      bootstrap: jest.fn(() => ({})),
+      vssStatus: jest.fn(() => ({ configured: false })),
+      shutdown: jest.fn()
+    }
+  })
+}
+
+describe('wallet snapshot option contract', () => {
+  it('normalizes bounded defaults and exact native names', () => {
+    const options = normalizeWalletSnapshotOptions()
+    expect(options).toMatchObject({
+      mode: 'routine',
+      maxAssets: 128,
+      maxChannels: 512,
+      maxActivityItems: 1000,
+      includeActivity: false,
+      assetIds: []
+    })
+    expect(options.nativeRequest).toEqual({
+      asset_ids: [],
+      max_assets: 128,
+      max_channels: 512,
+      max_activity_items: 1000,
+      include_activity: false
+    })
+    expect(Object.isFrozen(options.nativeRequest)).toBe(true)
+  })
+
+  it.each([
+    [{ typo: true }, 'options.typo'],
+    [{ mode: 'fast' }, 'options.mode'],
+    [{ maxAssets: 0 }, 'options.maxAssets'],
+    [{ maxChannels: 513 }, 'options.maxChannels'],
+    [{ assetIds: ['same', 'same'] }, 'options.assetIds[1]']
+  ])('rejects invalid options without silently applying defaults', (input, path) => {
+    expect(() => normalizeWalletSnapshotOptions(input)).toThrow(path)
+  })
+})
+
+describe('wallet snapshot response contract', () => {
+  it('accepts exact decimal strings beyond Number.MAX_SAFE_INTEGER', () => {
+    const options = normalizeWalletSnapshotOptions()
+    const result = validateWalletSnapshotResponse(snapshot(), options)
+    expect(result.node.claimable_onchain_sat).toBe('9007199254740993')
+    expect(Object.isFrozen(result.channels[0])).toBe(true)
+  })
+
+  it('rejects unsafe JSON numbers and additive v1 fields', () => {
+    const options = normalizeWalletSnapshotOptions()
+    expect(() => validateWalletSnapshotResponse(snapshot({
+      btc: {
+        vanilla: { settled: Number.MAX_SAFE_INTEGER + 2, future: '45', spendable: '40' },
+        colored: { settled: '5', future: '5', spendable: '5' }
+      }
+    }), options)).toThrow('snapshot.btc.vanilla.settled')
+    expect(() => validateWalletSnapshotResponse(snapshot({ extra: true }), options))
+      .toThrow('snapshot.extra')
+  })
+
+  it('requires the bounded activity envelope only when requested', () => {
+    const options = normalizeWalletSnapshotOptions({
+      includeActivity: true,
+      assetIds: ['asset-1']
+    })
+    expect(() => validateWalletSnapshotResponse(snapshot(), options))
+      .toThrow('snapshot.transactions')
+    expect(validateWalletSnapshotResponse(activitySnapshot(), options).payments)
+      .toHaveLength(1)
+  })
+
+  it('accepts transfer endpoint metadata and nullable transfer fields', () => {
+    const options = normalizeWalletSnapshotOptions({
+      includeActivity: true,
+      assetIds: ['asset-1']
+    })
+    const value = activitySnapshot()
+    value.transfers[0].transfers[0].transport_endpoints = [{
+      endpoint: 'rpc://127.0.0.1:3000/json-rpc',
+      transport_type: 'JsonRpc',
+      used: true
+    }]
+
+    expect(validateWalletSnapshotResponse(value, options).transfers[0]
+      .transfers[0].transport_endpoints[0].used).toBe(true)
+  })
+
+  it('accepts an unconfirmed transaction without block-time metadata', () => {
+    const options = normalizeWalletSnapshotOptions({
+      includeActivity: true,
+      assetIds: ['asset-1']
+    })
+    const value = activitySnapshot()
+    value.transactions[0].confirmation_time = null
+
+    expect(validateWalletSnapshotResponse(value, options).transactions[0]
+      .confirmation_time).toBeNull()
+  })
+
+  it.each([
+    [null, 'snapshot'],
+    [snapshot({ node: { ...snapshot().node, pubkey: '' } }), 'snapshot.node.pubkey'],
+    [snapshot({ node: { ...snapshot().node, pubkey: 42 } }), 'snapshot.node.pubkey'],
+    [snapshot({ node: { ...snapshot().node, pubkey: 'a'.repeat(131) } }), 'snapshot.node.pubkey'],
+    [snapshot({ assets: {} }), 'snapshot.assets'],
+    [snapshot({ contract_version: 2 }), 'snapshot.contract_version'],
+    [snapshot({ native_source: 'untrusted-native' }), 'snapshot.native_source'],
+    [snapshot({ started_at_ms: '1002', completed_at_ms: '1001' }), 'snapshot.completed_at_ms'],
+    [snapshot({ capture_sequence: '0' }), 'snapshot.capture_sequence'],
+    [snapshot({ channels: [{ ...snapshot().channels[0], ready: 'true' }] }), 'snapshot.channels[0].ready'],
+    [snapshot({ assets: [snapshot().assets[0], snapshot().assets[0]] }), 'snapshot.assets[1].asset_id']
+  ])('rejects malformed snapshot contract evidence', (value, path) => {
+    const options = normalizeWalletSnapshotOptions()
+    expect(() => validateWalletSnapshotResponse(value, options)).toThrow(path)
+  })
+
+  it('rejects activity for an asset that was not requested', () => {
+    const options = normalizeWalletSnapshotOptions({
+      includeActivity: true,
+      assetIds: ['asset-1']
+    })
+    const value = activitySnapshot()
+    value.transfers[0].asset_id = 'asset-2'
+
+    expect(() => validateWalletSnapshotResponse(value, options))
+      .toThrow('snapshot.transfers[0].asset_id')
+  })
+
+  it('requires activity fields to be absent when activity was not requested', () => {
+    const options = normalizeWalletSnapshotOptions()
+    expect(() => validateWalletSnapshotResponse(snapshot({ transactions: [] }), options))
+      .toThrow('snapshot.transactions')
+  })
+
+  it('requires every top-level snapshot field', () => {
+    const options = normalizeWalletSnapshotOptions()
+    const value = snapshot()
+    delete value.node
+
+    expect(() => validateWalletSnapshotResponse(value, options)).toThrow('snapshot.node')
+  })
+
+  it.each([
+    [syncResult({ contract_version: 2 }), 'sync.contract_version'],
+    [syncResult({ vanilla: { status: 'succeeded', error_code: 'IMPOSSIBLE' } }), 'sync.vanilla.error_code'],
+    [null, 'sync']
+  ])('rejects malformed sync contract evidence', (value, path) => {
+    expect(() => validateWalletSyncResponse(value, 'routine')).toThrow(path)
+  })
+
+  it('rejects a sync response for a different requested mode', () => {
+    expect(() => validateWalletSyncResponse(syncResult(), 'recovery'))
+      .toThrow('sync.mode')
+  })
+})
+
+describe('WalletAccountRgbLightning.refreshWalletSnapshot', () => {
+  it('syncs both keychains then captures an immutable coherent snapshot', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult()),
+      walletSnapshot: jest.fn(() => snapshot())
+    }
+    const account = accountWith(node)
+
+    const result = await account.refreshWalletSnapshot()
+
+    expect(node.syncWallet).toHaveBeenCalledWith({ mode: 'routine' })
+    expect(node.walletSnapshot).toHaveBeenCalledWith({
+      asset_ids: [],
+      max_assets: 128,
+      max_channels: 512,
+      max_activity_items: 1000,
+      include_activity: false
+    })
+    expect(result.contractVersion).toBe(1)
+    expect(Object.isFrozen(result)).toBe(true)
+    expect(Object.isFrozen(result.snapshot.btc)).toBe(true)
+  })
+
+  it('preserves structured evidence when only one keychain fails', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult({
+        vanilla: { status: 'failed', error_code: 'FAILED_BDK_SYNC' }
+      })),
+      walletSnapshot: jest.fn()
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(WalletSyncError)
+    expect(error.code).toBe('WALLET_SYNC_PARTIAL_FAILURE')
+    expect(error.details.vanilla).toEqual({
+      status: 'failed',
+      error_code: 'FAILED_BDK_SYNC'
+    })
+    expect(node.walletSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('uses FullScan recovery mode only when explicitly selected', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult({ mode: 'recovery' })),
+      walletSnapshot: jest.fn(() => snapshot())
+    }
+    await accountWith(node).refreshWalletSnapshot({ mode: 'recovery' })
+    expect(node.syncWallet).toHaveBeenCalledWith({ mode: 'recovery' })
+  })
+
+  it('retries one incoherent capture and returns the coherent retry', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult()),
+      walletSnapshot: jest.fn()
+        .mockReturnValueOnce(snapshot({
+          capture_sequence: '7',
+          network_after: { network: 'regtest', height: 101 }
+        }))
+        .mockReturnValueOnce(snapshot({ capture_sequence: '8' }))
+    }
+    const result = await accountWith(node).refreshWalletSnapshot()
+    expect(node.walletSnapshot).toHaveBeenCalledTimes(2)
+    expect(result.snapshot.capture_sequence).toBe('8')
+  })
+
+  it('fails closed when both capture attempts cross a chain tip', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult()),
+      walletSnapshot: jest.fn()
+        .mockReturnValueOnce(snapshot({
+          capture_sequence: '7',
+          network_after: { network: 'regtest', height: 101 }
+        }))
+        .mockReturnValueOnce(snapshot({
+          capture_sequence: '8',
+          network_after: { network: 'regtest', height: 101 }
+        }))
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+    expect(error).toBeInstanceOf(WalletSnapshotError)
+    expect(error.code).toBe('WALLET_SNAPSHOT_INCOHERENT')
+  })
+
+  it('fails closed when an incoherent retry does not advance its capture sequence', async () => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult()),
+      walletSnapshot: jest.fn(() => snapshot({
+        capture_sequence: '7',
+        network_after: { network: 'regtest', height: 101 }
+      }))
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(WalletSnapshotError)
+    expect(error.code).toBe('WALLET_SNAPSHOT_CONTRACT_MISMATCH')
+    expect(error.details).toEqual({
+      firstCaptureSequence: '7',
+      retryCaptureSequence: '7'
+    })
+  })
+
+  it.each([
+    [new Error('native sync failed'), 'WALLET_SYNC_NATIVE_FAILURE'],
+    [syncResult({ contract_version: 2 }), 'WALLET_SYNC_CONTRACT_MISMATCH']
+  ])('classifies native and contract sync failures', async (outcome, code) => {
+    const node = {
+      syncWallet: jest.fn(() => {
+        if (outcome instanceof Error) throw outcome
+        return outcome
+      }),
+      walletSnapshot: jest.fn()
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(WalletSyncError)
+    expect(error.code).toBe(code)
+  })
+
+  it.each([
+    [new Error('native snapshot failed'), 'WALLET_SNAPSHOT_NATIVE_FAILURE'],
+    [snapshot({ contract_version: 2 }), 'WALLET_SNAPSHOT_CONTRACT_MISMATCH'],
+    [new WalletSnapshotError('native typed failure', { code: 'NATIVE_TYPED_FAILURE' }), 'NATIVE_TYPED_FAILURE']
+  ])('classifies native, contract, and typed snapshot failures', async (outcome, code) => {
+    const node = {
+      syncWallet: jest.fn(() => syncResult()),
+      walletSnapshot: jest.fn(() => {
+        if (outcome instanceof Error) throw outcome
+        return outcome
+      })
+    }
+    const error = await accountWith(node).refreshWalletSnapshot().catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(WalletSnapshotError)
+    expect(error.code).toBe(code)
+  })
+
+  it('coalesces identical refreshes and serializes different modes', async () => {
+    let releaseRoutine
+    const routine = new Promise((resolve) => { releaseRoutine = resolve })
+    const node = {
+      syncWallet: jest.fn(({ mode }) => mode === 'routine'
+        ? routine
+        : syncResult({ mode: 'recovery' })),
+      walletSnapshot: jest.fn(() => snapshot())
+    }
+    const account = accountWith(node)
+    const first = account.refreshWalletSnapshot()
+    const duplicate = account.refreshWalletSnapshot()
+    const recovery = account.refreshWalletSnapshot({ mode: 'recovery' })
+
+    expect(duplicate).toBe(first)
+    await Promise.resolve()
+    expect(node.syncWallet).toHaveBeenCalledTimes(1)
+    releaseRoutine(syncResult())
+    await first
+    await recovery
+    expect(node.syncWallet.mock.calls.map(([request]) => request.mode))
+      .toEqual(['routine', 'recovery'])
+  })
+
+  it('keeps the serialized refresh queue usable after a failed request', async () => {
+    const node = {
+      syncWallet: jest.fn()
+        .mockReturnValueOnce(syncResult({ contract_version: 2 }))
+        .mockReturnValueOnce(syncResult({ mode: 'recovery' })),
+      walletSnapshot: jest.fn(() => snapshot())
+    }
+    const account = accountWith(node)
+    const failed = account.refreshWalletSnapshot()
+    const recovery = account.refreshWalletSnapshot({ mode: 'recovery' })
+
+    await expect(failed).rejects.toMatchObject({ code: 'WALLET_SYNC_CONTRACT_MISMATCH' })
+    await expect(recovery).resolves.toMatchObject({
+      sync: { mode: 'recovery' },
+      snapshot: { capture_sequence: '1' }
+    })
+  })
+
+  it('reports old native packages as an explicit compatibility error', async () => {
+    const error = await accountWith({ sync: jest.fn() })
+      .refreshWalletSnapshot()
+      .catch((reason) => reason)
+    expect(error).toBeInstanceOf(WalletSnapshotError)
+    expect(error.code).toBe('WALLET_SNAPSHOT_UNSUPPORTED_BINDING')
+  })
+})


### PR DESCRIPTION
## What changed

- adds `account.refreshWalletSnapshot(options)` as the versioned wallet refresh API
- coalesces identical requests and serializes different refresh modes so FullSync and FullScan cannot race
- validates the complete native v1 DTO, including ABI identity, exact keys, enums, u64 bounds, aggregate transfer counts, decimal strings, and activity envelopes
- preserves structured partial-sync evidence and classifies native, contract, and coherence failures with typed errors
- retries once when the chain tip moves, re-synchronizing both keychains before recapture, and fails closed if the retry remains incoherent
- canonicalizes only known legacy network names at the native boundary while unknown values still fail closed
- supports an explicit validated auto-unlock request, coalescing account activation so WDK Core can obtain the real native address without an address/unlock cycle
- documents that Lightning claimable value and routing capacity are separate accounting concepts

## Dependencies

- NodeJS native contract: https://github.com/UTEXO-Protocol/rgb-lightning-node-nodejs/pull/16
- Bare/mobile native contract and iOS installer: https://github.com/UTEXO-Protocol/rgb-lightning-node-bare/pull/14

## Why

The old `account.sync()` delegates to RLN's legacy Colored-only FastSync. It cannot refresh received Vanilla BTC and it encourages callers to assemble portfolio state from independent, loosely typed reads. This facade provides one explicit synchronization and snapshot boundary while retaining the legacy API for compatibility.

## Validation

- PR CI passed
- lint and strict TypeScript contract checks passed
- 15 suites / 568 tests passed
- snapshot validator and known/unknown network canonicalization regression tests passed
- funded iPhone 17 Pro Simulator consumer smoke returned `2.00000000 BTC` on-chain after biometric unlock
- npm audit: 0 vulnerabilities

## Deployment note

The API fails with `WALLET_SNAPSHOT_UNSUPPORTED_BINDING` unless the installed native binding implements contract v1. Consumers must pin compatible source commits and install native artifacts built from the corresponding Bare or NodeJS PR. Bare PR #14 provides a hash-pinned iOS source-build or trusted-artifact import path; immutable hosted iOS artifacts and Android distribution remain open.
