### PR TITLE
Harden npm release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,34 @@
 name: Build and Test
 
-# Mirrors UTEXO-Protocol/wdk-wallet-rgb/.github/workflows/build.yml. The
-# native bindings are optional peer deps, so CI runs without them: the
-# check is lint plus the jest unit suite, which exercises the host-side
-# JS logic (recipient routing, error wrapping, binding config mapping)
-# with the native addon mocked — no live node required.
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '22.23.1'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Pin npm
+        run: npm install --global npm@12.0.1
+
       - name: Install dependencies
-        run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+        run: npm ci --ignore-scripts
 
       - name: Lint
         run: npm run lint
@@ -40,3 +38,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Check package contents
+        run: npm run check:package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,111 +1,88 @@
 name: Release
 
 on:
-  # Triggered by rgb-lightning-node after a new SDK release
-  repository_dispatch:
-    types: [rln-release]
-
-  # Manual trigger
-  workflow_dispatch:
-    inputs:
-      rln_version:
-        description: 'RLN version to pin (e.g., 0.3.0-beta.2)'
-        required: true
-        type: string
-
-  # Tag-based release (manual version bump + tag push)
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to finalize (for example, v0.1.0-beta.15)'
+        required: true
+        type: string
 
-permissions:
-  contents: write
-  id-token: write # required for npm publish --provenance
+permissions: {}
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish npm package
+  stage:
+    name: Validate and stage npm package
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Resolve RLN version
-        id: rln
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-            echo "auto=true" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            VERSION="${{ inputs.rln_version }}"
-            echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-            echo "auto=true" >> $GITHUB_OUTPUT
-          else
-            echo "auto=false" >> $GITHUB_OUTPUT
-          fi
-
-      # NOTE: binding peerDependencies are intentionally NOT derived from the
-      # RLN SDK version. The native binding packages
-      # (@utexo/rgb-lightning-node-{bare,nodejs}) carry their own npm version
-      # line (0.1.0-beta.x), decoupled from the RLN SDK release tag
-      # (0.6.0-beta.x). Bump those peerDeps by hand when a new binding is cut.
+      - name: Checkout tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org/'
+          node-version: '24.18.0'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
-      - name: Wait for required native binding releases
-        if: steps.rln.outputs.auto == 'true'
+      - name: Pin npm
+        run: npm install --global npm@12.0.1
+
+      - name: Validate release tag
+        id: metadata
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          for package in \
-            '@utexo/rgb-lightning-node-bare' \
-            '@utexo/rgb-lightning-node-nodejs'; do
-            range=$(node -p "require('./package.json').peerDependencies['$package']")
-            minimum=$(printf '%s' "$range" | sed -n 's/^>=\([^ ]*\).*/\1/p')
-            if [ -z "$minimum" ]; then
-              echo "::error::Cannot derive a minimum version from $package peer range: $range"
-              exit 1
-            fi
 
-            for attempt in $(seq 1 60); do
-              if npm view "$package@$minimum" version >/dev/null 2>&1; then
-                echo "$package@$minimum is available"
-                break
-              fi
-              if [ "$attempt" -eq 60 ]; then
-                echo "::error::$package@$minimum was not published within 30 minutes"
-                exit 1
-              fi
-              echo "Waiting for $package@$minimum ($attempt/60)"
-              sleep 30
-            done
-          done
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+          TAG_COMMIT=$(git rev-parse HEAD)
 
-      - name: Bump package prerelease version
-        if: steps.rln.outputs.auto == 'true'
-        run: npm version prerelease --preid=beta --no-git-tag-version
+          if [ "$RELEASE_TAG" != "$EXPECTED_TAG" ]; then
+            echo "::error::Tag $RELEASE_TAG does not match package version $PACKAGE_VERSION"
+            exit 1
+          fi
 
-      - name: Commit and push version bump
-        if: steps.rln.outputs.auto == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "chore(release): bump prerelease version (RLN SDK v${{ steps.rln.outputs.version }})"
-          git push
+          git fetch --no-tags origin main
+          MAIN_COMMIT=$(git rev-parse origin/main)
+          if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then
+            echo "::error::Release tag must point to the current main commit"
+            exit 1
+          fi
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Release checkout is not clean"
+            exit 1
+          fi
+
+          {
+            echo "name=$PACKAGE_NAME"
+            echo "version=$PACKAGE_VERSION"
+            echo "tag=$RELEASE_TAG"
+            echo "commit=$TAG_COMMIT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+        run: npm ci --ignore-scripts
 
       - name: Lint
         run: npm run lint
@@ -113,54 +90,190 @@ jobs:
       - name: Check types
         run: npm run check:types
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Run tests with coverage
+        run: npm run test:coverage
 
-      - name: Get package version
-        id: pkg_version
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
+      - name: Verify native peer releases
+        run: node scripts/verify-peer-releases.mjs
+
+      - name: Build and verify package tarball
+        id: pack
+        run: node scripts/verify-package.mjs --output-dir "$RUNNER_TEMP/package"
+
+      - name: Smoke test Node package
+        run: npm run smoke:package:node -- "${{ steps.pack.outputs.tarball }}"
+
+      - name: Check registry state
+        id: registry
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=v$VERSION" >> $GITHUB_OUTPUT
-          echo "bare=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-bare']")" >> $GITHUB_OUTPUT
-          echo "nodejs=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-nodejs']")" >> $GITHUB_OUTPUT
+          node scripts/verify-registry-artifact.mjs \
+            --name "${{ steps.metadata.outputs.name }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --integrity "${{ steps.pack.outputs.integrity }}" \
+            --git-head "${{ steps.metadata.outputs.commit }}" \
+            --allow-missing \
+            --require-latest
 
-      # Create the GitHub Release for both trigger paths: the auto (RLN
-      # dispatch / workflow_dispatch) path AND the manual tag-push path.
-      # Previously this was gated on `auto == 'true'`, so a `v*` tag push
-      # published to npm but left no matching GitHub Release — the release
-      # had to be created by hand, which let npm and GitHub drift apart.
-      - name: Create Release
-        if: steps.rln.outputs.auto == 'true' || github.event_name == 'push'
-        uses: softprops/action-gh-release@v2
+      - name: Stage package for 2FA approval
+        if: steps.registry.outputs.published != 'true'
+        run: |
+          npm stage publish "${{ steps.pack.outputs.tarball }}" \
+            --access public \
+            --tag latest
+
+  finalize:
+    name: Verify publication and create GitHub release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: npm
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          tag_name: ${{ steps.pkg_version.outputs.version }}
-          name: Release ${{ steps.pkg_version.outputs.version }}
-          body: |
-            ## wdk-rgb-lightning ${{ steps.pkg_version.outputs.version }}
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
 
-            WDK module for RGB Lightning — channels, invoices, payments, RGB-over-LN.
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
-            ### Installation
-            ```bash
-            npm install @utexo/wdk-rgb-lightning
-            ```
+      - name: Pin npm
+        run: npm install --global npm@12.0.1
 
-            ### Peer dependencies
-            ```json
-            "@utexo/rgb-lightning-node-bare": "${{ steps.pkg_version.outputs.bare }}",
-            "@utexo/rgb-lightning-node-nodejs": "${{ steps.pkg_version.outputs.nodejs }}"
-            ```
-          draft: false
-          # Mark each new release as GitHub's "Latest" so it tracks npm's
-          # `latest` dist-tag. GitHub refuses to flag a *prerelease* as
-          # Latest, so the newest release is published as a non-prerelease
-          # (the version string itself, e.g. 0.1.0-beta.11, still signals
-          # the beta line). Without this, betas were left as prereleases
-          # and the "Latest" badge stuck to an older release, drifting from
-          # npm.
-          prerelease: false
-          make_latest: true
+      - name: Validate release tag
+        id: metadata
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+          TAG_COMMIT=$(git rev-parse HEAD)
+          BARE_RANGE=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-bare']")
+          NODEJS_RANGE=$(node -p "require('./package.json').peerDependencies['@utexo/rgb-lightning-node-nodejs']")
+
+          if [ "$RELEASE_TAG" != "$EXPECTED_TAG" ]; then
+            echo "::error::Tag $RELEASE_TAG does not match package version $PACKAGE_VERSION"
+            exit 1
+          fi
+          if [ "$(git rev-parse "${RELEASE_TAG}^{commit}")" != "$TAG_COMMIT" ]; then
+            echo "::error::Checked-out commit does not match $RELEASE_TAG"
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Release tag is not reachable from main"
+            exit 1
+          fi
+
+          {
+            echo "name=$PACKAGE_NAME"
+            echo "version=$PACKAGE_VERSION"
+            echo "tag=$RELEASE_TAG"
+            echo "commit=$TAG_COMMIT"
+            echo "bare_range=$BARE_RANGE"
+            echo "nodejs_range=$NODEJS_RANGE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Rebuild and verify package tarball
+        id: pack
+        run: node scripts/verify-package.mjs --output-dir "$RUNNER_TEMP/package"
+
+      - name: Verify published npm artifact
+        run: |
+          node scripts/verify-registry-artifact.mjs \
+            --name "${{ steps.metadata.outputs.name }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --integrity "${{ steps.pack.outputs.integrity }}" \
+            --git-head "${{ steps.metadata.outputs.commit }}" \
+            --require-provenance \
+            --require-latest \
+            --wait-seconds 600
+
+      - name: Smoke test published Node package
+        run: npm run smoke:package:node -- --registry --verify-signatures
+
+      - name: Require immutable GitHub releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --header 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/${GITHUB_REPOSITORY}/immutable-releases" \
+            --silent
+
+      - name: Create or verify GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+          PACKAGE_NAME: ${{ steps.metadata.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.metadata.outputs.version }}
+          PACKAGE_INTEGRITY: ${{ steps.pack.outputs.integrity }}
+          PACKAGE_TARBALL: ${{ steps.pack.outputs.tarball }}
+          PACKAGE_FILENAME: ${{ steps.pack.outputs.filename }}
+          BARE_RANGE: ${{ steps.metadata.outputs.bare_range }}
+          NODEJS_RANGE: ${{ steps.metadata.outputs.nodejs_range }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            NOTES=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n\n%s\n%s' \
+              "Published npm artifact: \`${PACKAGE_NAME}@${PACKAGE_VERSION}\`" \
+              "Install: \`npm install ${PACKAGE_NAME}\`" \
+              "Native peer dependencies:" \
+              "- \`@utexo/rgb-lightning-node-bare\`: \`${BARE_RANGE}\`" \
+              "- \`@utexo/rgb-lightning-node-nodejs\`: \`${NODEJS_RANGE}\`" \
+              "Integrity:" \
+              "\`${PACKAGE_INTEGRITY}\`")
+
+            gh release create "$RELEASE_TAG" \
+              "${PACKAGE_TARBALL}#npm package tarball" \
+              --verify-tag \
+              --title "Release ${RELEASE_TAG}" \
+              --notes "$NOTES" \
+              --generate-notes \
+              --latest
+          fi
+
+          RELEASE_JSON="$RUNNER_TEMP/release.json"
+          gh release view "$RELEASE_TAG" \
+            --json tagName,isDraft,isImmutable,isPrerelease,assets \
+            > "$RELEASE_JSON"
+
+          node --input-type=commonjs - "$RELEASE_JSON" "$RELEASE_TAG" "$PACKAGE_FILENAME" <<'NODE'
+          const fs = require('node:fs')
+          const [releaseFile, expectedTag, expectedAsset] = process.argv.slice(2)
+          const release = JSON.parse(fs.readFileSync(releaseFile, 'utf8'))
+
+          if (release.tagName !== expectedTag) {
+            throw new Error(`GitHub release tag is ${release.tagName}, not ${expectedTag}`)
+          }
+          if (release.isDraft || release.isPrerelease || !release.isImmutable) {
+            throw new Error('GitHub release is not published and immutable')
+          }
+          if (!release.assets.some(asset => asset.name === expectedAsset)) {
+            throw new Error(`GitHub release is missing ${expectedAsset}`)
+          }
+          NODE
+
+          ASSET_DIR="$RUNNER_TEMP/release-asset"
+          mkdir -p "$ASSET_DIR"
+          gh release download "$RELEASE_TAG" \
+            --pattern "$PACKAGE_FILENAME" \
+            --dir "$ASSET_DIR"
+          cmp "$PACKAGE_TARBALL" "$ASSET_DIR/$PACKAGE_FILENAME"

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+node_modules/
+coverage/
+tests/
+scripts/
+.github/
+jest.setup.js
+tsconfig.types.json
+RELEASING.md
+*.tgz

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,95 @@
+# Releasing `@utexo/wdk-rgb-lightning`
+
+Releases are built from a reviewed commit on `main`, staged through npm trusted
+publishing, approved by a maintainer with 2FA, and finalized as an immutable
+GitHub release.
+
+## One-time configuration
+
+### npm
+
+Configure the package's trusted publisher with:
+
+- Provider: GitHub Actions
+- Organization: `UTEXO-Protocol`
+- Repository: `wdk-rgb-lightning`
+- Workflow: `release.yml`
+- Environment: `npm`
+- Allowed action: staged publish only
+
+After the staged flow has been validated, set package publishing access to
+require 2FA and disallow tokens. Remove the repository's legacy `NPM_TOKEN`
+secret.
+
+### GitHub
+
+Create an `npm` environment with required reviewers and prevent self-review.
+Protect release tags matching `v*` so only release maintainers can create them.
+Enable immutable releases for the repository.
+
+## Release preparation
+
+1. Freeze unrelated merges, including native or wallet changes not included in
+   the release candidate.
+2. Confirm compatible native packages are already published. Native package
+   versions are independent from the RGB Lightning SDK version.
+3. Run the real Node native-binding smoke test and the Bare/iOS integration
+   regression against the exact release candidate.
+4. Open a release PR that changes only:
+   - `package.json` and `package-lock.json` version fields
+   - the matching `CHANGELOG.md` release section
+5. Require the normal `build` check and an approving review before squash merge.
+
+Do not release a version from a working branch, an unreviewed commit, or a
+commit that is not the current `main` head.
+
+## Stage the npm package
+
+Create an annotated tag on the exact release commit and push it:
+
+```bash
+git fetch origin main
+git tag -a v0.1.0-beta.15 origin/main -m "Release v0.1.0-beta.15"
+git push origin v0.1.0-beta.15
+```
+
+The tag-triggered `Release` workflow:
+
+1. Requires the tag to match `package.json` and point to the current `main`.
+2. Runs lint, type checking, coverage, audit, package-content validation, and a
+   clean Node/native-binding smoke test.
+3. Rebuilds the npm tarball deterministically and records its integrity.
+4. Stages that tarball through npm OIDC with the `latest` dist-tag.
+
+The staging command is the final workflow write. No GitHub release is created
+until the staged npm package is approved and publicly verifiable.
+
+## Approve and finalize
+
+Review the staged package on npm, including its files, version, tag, and
+integrity. Approve it with 2FA.
+
+After the package is public, run the `Release` workflow manually with the
+existing tag. The finalization job verifies:
+
+- npm integrity against a fresh local pack
+- npm `gitHead` against the tagged commit
+- SLSA provenance and the attestation endpoint
+- the `latest` dist-tag
+- a clean registry install, native Node load, and npm signatures
+- repository-level immutable releases
+
+It then creates an immutable GitHub release, attaches the exact npm tarball,
+and verifies the downloaded release asset byte-for-byte.
+
+## Rollback
+
+npm versions and immutable GitHub releases are never overwritten.
+
+For a defective release:
+
+1. Move `latest` back to the previous known-good version using a maintainer
+   session with 2FA.
+2. Deprecate the defective version with a precise warning.
+3. Fix forward in the next prerelease version.
+4. Record the incident and recovery in the next changelog entry.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/UTEXO-Protocol/wdk-rgb-lightning.git"
+    "url": "git+https://github.com/UTEXO-Protocol/wdk-rgb-lightning.git"
   },
   "main": "index.js",
   "types": "./index.d.ts",
@@ -23,6 +23,8 @@
     "lint": "standard --env jest",
     "lint:fix": "standard --fix --env jest",
     "check:types": "tsc -p tsconfig.types.json",
+    "check:package": "node scripts/verify-package.mjs",
+    "smoke:package:node": "node scripts/smoke-node-package.mjs",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },

--- a/scripts/smoke-node-package.mjs
+++ b/scripts/smoke-node-package.mjs
@@ -1,0 +1,141 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(
+  readFileSync(path.join(rootDir, 'package.json'), 'utf8')
+)
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+function hasArgument (name) {
+  return process.argv.includes(name)
+}
+
+function run (command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: 'inherit',
+    ...options
+  })
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with ${result.status}`)
+  }
+}
+
+function minimumVersion (range, packageName) {
+  const match = /^>=([^ ]+)/.exec(range)
+  if (!match) {
+    throw new Error(
+      `Cannot derive the minimum version from ${packageName} range: ${range}`
+    )
+  }
+  return match[1]
+}
+
+const temporaryRoot = mkdtempSync(
+  path.join(tmpdir(), 'wdk-rgb-lightning-smoke-')
+)
+
+try {
+  const registryPackage = hasArgument('--registry')
+  const verifySignatures = hasArgument('--verify-signatures')
+  const positionalArgument = process.argv
+    .slice(2)
+    .find(argument => !argument.startsWith('--'))
+  let packageSpec = registryPackage
+    ? `${packageJson.name}@${packageJson.version}`
+    : positionalArgument && path.resolve(positionalArgument)
+
+  if (!packageSpec) {
+    const packDir = path.join(temporaryRoot, 'pack')
+    run(process.execPath, [
+      path.join(rootDir, 'scripts', 'verify-package.mjs'),
+      '--output-dir',
+      packDir
+    ])
+    packageSpec = path.join(
+      packDir,
+      `${packageJson.name.replace('@', '').replace('/', '-')}-${packageJson.version}.tgz`
+    )
+  }
+
+  const nativePackage = '@utexo/rgb-lightning-node-nodejs'
+  const nativeVersion = minimumVersion(
+    packageJson.peerDependencies[nativePackage],
+    nativePackage
+  )
+
+  writeFileSync(
+    path.join(temporaryRoot, 'package.json'),
+    JSON.stringify({
+      private: true,
+      allowScripts: {
+        [`${nativePackage}@${nativeVersion}`]: true
+      }
+    }, null, 2) + '\n'
+  )
+  writeFileSync(
+    path.join(temporaryRoot, '.npmrc'),
+    'strict-allow-scripts=true\n'
+  )
+
+  run(npmExecutable, [
+    'install',
+    '--no-audit',
+    '--no-fund',
+    '--save-exact',
+    packageSpec,
+    `${nativePackage}@${nativeVersion}`
+  ], { cwd: temporaryRoot })
+
+  if (verifySignatures) {
+    run(npmExecutable, ['audit', 'signatures'], { cwd: temporaryRoot })
+  }
+
+  const smokeProgram = `
+    import WalletManagerRgbLightning, {
+      NodeRgbLightningBinding,
+      WalletAccountReadOnlyRgbLightning
+    } from '${packageJson.name}'
+
+    const metadata = (
+      await import('${packageJson.name}/package', {
+        with: { type: 'json' }
+      })
+    ).default
+
+    if (metadata.name !== '${packageJson.name}') {
+      throw new Error('Package subpath returned the wrong package name')
+    }
+    if (metadata.version !== '${packageJson.version}') {
+      throw new Error('Package subpath returned the wrong package version')
+    }
+    if (WalletManagerRgbLightning.Binding !== NodeRgbLightningBinding) {
+      throw new Error('The default Node export is wired to the wrong binding')
+    }
+    if (typeof WalletAccountReadOnlyRgbLightning !== 'function') {
+      throw new Error('The read-only account export is missing')
+    }
+    if (typeof NodeRgbLightningBinding.healthcheck !== 'function') {
+      throw new Error('The native healthcheck surface is missing')
+    }
+
+    NodeRgbLightningBinding.healthcheck()
+  `
+
+  run(
+    process.execPath,
+    ['--input-type=module', '--eval', smokeProgram],
+    { cwd: temporaryRoot }
+  )
+
+  console.log(
+    `Node package smoke passed with ${nativePackage}@${nativeVersion}`
+  )
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true })
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,165 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(
+  await import('node:fs/promises').then(({ readFile }) =>
+    readFile(path.join(rootDir, 'package.json'), 'utf8')
+  )
+)
+
+function argumentValue (name) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return undefined
+  if (!process.argv[index + 1]) throw new Error(`${name} requires a value`)
+  return process.argv[index + 1]
+}
+
+function walkFiles (directory, prefix) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = path.posix.join(prefix, entry.name)
+    return entry.isDirectory()
+      ? walkFiles(absolutePath, relativePath)
+      : [relativePath]
+  })
+}
+
+function writeOutputs (report) {
+  if (!process.env.GITHUB_OUTPUT) return
+
+  const outputs = {
+    tarball: report.tarball,
+    filename: report.filename,
+    integrity: report.integrity,
+    shasum: report.shasum,
+    size: report.size,
+    unpacked_size: report.unpackedSize,
+    file_count: report.fileCount
+  }
+
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n') + '\n'
+  )
+}
+
+const requestedOutputDir = argumentValue('--output-dir')
+const temporaryOutputDir = !requestedOutputDir
+const outputDir = requestedOutputDir
+  ? path.resolve(requestedOutputDir)
+  : mkdtempSync(path.join(tmpdir(), 'wdk-rgb-lightning-pack-'))
+
+mkdirSync(outputDir, { recursive: true })
+
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const pack = spawnSync(
+  npmExecutable,
+  ['pack', '--json', '--pack-destination', outputDir],
+  {
+    cwd: rootDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+)
+
+if (pack.status !== 0) {
+  throw new Error(`npm pack failed:\n${pack.stderr || pack.stdout}`)
+}
+
+let packResult
+try {
+  packResult = JSON.parse(pack.stdout)
+} catch (error) {
+  throw new Error(`npm pack returned invalid JSON:\n${pack.stdout}`, {
+    cause: error
+  })
+}
+
+const packedPackages = Array.isArray(packResult)
+  ? packResult
+  : Object.values(packResult)
+
+if (packedPackages.length !== 1) {
+  throw new Error('npm pack must return exactly one package')
+}
+
+const packed = packedPackages[0]
+const packedFiles = new Set(packed.files.map(file => file.path))
+const requiredRootFiles = [
+  'CHANGELOG.md',
+  'LICENSE',
+  'README.md',
+  'bare.js',
+  'index-bare.js',
+  'index-node.js',
+  'index.d.ts',
+  'index.js',
+  'package.json'
+]
+const requiredRuntimeFiles = [
+  ...walkFiles(path.join(rootDir, 'assets'), 'assets'),
+  ...walkFiles(path.join(rootDir, 'src'), 'src')
+]
+const requiredFiles = [...requiredRootFiles, ...requiredRuntimeFiles]
+
+for (const requiredFile of requiredFiles) {
+  if (!packedFiles.has(requiredFile)) {
+    throw new Error(`Package is missing required file: ${requiredFile}`)
+  }
+}
+
+const allowedRootFiles = new Set(requiredRootFiles)
+const unexpectedFiles = [...packedFiles].filter(file => {
+  if (allowedRootFiles.has(file)) return false
+  return !file.startsWith('assets/') && !file.startsWith('src/')
+})
+
+if (unexpectedFiles.length > 0) {
+  throw new Error(
+    `Package contains unexpected files:\n${unexpectedFiles.sort().join('\n')}`
+  )
+}
+
+if (packed.name !== packageJson.name || packed.version !== packageJson.version) {
+  throw new Error(
+    `Packed identity ${packed.name}@${packed.version} does not match ` +
+    `${packageJson.name}@${packageJson.version}`
+  )
+}
+
+const tarball = path.resolve(outputDir, packed.filename)
+if (!existsSync(tarball)) {
+  throw new Error(`npm pack did not create ${tarball}`)
+}
+
+const report = {
+  name: packed.name,
+  version: packed.version,
+  filename: packed.filename,
+  tarball,
+  integrity: packed.integrity,
+  shasum: packed.shasum,
+  size: packed.size,
+  unpackedSize: packed.unpackedSize,
+  fileCount: packed.entryCount
+}
+
+writeOutputs(report)
+console.log(JSON.stringify(report, null, 2))
+
+if (temporaryOutputDir) {
+  rmSync(outputDir, { force: true, recursive: true })
+}

--- a/scripts/verify-peer-releases.mjs
+++ b/scripts/verify-peer-releases.mjs
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(
+  readFileSync(path.join(rootDir, 'package.json'), 'utf8')
+)
+
+function minimumVersion (range, packageName) {
+  const match = /^>=([^ ]+)/.exec(range)
+  if (!match) {
+    throw new Error(
+      `Cannot derive the minimum version from ${packageName} range: ${range}`
+    )
+  }
+  return match[1]
+}
+
+const verifiedPeers = []
+for (const [packageName, range] of Object.entries(packageJson.peerDependencies)) {
+  const version = minimumVersion(range, packageName)
+  const url =
+    `https://registry.npmjs.org/${encodeURIComponent(packageName)}/` +
+    encodeURIComponent(version)
+  const response = await fetch(url, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(30_000)
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `${packageName}@${version} is unavailable ` +
+      `(${response.status} ${response.statusText})`
+    )
+  }
+
+  const metadata = await response.json()
+  if (metadata.name !== packageName || metadata.version !== version) {
+    throw new Error(`Registry returned the wrong identity for ${packageName}`)
+  }
+
+  verifiedPeers.push({ name: packageName, range, minimum: version })
+}
+
+console.log(JSON.stringify(verifiedPeers, null, 2))

--- a/scripts/verify-registry-artifact.mjs
+++ b/scripts/verify-registry-artifact.mjs
@@ -1,0 +1,169 @@
+import { appendFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { setTimeout as delay } from 'node:timers/promises'
+
+function argumentValue (name) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return undefined
+  if (!process.argv[index + 1]) throw new Error(`${name} requires a value`)
+  return process.argv[index + 1]
+}
+
+function hasArgument (name) {
+  return process.argv.includes(name)
+}
+
+function writeOutputs (outputs) {
+  if (!process.env.GITHUB_OUTPUT) return
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n') + '\n'
+  )
+}
+
+async function registryFetch (url) {
+  const response = await fetch(url, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(30_000)
+  })
+
+  if (response.status === 404) return null
+  if (!response.ok) {
+    throw new Error(
+      `Registry request failed (${response.status} ${response.statusText}): ` +
+      `${await response.text()}`
+    )
+  }
+  return response
+}
+
+function verifyIntegrity (contents, integrity) {
+  const match = /^([a-z0-9]+)-(.+)$/.exec(integrity)
+  if (!match) throw new Error(`Unsupported integrity value: ${integrity}`)
+
+  const actual = createHash(match[1]).update(contents).digest('base64')
+  if (actual !== match[2]) {
+    throw new Error('Downloaded registry tarball does not match its integrity')
+  }
+}
+
+const packageName = argumentValue('--name')
+const packageVersion = argumentValue('--version')
+const expectedIntegrity = argumentValue('--integrity')
+const expectedGitHead = argumentValue('--git-head')
+const allowMissing = hasArgument('--allow-missing')
+const requireLatest = hasArgument('--require-latest')
+const requireProvenance = hasArgument('--require-provenance')
+const waitSeconds = Number(argumentValue('--wait-seconds') || 0)
+
+if (!packageName || !packageVersion || !expectedIntegrity) {
+  throw new Error('--name, --version, and --integrity are required')
+}
+if (!Number.isFinite(waitSeconds) || waitSeconds < 0) {
+  throw new Error('--wait-seconds must be a non-negative number')
+}
+
+const encodedName = encodeURIComponent(packageName)
+const encodedVersion = encodeURIComponent(packageVersion)
+const versionUrl =
+  `https://registry.npmjs.org/${encodedName}/${encodedVersion}`
+const distTagsUrl =
+  `https://registry.npmjs.org/-/package/${encodedName}/dist-tags`
+const deadline = Date.now() + waitSeconds * 1000
+
+let verification
+while (!verification) {
+  const versionResponse = await registryFetch(versionUrl)
+  if (!versionResponse) {
+    if (Date.now() < deadline) {
+      await delay(10_000)
+      continue
+    }
+    if (allowMissing) {
+      writeOutputs({ published: false })
+      console.log(`${packageName}@${packageVersion} is not published`)
+      process.exit(0)
+    }
+    throw new Error(`${packageName}@${packageVersion} is not published`)
+  }
+
+  const metadata = await versionResponse.json()
+  if (metadata.name !== packageName || metadata.version !== packageVersion) {
+    throw new Error('Registry metadata returned the wrong package identity')
+  }
+  if (metadata.dist?.integrity !== expectedIntegrity) {
+    throw new Error(
+      `Registry integrity ${metadata.dist?.integrity || '<missing>'} does not ` +
+      `match local integrity ${expectedIntegrity}`
+    )
+  }
+  if (expectedGitHead && metadata.gitHead !== expectedGitHead) {
+    throw new Error(
+      `Registry gitHead ${metadata.gitHead || '<missing>'} does not match ` +
+      expectedGitHead
+    )
+  }
+
+  if (requireProvenance) {
+    const provenance = metadata.dist?.attestations?.provenance
+    const attestationUrl = metadata.dist?.attestations?.url
+    if (
+      provenance?.predicateType !== 'https://slsa.dev/provenance/v1' ||
+      !attestationUrl
+    ) {
+      if (Date.now() < deadline) {
+        await delay(10_000)
+        continue
+      }
+      throw new Error('Registry metadata does not contain SLSA provenance')
+    }
+
+    const attestationResponse = await registryFetch(attestationUrl)
+    if (!attestationResponse) {
+      if (Date.now() < deadline) {
+        await delay(10_000)
+        continue
+      }
+      throw new Error('The npm provenance attestation is unavailable')
+    }
+  }
+
+  let latest
+  if (requireLatest) {
+    const distTagsResponse = await registryFetch(distTagsUrl)
+    if (!distTagsResponse) {
+      throw new Error('The npm dist-tags endpoint is unavailable')
+    }
+    const distTags = await distTagsResponse.json()
+    latest = distTags.latest
+    if (latest !== packageVersion) {
+      if (Date.now() < deadline) {
+        await delay(10_000)
+        continue
+      }
+      throw new Error(
+        `npm latest points to ${latest || '<missing>'}, not ${packageVersion}`
+      )
+    }
+  }
+
+  const tarballResponse = await registryFetch(metadata.dist.tarball)
+  if (!tarballResponse) {
+    throw new Error('The registry tarball is unavailable')
+  }
+  const tarball = Buffer.from(await tarballResponse.arrayBuffer())
+  verifyIntegrity(tarball, expectedIntegrity)
+
+  verification = {
+    published: true,
+    integrity: metadata.dist.integrity,
+    tarball: metadata.dist.tarball,
+    registry_git_head: metadata.gitHead,
+    latest: latest || ''
+  }
+}
+
+writeOutputs(verification)
+console.log(JSON.stringify(verification, null, 2))


### PR DESCRIPTION
## Summary

Replace the direct-push, token-based release workflow with a reviewable and recoverable production release process.

This PR does not change the package version or runtime implementation.

## Release architecture

- Release only from an existing `v*.*.*` tag whose version matches `package.json`.
- Require the staging tag to point to the current `main` head.
- Run lint, type checking, coverage, audit, peer-release validation, package-content validation, and a real Node native-addon healthcheck before any registry write.
- Stage the exact verified tarball through npm trusted publishing (OIDC), using npm staged publishing and the `latest` tag.
- Require a maintainer to review and approve the staged npm package with 2FA.
- Finalize through a separate manual job that verifies npm integrity, `gitHead`, provenance, signatures, and `latest` before creating a GitHub release.
- Attach the exact npm tarball to the GitHub release and compare the downloaded asset byte-for-byte.
- Refuse GitHub release creation unless repository-level immutable releases are enabled.

The npm staging command is the last step in the tag-triggered job. This avoids the previous partial-success state where npm could publish successfully and a later GitHub Release step could fail.

## Supply-chain hardening

- Remove direct commits and pushes to protected `main` from Actions.
- Remove `NPM_TOKEN` from the workflow and scope job permissions explicitly.
- Pin GitHub Actions to reviewed commit SHAs.
- Pin CI and release Node/npm toolchains.
- Disable dependency lifecycle scripts during repository installs.
- Grant a strict, version-pinned install-script approval only to the exact Node native peer during the clean-consumer smoke test.
- Serialize releases with a non-cancelling concurrency group.
- Add idempotent checks for an already-published version and an existing GitHub release.

## Package boundary

Add a WDK-aligned `.npmignore` and an allowlist verifier. The package now contains only runtime code, types, documentation, license, and assets:

- 23 files
- 100,925 bytes packed with the release toolchain
- 288,930 bytes unpacked

Tests, coverage output, workflows, Jest setup, TypeScript test configuration, release scripts, and the operator runbook are excluded.

## Validation

- `actionlint` 1.7.12: passed
- YAML parse: passed
- Node 22.23.1 / npm 12.0.1 CI toolchain: passed
- Node 24.18.0 / npm 12.0.1 release toolchain: passed
- npm staged-publish dry run from the generated tarball: passed
- `npm run lint`: passed
- `npm run check:types`: passed
- 14 suites / 516 tests: passed
- Coverage: 99.24% statements, 95.76% branches, 98.83% functions, 99.63% lines
- `npm audit --audit-level=high`: zero vulnerabilities
- Native peer floors verified in the npm registry
- Clean tarball install with `@utexo/rgb-lightning-node-nodejs@0.1.0-beta.10`: passed
- Real native addon load and healthcheck: passed
- Existing beta.14 registry integrity, `gitHead`, provenance, tarball digest, and `latest`: verified

## Required repository configuration before release

These are intentionally external gates and must be completed before creating the release tag:

- Create a GitHub `npm` environment with required reviewers and prevent self-review.
- Configure the npm trusted publisher for `UTEXO-Protocol/wdk-rgb-lightning`, workflow `release.yml`, environment `npm`, with staged-publish permission only.
- Enable immutable GitHub releases and protect `v*` tags. The current CLI identity does not have repository administration permission to apply these settings.

The exact operator sequence and rollback procedure are documented in `RELEASING.md`.