### PR TITLE
Align Bare runtime with current WDK architecture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tetherto/wdk-wallet": "1.0.0-beta.14",
-        "bare-node-runtime": "1.2.0",
+        "bare-node-runtime": "^1.5.0",
         "bip39": "3.1.0",
         "sodium-universal": "5.0.1"
       },
@@ -1123,191 +1123,6 @@
         "bip39": "3.1.0"
       }
     },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-3.0.1.tgz",
-      "integrity": "sha512-OWC8Z62E8JmomltTkXt9cCPMPj2DNi2vp66FOj3BkglNKNshZuk8n98Ba3afUxrrM4kv9/eMzh9+U9dXZSQyOg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-form-data": "^1.2.0",
-        "bare-http1": "^4.5.2",
-        "bare-https": "^3.0.0",
-        "bare-mime": "^1.0.0",
-        "bare-stream": "^2.9.1",
-        "bare-url": "^2.4.0",
-        "bare-zlib": "^1.3.0"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-https": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
-      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-http1": "^4.4.0",
-        "bare-tcp": "^2.2.0",
-        "bare-tls": "^3.0.0"
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-inspector": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.1.0.tgz",
-      "integrity": "sha512-PRxmZ4gF+K3TLzGubgRFvzdECybTCSKackgNsAdd4e7SdvICxMkGj+p5iX7bSKYSmgDnxgCR+2Z6UXmWykKhvw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.1.0",
-        "bare-http1": "^4.0.0",
-        "bare-stream": "^2.0.0",
-        "bare-url": "^2.0.0",
-        "bare-ws": "^3.0.0"
-      },
-      "engines": {
-        "bare": ">=1.29.0"
-      },
-      "peerDependencies": {
-        "bare-tcp": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-tcp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-node-runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.5.0.tgz",
-      "integrity": "sha512-eMRq9WDYd+E0IZ8EG/8iCozZJl511z6vp7kxZyxjDw77ggOZ7bThFpJ72Kztjs8sh0hoe+xhFyZmoqAdVE/Ziw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-abort-controller": "^1.0.0",
-        "bare-assert": "^1.1.0",
-        "bare-async-hooks": "^0.0.0",
-        "bare-buffer": "^3.3.1",
-        "bare-console": "^6.0.1",
-        "bare-crypto": "^1.11.2",
-        "bare-dgram": "^1.0.1",
-        "bare-diagnostics-channel": "^1.1.0",
-        "bare-dns": "^2.1.4",
-        "bare-events": "^2.7.0",
-        "bare-fetch": "^3.0.0",
-        "bare-fs": "^4.2.3",
-        "bare-http1": "^4.0.4",
-        "bare-https": "^3.0.0",
-        "bare-inspector": "^6.0.1",
-        "bare-module": "^6.1.2",
-        "bare-net": "^2.0.2",
-        "bare-os": "^3.6.2",
-        "bare-path": "^3.0.0",
-        "bare-performance": "^2.0.0",
-        "bare-process": "^4.2.1",
-        "bare-punycode": "^0.0.0",
-        "bare-querystring": "^1.0.0",
-        "bare-readline": "^1.1.0",
-        "bare-repl": "^6.0.1",
-        "bare-sqlite": "^0.1.4",
-        "bare-stream": "^2.7.0",
-        "bare-string-decoder": "^1.0.0",
-        "bare-subprocess": "^6.0.0",
-        "bare-timers": "^3.0.3",
-        "bare-tls": "^3.0.0",
-        "bare-tty": "^5.0.3",
-        "bare-url": "^2.2.2",
-        "bare-utils": "^1.5.1",
-        "bare-v8": "^1.0.1",
-        "bare-vm": "^1.0.0",
-        "bare-worker": "^4.0.0",
-        "bare-ws": "^3.0.0",
-        "bare-zlib": "^1.3.1"
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-performance": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bare-performance/-/bare-performance-2.1.1.tgz",
-      "integrity": "sha512-nVlulswnYgXS2Fkbk4ZIKgfIWY/rmeG8ljM9aryPYClgPNzpOgOSLQzVSgU/K+ReLJHq7fEUQ9SBdjEs1QTIfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.9.1"
-      },
-      "engines": {
-        "bare": ">=1.27.0"
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-subprocess": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
-      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-env": "^3.0.0",
-        "bare-events": "^2.5.4",
-        "bare-os": "^3.0.1",
-        "bare-pipe": "^4.2.0",
-        "bare-structured-clone": "^1.5.2",
-        "bare-tcp": "^2.4.1",
-        "bare-url": "^2.2.2"
-      },
-      "engines": {
-        "bare": ">=1.7.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-tls": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.7.tgz",
-      "integrity": "sha512-AMw8tJlb3LhzAmhgXRcjDrTlNxR3gXXyj6G8eU9iwvCFtiUBD8MxAW7bwunA1gXDukgo40A970jX0APc2jMU7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-net": "^2.0.1",
-        "bare-stream": "^2.6.4"
-      },
-      "engines": {
-        "bare": ">=1.7.0"
-      }
-    },
-    "node_modules/@tetherto/wdk-wallet/node_modules/bare-ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-3.0.0.tgz",
-      "integrity": "sha512-q2v0UIQ0cFQBXQMp+0FRaoSk1EoYgOhzO7yio0TqBV6Rkfot97mbBYxb1ssw5faVCisVaFxQYY8113SMLYQBow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-crypto": "^1.2.0",
-        "bare-events": "^2.3.1",
-        "bare-http1": "^4.0.0",
-        "bare-https": "^3.0.0",
-        "bare-stream": "^2.1.2"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*",
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2087,15 +1902,16 @@
       }
     },
     "node_modules/bare-fetch": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.9.1.tgz",
-      "integrity": "sha512-OqyubfnEXu9BqIVXg+LcdsutZk+amvPey2N+FeG7zeIk+0qarDreAMtixcRGvpR95rM1SNJedHRpBv3BNjja5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-3.2.0.tgz",
+      "integrity": "sha512-ijeXh8iSZb8QcGr8gMXbnoxQe/sWWsde4ofTolyiDH8GtLmqjj141QZDoYYMq0fmwp60oFgngmumQO2/tAytwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-form-data": "^1.2.0",
         "bare-http1": "^4.5.2",
         "bare-https": "^3.0.0",
         "bare-mime": "^1.0.0",
+        "bare-performance": "^2.1.1",
         "bare-stream": "^2.9.1",
         "bare-url": "^2.4.0",
         "bare-zlib": "^1.3.0"
@@ -2111,30 +1927,6 @@
         "bare-buffer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/bare-fetch/node_modules/bare-https": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
-      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-http1": "^4.4.0",
-        "bare-tcp": "^2.2.0",
-        "bare-tls": "^3.0.0"
-      }
-    },
-    "node_modules/bare-fetch/node_modules/bare-tls": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.7.tgz",
-      "integrity": "sha512-AMw8tJlb3LhzAmhgXRcjDrTlNxR3gXXyj6G8eU9iwvCFtiUBD8MxAW7bwunA1gXDukgo40A970jX0APc2jMU7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-net": "^2.0.1",
-        "bare-stream": "^2.6.4"
-      },
-      "engines": {
-        "bare": ">=1.7.0"
       }
     },
     "node_modules/bare-form-data": {
@@ -2217,14 +2009,14 @@
       }
     },
     "node_modules/bare-https": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-2.1.3.tgz",
-      "integrity": "sha512-0TI/mJXQGYXmG7UUyWEG+KCJusayIAQLywUjFAskDoKuxfqVnGF+M/mTMrEV8J64DaIdU+5x761FvgmT7M68tA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
+      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-http1": "^4.4.0",
         "bare-tcp": "^2.2.0",
-        "bare-tls": "^2.0.0"
+        "bare-tls": "^3.0.0"
       }
     },
     "node_modules/bare-inspect": {
@@ -2241,19 +2033,19 @@
       }
     },
     "node_modules/bare-inspector": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-5.0.0.tgz",
-      "integrity": "sha512-blObRFPBK6yn0/wZbrRgkGcOuLUQUYVvkKbsEp5p3bWJB+uNrAh+qUqOijQHS6mZjGvyGCE86VERp3EiUR2TyA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.1.0.tgz",
+      "integrity": "sha512-PRxmZ4gF+K3TLzGubgRFvzdECybTCSKackgNsAdd4e7SdvICxMkGj+p5iX7bSKYSmgDnxgCR+2Z6UXmWykKhvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.1.0",
         "bare-http1": "^4.0.0",
         "bare-stream": "^2.0.0",
         "bare-url": "^2.0.0",
-        "bare-ws": "^2.0.0"
+        "bare-ws": "^3.0.0"
       },
       "engines": {
-        "bare": ">=1.2.0"
+        "bare": ">=1.29.0"
       },
       "peerDependencies": {
         "bare-tcp": "*"
@@ -2374,9 +2166,9 @@
       }
     },
     "node_modules/bare-node-runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.2.0.tgz",
-      "integrity": "sha512-oCpkcKBLDuzhtga0Q/63Ds3Gj03I0jIf+VX4mDhSClpoBfz/wnDtl2d1NKQDAVNCoP4I617GrJkS3vwNO4dd7w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.5.0.tgz",
+      "integrity": "sha512-eMRq9WDYd+E0IZ8EG/8iCozZJl511z6vp7kxZyxjDw77ggOZ7bThFpJ72Kztjs8sh0hoe+xhFyZmoqAdVE/Ziw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort-controller": "^1.0.0",
@@ -2389,33 +2181,34 @@
         "bare-diagnostics-channel": "^1.1.0",
         "bare-dns": "^2.1.4",
         "bare-events": "^2.7.0",
-        "bare-fetch": "^2.5.0",
+        "bare-fetch": "^3.0.0",
         "bare-fs": "^4.2.3",
         "bare-http1": "^4.0.4",
-        "bare-https": "^2.0.0",
-        "bare-inspector": "^5.0.0",
+        "bare-https": "^3.0.0",
+        "bare-inspector": "^6.0.1",
         "bare-module": "^6.1.2",
         "bare-net": "^2.0.2",
         "bare-os": "^3.6.2",
         "bare-path": "^3.0.0",
-        "bare-performance": "^1.1.0",
+        "bare-performance": "^2.0.0",
         "bare-process": "^4.2.1",
         "bare-punycode": "^0.0.0",
         "bare-querystring": "^1.0.0",
         "bare-readline": "^1.1.0",
         "bare-repl": "^6.0.1",
+        "bare-sqlite": "^0.1.4",
         "bare-stream": "^2.7.0",
         "bare-string-decoder": "^1.0.0",
-        "bare-subprocess": "^5.1.1",
+        "bare-subprocess": "^6.0.0",
         "bare-timers": "^3.0.3",
-        "bare-tls": "^2.1.3",
+        "bare-tls": "^3.0.0",
         "bare-tty": "^5.0.3",
         "bare-url": "^2.2.2",
         "bare-utils": "^1.5.1",
         "bare-v8": "^1.0.1",
         "bare-vm": "^1.0.0",
         "bare-worker": "^4.0.0",
-        "bare-ws": "^2.1.0",
+        "bare-ws": "^3.0.0",
         "bare-zlib": "^1.3.1"
       }
     },
@@ -2435,10 +2228,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-performance": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bare-performance/-/bare-performance-1.3.0.tgz",
-      "integrity": "sha512-ITlHSQwsnJSPjpagTtPo043LRkFgcrl9SgPsVUBXZvTeGWuNLUfMRwmwAS+35i8qnIEinySoLxwhVoJNZAIF2g==",
-      "license": "Apache-2.0"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-performance/-/bare-performance-2.1.1.tgz",
+      "integrity": "sha512-nVlulswnYgXS2Fkbk4ZIKgfIWY/rmeG8ljM9aryPYClgPNzpOgOSLQzVSgU/K+ReLJHq7fEUQ9SBdjEs1QTIfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.9.1"
+      },
+      "engines": {
+        "bare": ">=1.27.0"
+      }
     },
     "node_modules/bare-pipe": {
       "version": "4.2.2",
@@ -2637,15 +2436,17 @@
       }
     },
     "node_modules/bare-subprocess": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.3.tgz",
-      "integrity": "sha512-07wwswlV7M3sC9IykbZRZ/jHAkrXFWVLqdBWGv1y0ojCimtRD9hGwxdHmR5FUFmDUZLNsBmTYJNQqgio5+A85Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-env": "^3.0.0",
         "bare-events": "^2.5.4",
         "bare-os": "^3.0.1",
-        "bare-pipe": "^4.0.0",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
         "bare-url": "^2.2.2"
       },
       "engines": {
@@ -2721,9 +2522,9 @@
       }
     },
     "node_modules/bare-tls": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.3.tgz",
-      "integrity": "sha512-dPYBGEXtgLceRFMfGaF2/rqR86/xMxMyrM9ootO/gaRKL/z2uNHJs7aP7IOBtnJF8eUCt5qwMzbKfrKgDIxPLg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.7.tgz",
+      "integrity": "sha512-AMw8tJlb3LhzAmhgXRcjDrTlNxR3gXXyj6G8eU9iwvCFtiUBD8MxAW7bwunA1gXDukgo40A970jX0APc2jMU7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-net": "^2.0.1",
@@ -2826,15 +2627,15 @@
       }
     },
     "node_modules/bare-ws": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-2.1.0.tgz",
-      "integrity": "sha512-2gEWlPK9iyBchACdIY6oQXgmDz3KLrChdwrPgmU3IVXOFTnxTqSUT27WE/+izd4QojHj/SsqDkQiD2HDvuTdAA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-3.0.0.tgz",
+      "integrity": "sha512-q2v0UIQ0cFQBXQMp+0FRaoSk1EoYgOhzO7yio0TqBV6Rkfot97mbBYxb1ssw5faVCisVaFxQYY8113SMLYQBow==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-crypto": "^1.2.0",
         "bare-events": "^2.3.1",
         "bare-http1": "^4.0.0",
-        "bare-https": "^2.0.0",
+        "bare-https": "^3.0.0",
         "bare-stream": "^2.1.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@tetherto/wdk-wallet": "1.0.0-beta.14",
-    "bare-node-runtime": "1.2.0",
+    "bare-node-runtime": "^1.5.0",
     "bip39": "3.1.0",
     "sodium-universal": "5.0.1"
   },

--- a/scripts/smoke-node-package.mjs
+++ b/scripts/smoke-node-package.mjs
@@ -26,6 +26,22 @@ function run (command, args, options = {}) {
   }
 }
 
+function runAndCapture (command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options
+  })
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} exited with ${result.status}:\n` +
+      (result.stderr || result.stdout)
+    )
+  }
+  return result.stdout.trim()
+}
+
 function minimumVersion (range, packageName) {
   const match = /^>=([^ ]+)/.exec(range)
   if (!match) {
@@ -78,10 +94,6 @@ try {
       }
     }, null, 2) + '\n'
   )
-  writeFileSync(
-    path.join(temporaryRoot, '.npmrc'),
-    'strict-allow-scripts=true\n'
-  )
 
   run(npmExecutable, [
     'install',
@@ -91,6 +103,44 @@ try {
     packageSpec,
     `${nativePackage}@${nativeVersion}`
   ], { cwd: temporaryRoot })
+
+  const runtimeInstallations = runAndCapture(
+    npmExecutable,
+    ['ls', 'bare-node-runtime', '--parseable', '--all'],
+    { cwd: temporaryRoot }
+  ).split('\n').filter(Boolean)
+  if (runtimeInstallations.length !== 1) {
+    throw new Error(
+      'Expected one bare-node-runtime installation, found ' +
+      runtimeInstallations.length
+    )
+  }
+
+  const npmMajor = Number(
+    runAndCapture(npmExecutable, ['--version'], { cwd: temporaryRoot })
+      .split('.')[0]
+  )
+  if (!Number.isInteger(npmMajor)) {
+    throw new Error('npm returned an invalid version')
+  }
+  if (npmMajor >= 12) {
+    const policy = JSON.parse(
+      runAndCapture(
+        npmExecutable,
+        ['install-scripts', 'ls', '--json'],
+        { cwd: temporaryRoot }
+      )
+    )
+    if (!Array.isArray(policy.allowScripts)) {
+      throw new Error('npm returned an invalid install-script policy')
+    }
+    if (policy.allowScripts.length > 0) {
+      throw new Error(
+        'Unreviewed dependency install scripts remain:\n' +
+        JSON.stringify(policy.allowScripts, null, 2)
+      )
+    }
+  }
 
   if (verifySignatures) {
     run(npmExecutable, ['audit', 'signatures'], { cwd: temporaryRoot })


### PR DESCRIPTION
## Summary

- align the direct `bare-node-runtime` dependency with `@tetherto/wdk-wallet` and current WDK modules at `^1.5.0`
- regenerate the lockfile so the package and WDK Core share one physical Bare runtime and one transitive runtime tree
- harden the npm 12 package smoke by removing the unsupported `strict-allow-scripts` setting, asserting one Bare runtime installation, and failing when npm reports unreviewed install scripts

This PR does not change the package version or public API.

## Validation

- `npm run lint`
- `npm run check:types`
- `npm run test:coverage`: 14 suites and 516 tests passed; 99.24% statements, 95.76% branches, 98.83% functions, 99.63% lines
- `npm run check:package` under Node 24.18.0 and npm 12.0.1
- `npm run smoke:package:node` under Node 24.18.0 and npm 12.0.1, including the real Node native binding healthcheck
- real Bare 1.30.3 consumer smoke with `@utexo/rgb-lightning-node-bare@0.1.0-beta.14`, including native healthcheck and HTTPS/TLS fetch
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm ls bare-node-runtime --all`: one physical `bare-node-runtime@1.5.0` installation