### PR TITLE
chore(release): prepare v0.1.0-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ while pre-`1.0`.
 
 ## [Unreleased]
 
+## [0.1.0-beta.15] — 2026-07-23
+
 ### Added
 - **First-class read-only account:** exported
   `WalletAccountReadOnlyRgbLightning extends WalletAccountReadOnly`, with
@@ -27,69 +29,6 @@ while pre-`1.0`.
   bytes of WDK's normalized BIP-39 seed. `nodeSeedDerivation: 'auto'` retries
   the exact legacy beta derivation only after RLN reports a persisted signer
   identity mismatch, preserving existing node identities.
-- **`UtexoLsp` composed-flow class** (`src/utexo-lsp.js`) — brings the
-  LSP surface to parity with `@utexo/rgb-sdk-rn`'s `UtexoLsp`. A
-  stateful orchestration object over an account + `LspClient` covering
-  the full lifecycle: `connect`, `waitForChannel`, `receiveAsset`,
-  `awaitReceiveSettlement`, `waitForOutboundLiquidity`, `sendAsset`,
-  `payAddress`, `enableLightningAddress`, and `claimPendingPayments`.
-  All poll loops accept `WaitOptions` (`timeoutMs`, `pollIntervalMs`,
-  `signal`, `onProgress`, `onEachPoll`). Construct via
-  `account.createLsp(peer?)` — the no-arg form auto-discovers the peer
-  from the wallet's `lspBaseUrl`. Also exports `LspChannelTimeoutError`,
-  `LspSettlementError`, `peerUri()`, and `normalizeReceiveStatus()`.
-- **`LspClient.resolveAddress(username, amtMsat, opts)`** — full LUD-06
-  resolution (discovery + callback) routed through the LSP's `baseUrl`,
-  with the callback URL rewritten onto the base origin so the second hop
-  inherits the client's retry/timeout rails and survives an LSP that
-  advertises an internal/emulator host (e.g. `10.0.2.2`). Mirrors
-  `rgb-sdk-rn`'s `UtexoLSPClient.resolveAddress`.
-- **`LspClient.getLightningAddressByPubkey(pubkey, opts)`** — reads back
-  the auto-assigned `{ username, domain }` the LSP minted for a node
-  pubkey (post-`apayNew`). The one raw-client endpoint we were missing.
-- **`account.createLsp(peer?, peerPort?)`** + **`account.getLspConfig()`**
-  — factory for `UtexoLsp` and a read of the `lspBaseUrl`/
-  `lspBearerToken` the node was constructed with.
-- **`account.createHodlInvoice(params)`** — named convenience over
-  `createInvoice({ payment_hash })`, returning `{ bolt11, paymentHash }`.
-  Parity with `rgb-sdk-rn`'s `createHodlInvoice`.
-- TS declarations extended for all of the above (`UtexoLsp`, `LspPeer`,
-  `WaitOptions`, `ReceiveStatus`, `ChannelReadyInfo`,
-  `CreateHodlInvoiceParams`, the LSP timeout/settlement error classes, etc.).
-- **`virtualPeerPubkeys` config** — plumbed through manager → binding →
-  init request (`virtual_peer_pubkeys`). Required (together with
-  `enableVirtualChannelsV0`) for async-payments against a production
-  LSP: every mobile client must list the LSP's node_id so RLN's
-  `allows_peer` accepts the `trusted_no_broadcast` virtual channel.
-  The native layer already accepted the field via the init JSON, so no
-  native rebuild; forwarded only when a non-empty array. Also documents
-  `virtual_open_mode:
-  'trusted_no_broadcast'` on `openChannel` and the 3_000_000-msat RGB
-  HTLC minimum (`MIN_AMT_MSAT`).
-- **TypeScript declarations.** Ship a hand-authored `index.d.ts`
-  covering the full public surface (manager, account, bindings,
-  errors, `LspClient`, LNURL + LSP helpers) and wire it via the
-  `types` field + the `types` condition in the `exports` map. The
-  package previously shipped no types; consumers now get IntelliSense
-  + type-checking. Verified with `tsc --strict` (internal + consumer
-  resolution under `nodenext`).
-- **Typed error hierarchy** (`src/errors.js`): `RgbLightningError`
-  (base, with `code` + `cause` + `toJSON()`) and `UnlockError`,
-  `AccountLockedError`, `VssError`, `VssNotConfiguredError`, `ApayError`,
-  `NotImplementedError`. `unlock`, locked address reads, `clearVssFence`,
-  `vssBackup`, `apayNew`, `bootstrapLsp`, and `signTransaction` now throw
-  these instead of bare `Error`, so callers branch on `err.name` /
-  `err.code` rather than substring-matching `Rln(...)` strings. The
-  original RLN message is preserved verbatim and attached as `cause`,
-  so existing substring checks keep working.
-- `account.vssStatus()` — local-view VSS status
-  (`{ configured, url, allowHttp, lastBackupVersion }`) with no server
-  round-trip. (RLN's C-FFI has no read-only server-side backup-info
-  query; call `vssBackup()` for a live version.)
-- `account.createLightningInvoice(request)` — cross-SDK alias for
-  `createInvoice` (matches `@utexo/rgb-sdk-rn`'s naming), accepting
-  either the native snake_case request or a camelCase convenience
-  shape.
 
 ### Fixed
 - WDK conformance for `index`, `path`, `keyPair`, `sign()`, `getBalance()`,
@@ -101,13 +40,6 @@ while pre-`1.0`.
 - WDK bindings now force RLN's pinned-address mode, so inherited read-only
   `getAddress()` calls do not allocate a fresh address each time; explicit
   rotation remains a full-account command.
-- Aligned exactly with the current `@tetherto/wdk-wallet@1.0.0-beta.14`
-  architecture and added strict declaration checks to build/release CI.
-- Automatic releases wait for both minimum native peer versions to be
-  available from npm before bumping or publishing the WDK package.
-- Removed a duplicate `apayNew` method definition in both
-  `node-binding.js` and `bare-binding.js` (the shadowed first copy
-  used `this.node`, which throws pre-unlock).
 - Consolidated LSP wire-shape and uint conversion helpers. Fractional,
   unsafe, negative, and overflowing uint values now fail predictably;
   `lightningReceive()` sends the documented default RGB assignment `Any`.
@@ -123,13 +55,117 @@ while pre-`1.0`.
   its deadline expires instead of resolving without the requested capacity.
 
 ### Changed
-- README: tightened the *"Why a separate module from `wdk-wallet-rgb`?"*
-  section. Added a *"Use `wdk-wallet-rgb` for asset issuance +
-  inflation"* subsection pointing at the on-chain module for the five
-  ops not exposed here (`issueAssetNia/Ifa/Cfa/Uda`, `inflate`). Both
-  modules target the same `rgb-lib` SQLite `dataDir`, so assets
-  issued via `wdk-wallet-rgb` are available here for channels and
-  invoices. No code changes.
+- Aligned the manager, writable account, read-only account, and declarations
+  with `@tetherto/wdk-wallet@1.0.0-beta.14`, including structural type checks
+  in build and release CI.
+- Updated native peer requirements to
+  `@utexo/rgb-lightning-node-bare >=0.1.0-beta.14 <0.2.0` and
+  `@utexo/rgb-lightning-node-nodejs >=0.1.0-beta.10 <0.2.0`.
+- Aligned `bare-node-runtime` with WDK Core at `^1.5.0`, producing one
+  deduplicated runtime tree for consumers.
+- Restricted the npm tarball to the public runtime, types, license, changelog,
+  and README, with clean-install and native-binding smoke validation.
+- Replaced the direct-push release job with a reviewed, tag-driven pipeline
+  that validates native peers, package integrity, npm provenance, registry
+  installation, and the immutable GitHub release artifact.
+- Documented the account's forwarded node-level issuance and inflation calls
+  while identifying `@utexo/wdk-wallet-rgb` as the supported path for
+  issuance-focused flows and clarifying that the two modules own separate
+  wallet state and `dataDir` values.
+
+## [0.1.0-beta.14] — 2026-06-19
+
+### Added
+- TypeScript vocabulary for native payment discriminants, RGB invoice and send
+  requests, binding lifecycle methods, LSP bridge responses, and terminal
+  settlement errors.
+
+### Fixed
+- Generic RGB `transfer()` now decodes the invoice and constructs RLN's nested
+  `recipient_groups` request with the required assignment and transport
+  endpoints instead of sending the rejected legacy flat shape.
+- Corrected public declarations and request documentation for RLN payment,
+  keysend, RGB invoice, and RGB send wire formats.
+
+## [0.1.0-beta.13] — 2026-06-19
+
+### Fixed
+- `getTransactionReceipt()` now queries RLN's `Outbound`,
+  `InboundAutoClaim`, and `InboundHodl` payment discriminants instead of the
+  obsolete `sent` and `received` values.
+
+### Changed
+- Expanded the unit suite across the wallet account, bindings, LSP client,
+  LNURL, transfer routing, and composed LSP flows.
+
+## [0.1.0-beta.12] — 2026-06-18
+
+### Removed
+- Removed unsupported RGB issuance and inflation methods from the public
+  declarations and documentation. Asset creation belongs to
+  `@utexo/wdk-wallet-rgb`.
+
+### Changed
+- Release automation now marks the newly published package as the latest
+  GitHub release.
+
+## [0.1.0-beta.11] — 2026-06-18
+
+### Changed
+- Updated WDK Core to `@tetherto/wdk-wallet@1.0.0-beta.10`.
+- Added the Jest unit suite and coverage execution to build and release CI.
+- Reworked the README around the supported runtime, security, configuration,
+  account, LSP, and troubleshooting contracts.
+
+## [0.1.0-beta.10] — 2026-06-16
+
+### Added
+- `UtexoLsp`, a composed account and `LspClient` orchestration surface for
+  connecting, channel readiness, RGB receive/send, Lightning Address payment,
+  outbound liquidity, APay registration, and pending-payment claims.
+- `LspClient.resolveAddress()` and
+  `LspClient.getLightningAddressByPubkey()`.
+- `account.createLsp()`, `account.getLspConfig()`, and
+  `account.createHodlInvoice()`.
+- `virtualPeerPubkeys` configuration for trusted virtual-channel peers.
+- Full TypeScript declarations for the public package surface.
+- The `RgbLightningError` hierarchy, local `account.vssStatus()`, and the
+  `account.createLightningInvoice()` cross-SDK alias.
+
+### Fixed
+- Removed duplicate `apayNew` implementations from both runtime bindings.
+
+### Changed
+- Updated native peers to `@utexo/rgb-lightning-node-bare@^0.1.0-beta.13`
+  and `@utexo/rgb-lightning-node-nodejs@^0.1.0-beta.9`.
+- Added build and provenance-enabled release workflows.
+
+## [0.1.0-beta.9] — 2026-06-15
+
+### Changed
+- Updated both native binding peer requirements to `^0.6.0-beta.1`.
+
+## [0.1.0-beta.8] — 2026-06-10
+
+### Added
+- Forwarded `lspBaseUrl` and `lspBearerToken` through the wallet manager and
+  both bindings for RLN's internal APay client.
+
+### Changed
+- Updated both native binding peer requirements to `^0.5.2-beta.1`.
+
+## [0.1.0-beta.7] — 2026-06-04
+
+### Changed
+- Rebased both native binding peer requirements to the
+  `^0.1.0-beta.3` package line.
+- Clarified the RGB Lightning and on-chain RGB module boundary and directed
+  asset issuance and inflation to `@utexo/wdk-wallet-rgb`.
+- Added the first automated release workflow for native release dispatches.
+
+`0.1.0-beta.1` and `0.1.0-beta.2` were repository-tagged releases. npm
+publishing for this package began at `0.1.0-beta.7`; versions
+`0.1.0-beta.3` through `0.1.0-beta.6` were not released.
 
 ## [0.1.0-beta.2] — 2026-06-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@utexo/wdk-rgb-lightning",
-      "version": "0.1.0-beta.14",
+      "version": "0.1.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@tetherto/wdk-wallet": "1.0.0-beta.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utexo/wdk-rgb-lightning",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "description": "WDK module for RGB Lightning (rgb-lightning-node) — channels, invoices, payments, hodl, RGB-over-LN.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
## Summary

- bump `@utexo/wdk-rgb-lightning` from `0.1.0-beta.14` to `0.1.0-beta.15` in `package.json` and both root lockfile fields
- reconstruct the missing `beta.7` through `beta.14` changelog history from the exact Git tags, commit diffs, GitHub releases, and published npm `gitHead` values
- finalize the `beta.15` notes for the WDK read-only architecture, review hardening, dependency alignment, package artifact, and release pipeline

This PR changes only `CHANGELOG.md`, `package.json`, and `package-lock.json`. It contains no runtime source or dependency-range changes.

## Release-candidate validation

- clean `npm ci --ignore-scripts` with Node 24.18.0 and npm 12.0.1
- `npm run lint`
- `npm run check:types`
- `npm run test:coverage -- --runInBand`: 14 suites and 516 tests passed; 99.24% statements, 95.76% branches, 98.83% functions, 99.63% lines
- `node scripts/verify-peer-releases.mjs`: both native peer minimums are published
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run check:package`: 23 files; integrity `sha512-Lj1FoXAmK8SdgE9oLmDZ6JgEJfT20F7Bluau6XUbWGEAglO0mkvjQ5B4pPV/MQzZC0ygtr7IZokip1S8s1assQ==`
- `npm run smoke:package:node`: real Node native binding healthcheck passed
- exact tarball installed into Bare 1.30.3 with `@utexo/rgb-lightning-node-bare@0.1.0-beta.14`: native healthcheck and HTTPS/TLS smoke passed
- `v0.1.0-beta.15` is absent from both Git tags and npm

## Required before creating the release tag

- configure the GitHub `npm` environment with required reviewers and prevent self-review
- configure npm trusted publishing for `UTEXO-Protocol/wdk-rgb-lightning`, `release.yml`, environment `npm`, staged publish only
- enable immutable GitHub releases
- protect `v*` release tags

The release tag must not be created until these repository and npm controls are confirmed.