### PR TITLE
Harden RGB Lightning mobile lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,13 @@ cross-host callbacks require the explicit `allowCrossHostCallback: true` opt-in.
 
 Set `vssUrl` at construction to mirror LDK channel state and RGB wallet data
 to a remote VSS key-value store in near-real-time. Payloads are client-side
-encrypted (XChaCha20-Poly1305, keyed via HKDF of a signing key derived from
-the BIP-39 mnemonic at BIP-32 path `m/535'/1'`); the server sees only
-ciphertext, and recovery requires the original seed. Plain `http://` is
-rejected for non-loopback hosts unless `vssAllowHttp: true`.
+encrypted by RLN before upload; the VSS server sees only ciphertext. In
+internal-mnemonic mode RLN derives the VSS identity from the BIP-39 wallet
+secret; in this package's external-signer mode RLN reconstructs the same VSS
+identity from the persisted key-source identity written by the signer
+bootstrap. Recovery still requires recreating the same signer/node identity
+from the original seed. Plain `http://` is rejected for non-loopback hosts
+unless `vssAllowHttp: true`.
 
 - `account.vssStatus()` — local view: whether VSS is configured, the URL +
   allow-http flag, and the snapshot version from the most recent

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ and a regtest stack via Docker Compose — lives in
 | `permissiveSignerPolicy` | `true` | Loosen the VLS policy filter for in-process single-user use. |
 | `nodeSeedDerivation` | `auto` | New nodes use WDK's normalized BIP-39 seed directly; existing beta nodes retry the legacy identity only on an exact persisted-identity mismatch. Use `wdk-seed-v2` or `legacy-v1` to disable auto-detection. |
 | `autoUnlockRequest` | — | Optional typed node request for integrations that load `getAddress()` before exposing account extensions, including WDK React Native Core. Concurrent activation is coalesced and only the real native address is returned. Omit it for explicit/manual unlock. |
+| `autoRecoverStaleVssFence` | `false` | Optional single-retry recovery for RLN's stale VSS `__rln_instance__` fence during unlock. Enable only in hosts that can guarantee no other live node is using the same VSS store. |
 | `vssUrl` / `vssAllowHttp` / `vssAllowEmptyRestore` | — | VSS cloud backup; see [below](#vss-cloud-backup). |
 | `lspBaseUrl` / `lspBearerToken` | — | LSP wiring for APay and the LSP client; see [below](#lsp-integration). |
 
@@ -363,6 +364,10 @@ rejected for non-loopback hosts unless `vssAllowHttp: true`.
   ownership fence after a previous node died holding it (restarts otherwise
   fail with `Rln(VssFenceHeld)`). Only call this when certain the previous
   owner is gone — pointing two live nodes at one VSS store corrupts state.
+- `autoRecoverStaleVssFence: true` — host-level opt-in that applies the same
+  clear-fence operation once during unlock, and only for the exact stale-owner
+  fence error. Keep it disabled for production until ownership/liveness policy
+  is implemented around the VSS service.
 
 VSS operations on a wallet constructed without `vssUrl` throw
 `VssNotConfiguredError`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -394,6 +394,14 @@ export interface RgbLightningWalletConfig extends RgbLightningBindingConfig {
    * extension methods. The account returns only the real native address.
    */
   autoUnlockRequest?: RgbLightningNodeUnlockRequest
+  /**
+   * Opt-in recovery for a stale VSS single-writer fence during automatic or
+   * explicit unlock. When enabled, the account clears the fence once and retries
+   * unlock only for RLN's stale-owner `__rln_instance__` failure. Keep disabled
+   * unless the host can guarantee another live node is not using the same VSS
+   * store.
+   */
+  autoRecoverStaleVssFence?: boolean
   bitcoindRpcUsername?: string
   bitcoindRpcPassword?: string
   bitcoindRpcHost?: string

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -35,10 +35,13 @@
  * @property {string}  [vssUrl]
  *   Enables VSS cloud backup. Setting it points the node at a remote
  *   key-value store that mirrors LDK channel state + RGB wallet data
- *   in near-real-time. The encryption key is derived from the BIP-39
- *   mnemonic, so recovery requires the original seed. Leave undefined
- *   to disable VSS (default). Only `https://` URLs (or loopback http)
- *   are accepted unless `vssAllowHttp` is set.
+ *   in near-real-time. Payloads are encrypted inside RLN before upload.
+ *   Internal-mnemonic mode derives the VSS identity from the wallet secret;
+ *   this package's external-signer mode reconstructs it from the persisted
+ *   signer key-source identity. Recovery requires recreating the same
+ *   signer/node identity from the original seed. Leave undefined to disable
+ *   VSS (default). Only `https://` URLs (or loopback http) are accepted unless
+ *   `vssAllowHttp` is set.
  * @property {boolean} [vssAllowHttp=false]
  *   Permit plain `http://` for non-loopback hosts. Off by default so
  *   channel state can't be sent in plaintext to an untrusted server

--- a/src/binding-interface.js
+++ b/src/binding-interface.js
@@ -58,6 +58,10 @@
  *   Must match the LSP's `APAY_BEARER_TOKEN` config. Omit if the LSP
  *   doesn't require auth (some dev setups).
  *
+ * Wallet-manager-only policy fields such as `autoUnlockRequest` and
+ * `autoRecoverStaleVssFence` are intentionally not part of this native binding
+ * config. The manager consumes them before constructing the binding.
+ *
  * Concrete WDK bindings always send RLN `reuse_addresses: true`. This keeps
  * inherited read-only `getAddress()` calls pinned to the current address;
  * callers use the full account's explicit `rotateAddress()` command when

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -69,6 +69,31 @@ function sameUnlockRequest (left, right) {
   })
 }
 
+const STALE_VSS_FENCE_PATTERN = /VSS store_id is owned by another rgb-lightning-node instance|__rln_instance__/i
+
+function isStaleVssFenceError (error) {
+  let current = error
+  for (let depth = 0; current && depth < 4; depth += 1) {
+    const message = current && typeof current === 'object' && 'message' in current
+      ? String(current.message)
+      : String(current)
+    if (STALE_VSS_FENCE_PATTERN.test(message)) return true
+    current = current && typeof current === 'object' && 'cause' in current
+      ? current.cause
+      : undefined
+  }
+  return false
+}
+
+function vssFenceClearPassword (unlockRequest) {
+  return unlockRequest &&
+    typeof unlockRequest === 'object' &&
+    typeof unlockRequest.bitcoind_rpc_password === 'string' &&
+    unlockRequest.bitcoind_rpc_password.length > 0
+    ? unlockRequest.bitcoind_rpc_password
+    : undefined
+}
+
 /**
  * Seed-isolated via RLN's `NativeExternalSigner`: the WDK secret manager
  * owns the BIP-39 mnemonic; the manager derives a 32-byte VLS node
@@ -81,7 +106,7 @@ function sameUnlockRequest (left, right) {
  */
 export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbLightning {
   /**
-   * @param {{ binding: BareRgbLightningBinding, autoUnlockRequest?: object }} bindings
+   * @param {{ binding: BareRgbLightningBinding, autoUnlockRequest?: object, autoRecoverStaleVssFence?: boolean }} bindings
    */
   constructor (bindings) {
     if (!bindings || !bindings.binding) {
@@ -90,6 +115,7 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
     super(createReadOnlyRgbLightningAdapter(bindings.binding))
     /** @private */ this._binding = bindings.binding
     /** @private */ this._autoUnlockRequest = normalizeAutoUnlockRequest(bindings.autoUnlockRequest)
+    /** @private */ this._autoRecoverStaleVssFence = bindings.autoRecoverStaleVssFence === true
     /** @private @type {{ request: object, promise: Promise<{ ok: true }> } | null} */
     this._unlockInFlight = null
     /** @private @type {WalletAccountReadOnlyRgbLightning | null} */
@@ -128,6 +154,18 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
       try {
         this._binding.unlock(unlockRequest)
       } catch (e) {
+        if (this._autoRecoverStaleVssFence && isStaleVssFenceError(e)) {
+          const password = vssFenceClearPassword(unlockRequest)
+          if (password) {
+            try {
+              this._binding.clearVssFence(password)
+              this._binding.unlock(unlockRequest)
+              return { ok: true }
+            } catch (recoveryError) {
+              throw wrapError(recoveryError, UnlockError)
+            }
+          }
+        }
         // Wrap into a typed UnlockError so callers can branch on
         // `err.name === 'UnlockError'` / `err.code` instead of
         // substring-matching the RLN message. The original message is

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -26,6 +26,7 @@ const MEMPOOL_SPACE_URL = 'https://mempool.space'
  *   announceAddresses?: string[],
  *   announceAlias?: string,
  *   autoUnlockRequest?: object,
+ *   autoRecoverStaleVssFence?: boolean,
  *   nodeSeedDerivation?: 'auto'|'wdk-seed-v2'|'legacy-v1'
  * }} RgbLightningWalletConfig
  */
@@ -100,7 +101,7 @@ export default class WalletManagerRgbLightning extends WalletManager {
    * @param {RgbLightningWalletConfig} config
    */
   constructor (seed, config = {}) {
-    const { autoUnlockRequest, ...managerConfig } = config
+    const { autoUnlockRequest, autoRecoverStaleVssFence, ...managerConfig } = config
     super(seed, managerConfig)
 
     if (!config.network) throw new Error('network configuration is required.')
@@ -113,6 +114,7 @@ export default class WalletManagerRgbLightning extends WalletManager {
 
     /** @private */ this._network = config.network
     /** @private */ this._autoUnlockRequest = normalizeAutoUnlockRequest(autoUnlockRequest)
+    /** @private */ this._autoRecoverStaleVssFence = autoRecoverStaleVssFence === true
     /** @private @type {IRgbLightningBinding | null} */
     this._binding = null
   }
@@ -180,7 +182,8 @@ export default class WalletManagerRgbLightning extends WalletManager {
 
       this._accounts[index] = new WalletAccountRgbLightning({
         binding,
-        autoUnlockRequest: this._autoUnlockRequest
+        autoUnlockRequest: this._autoUnlockRequest,
+        autoRecoverStaleVssFence: this._autoRecoverStaleVssFence
       })
     }
     return this._accounts[index]

--- a/src/wallet-manager-rgb-lightning.js
+++ b/src/wallet-manager-rgb-lightning.js
@@ -217,10 +217,33 @@ export default class WalletManagerRgbLightning extends WalletManager {
   }
 
   dispose () {
-    if (this._binding) {
-      this._binding.shutdown()
+    let accountDisposalError
+    let bindingShutdownError
+
+    // The base manager inspects account.keyPair while clearing its account
+    // cache. RGB Lightning derives that public identity from the external
+    // signer, so the signer must remain attached until base disposal finishes.
+    try {
+      super.dispose()
+    } catch (error) {
+      accountDisposalError = error
+    }
+
+    try {
+      this._binding?.shutdown()
+    } catch (error) {
+      bindingShutdownError = error
+    } finally {
       this._binding = null
     }
-    super.dispose()
+
+    if (accountDisposalError && bindingShutdownError) {
+      throw new AggregateError(
+        [accountDisposalError, bindingShutdownError],
+        'Failed to dispose RGB Lightning accounts and binding'
+      )
+    }
+    if (accountDisposalError) throw accountDisposalError
+    if (bindingShutdownError) throw bindingShutdownError
   }
 }

--- a/tests/wallet-account-surface.test.js
+++ b/tests/wallet-account-surface.test.js
@@ -105,6 +105,7 @@ function makeBinding (overrides = {}) {
     bootstrap: jest.fn(() => ({ node_id: 'aa'.repeat(33) })),
     shutdown: jest.fn(() => undefined),
     apayNew: jest.fn(() => ({ order_id: 'o1' })),
+    clearVssFence: jest.fn(() => undefined),
     vssStatus: jest.fn(() => ({ configured: false, url: null, allowHttp: false, lastBackupVersion: null })),
     ...bindingOverrides
   }
@@ -168,6 +169,77 @@ describe('lifecycle', () => {
     expect(err).toBeInstanceOf(UnlockError)
     expect(err.message).toBe('Rln(NotInitialized): bad creds')
     expect(err.code).toBe('UNLOCK_FAILED')
+  })
+
+  it('does not clear a stale VSS fence unless the host opts in', async () => {
+    const clearVssFence = jest.fn()
+    const account = makeAccount({
+      unlock: () => {
+        throw new Error('VSS store_id is owned by another rgb-lightning-node instance')
+      },
+      clearVssFence
+    })
+
+    await expect(account.unlock(AUTO_UNLOCK_REQUEST)).rejects.toMatchObject({
+      name: 'UnlockError',
+      code: 'UNLOCK_FAILED'
+    })
+    expect(clearVssFence).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale VSS fence once and retries unlock when explicitly enabled', async () => {
+    const unlock = jest.fn()
+      .mockImplementationOnce(() => {
+        throw new Error(
+          'VSS store_id is owned by another rgb-lightning-node instance; delete the `__rln_instance__` key from VSS first'
+        )
+      })
+      .mockImplementationOnce(() => undefined)
+    const clearVssFence = jest.fn()
+    const account = makeAccount(
+      { unlock, clearVssFence },
+      { autoRecoverStaleVssFence: true }
+    )
+
+    await expect(account.unlock(AUTO_UNLOCK_REQUEST)).resolves.toEqual({ ok: true })
+    expect(clearVssFence).toHaveBeenCalledTimes(1)
+    expect(clearVssFence).toHaveBeenCalledWith(AUTO_UNLOCK_REQUEST.bitcoind_rpc_password)
+    expect(unlock).toHaveBeenCalledTimes(2)
+    expect(unlock).toHaveBeenNthCalledWith(2, AUTO_UNLOCK_REQUEST)
+  })
+
+  it('does not clear VSS for unrelated unlock failures even when recovery is enabled', async () => {
+    const clearVssFence = jest.fn()
+    const account = makeAccount(
+      {
+        unlock: () => { throw new Error('Rln(Conflict): Invalid indexer') },
+        clearVssFence
+      },
+      { autoRecoverStaleVssFence: true }
+    )
+
+    await expect(account.unlock(AUTO_UNLOCK_REQUEST)).rejects.toMatchObject({
+      name: 'UnlockError',
+      message: 'Rln(Conflict): Invalid indexer'
+    })
+    expect(clearVssFence).not.toHaveBeenCalled()
+  })
+
+  it('does not attempt stale-fence recovery without a clear-fence password', async () => {
+    const clearVssFence = jest.fn()
+    const account = makeAccount(
+      {
+        unlock: () => { throw new Error('__rln_instance__ belongs to a previous owner') },
+        clearVssFence
+      },
+      { autoRecoverStaleVssFence: true }
+    )
+
+    await expect(account.unlock({})).rejects.toMatchObject({
+      name: 'UnlockError',
+      code: 'UNLOCK_FAILED'
+    })
+    expect(clearVssFence).not.toHaveBeenCalled()
   })
 
   it('coalesces concurrent unlock calls at the account boundary', async () => {

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -92,16 +92,19 @@ describe('WalletManagerRgbLightning', () => {
     const manager = new TestManager(MNEMONIC, {
       network: 'regtest',
       dataDir: '/wallet',
-      autoUnlockRequest: AUTO_UNLOCK_REQUEST
+      autoUnlockRequest: AUTO_UNLOCK_REQUEST,
+      autoRecoverStaleVssFence: true
     })
     const account = await manager.getAccount()
     const binding = FakeBinding.instances[0]
 
     expect(account._autoUnlockRequest).toEqual(AUTO_UNLOCK_REQUEST)
+    expect(account._autoRecoverStaleVssFence).toBe(true)
     expect(account._autoUnlockRequest).not.toBe(AUTO_UNLOCK_REQUEST)
     expect(Object.isFrozen(account._autoUnlockRequest)).toBe(true)
     expect(Object.isFrozen(account._autoUnlockRequest.announce_addresses)).toBe(true)
     expect(binding._config.autoUnlockRequest).toBeUndefined()
+    expect(binding._config.autoRecoverStaleVssFence).toBeUndefined()
   })
 
   it('rejects malformed automatic activation requests without exposing values', () => {

--- a/tests/wallet-manager.test.js
+++ b/tests/wallet-manager.test.js
@@ -30,9 +30,17 @@ class FakeBinding {
 
   constructor (config) {
     this._config = config
+    this._shutdown = false
     this.attachExternalSigner = jest.fn()
-    this.shutdown = jest.fn()
-    this.bootstrap = jest.fn(() => ({ node_id: '02' + '11'.repeat(32) }))
+    this.shutdown = jest.fn(() => {
+      this._shutdown = true
+    })
+    this.bootstrap = jest.fn(() => {
+      if (this._shutdown) {
+        throw new Error('attachExternalSigner(seedHex) must be called before bootstrap()')
+      }
+      return { node_id: '02' + '11'.repeat(32) }
+    })
     this.vssStatus = jest.fn(() => ({ configured: false, url: null, allowHttp: false, lastBackupVersion: null }))
     this.ensureNode = jest.fn(() => ({}))
     FakeBinding.instances.push(this)
@@ -144,7 +152,26 @@ describe('WalletManagerRgbLightning', () => {
     const binding = FakeBinding.instances[0]
     expect(account.keyPair.privateKey).toBeNull()
     manager.dispose()
+    expect(binding.bootstrap).toHaveBeenCalledTimes(2)
     expect(binding.shutdown).toHaveBeenCalledTimes(1)
+    expect(binding.bootstrap.mock.invocationCallOrder[1])
+      .toBeLessThan(binding.shutdown.mock.invocationCallOrder[0])
+  })
+
+  it('still destroys the signer when base account cleanup fails', async () => {
+    const manager = new TestManager(MNEMONIC, { network: 'regtest', dataDir: '/wallet' })
+    const account = await manager.getAccount()
+    const binding = FakeBinding.instances[0]
+    Object.defineProperty(account, 'keyPair', {
+      configurable: true,
+      get: () => {
+        throw new Error('account cleanup failed')
+      }
+    })
+
+    expect(() => manager.dispose()).toThrow('account cleanup failed')
+    expect(binding.shutdown).toHaveBeenCalledTimes(1)
+    expect(manager._binding).toBeNull()
   })
 
   it('dispose is a no-op before an account has created a binding', () => {


### PR DESCRIPTION
## Summary\n- preserves signer lifetime through wallet-manager disposal\n- adds opt-in stale VSS fence recovery during unlock\n- documents the VSS single-writer risk and external-signer VSS identity behavior\n- keeps recovery disabled unless a host opts in\n\n## Validation\n- npm run lint\n- npm run check:types\n- npm test -- --runInBand