### PR TITLE
feat: add UMA address normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ while pre-`1.0`.
 
 ## [Unreleased]
 
+### Added
+- UMA address-format compatibility across Lightning Address payment flows.
+  `$recipient@example.com` is normalized to `recipient@example.com` before
+  LNURL discovery. New root exports include `isUmaAddress`,
+  `normalizeLightningAddress`, `UMA_PREFIX`, and `UMA_MAX_USERNAME_LENGTH`;
+  `parseLightningAddress` now also returns the canonical address, domain, and
+  whether the input used UMA form.
+
 ## [0.1.0-beta.15] — 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -324,9 +324,16 @@ Channel and liquidity wait timeouts throw `LspChannelTimeoutError` and
 
 ### LNURL / Lightning Address helpers
 
-`parseLightningAddress`, `fetchDiscovery`, `resolveAddressToInvoice`
-(LNURL-pay), and the account-bound helpers `payLightningAddress`,
-`requestLspRgbDeposit`, `payRgbViaLsp` are also exported from the root.
+Lightning Address payment APIs accept both `recipient@example.com` and
+[UMA's](https://www.uma.me/) `$recipient@example.com` form. UMA input is
+normalized to the equivalent Lightning Address before LNURL discovery. This is
+address-format compatibility; it does not implement UMA signing, compliance,
+or currency negotiation.
+
+`isUmaAddress`, `normalizeLightningAddress`, `parseLightningAddress`,
+`fetchDiscovery`, `resolveAddressToInvoice` (LNURL-pay), and the account-bound
+helpers `payLightningAddress`, `requestLspRgbDeposit`, `payRgbViaLsp` are
+exported from the root.
 LNURL callbacks are restricted to the discovery host by default; delegated
 cross-host callbacks require the explicit `allowCrossHostCallback: true` opt-in.
 

--- a/index-bare.js
+++ b/index-bare.js
@@ -38,6 +38,10 @@ export {
 export { LspClient, LspError } from './src/lsp-client.js'
 export {
   LnurlPayError,
+  UMA_PREFIX,
+  UMA_MAX_USERNAME_LENGTH,
+  isUmaAddress,
+  normalizeLightningAddress,
   parseLightningAddress,
   fetchDiscovery,
   resolveAddressToInvoice

--- a/index-node.js
+++ b/index-node.js
@@ -38,6 +38,10 @@ export {
 export { LspClient, LspError } from './src/lsp-client.js'
 export {
   LnurlPayError,
+  UMA_PREFIX,
+  UMA_MAX_USERNAME_LENGTH,
+  isUmaAddress,
+  normalizeLightningAddress,
   parseLightningAddress,
   fetchDiscovery,
   resolveAddressToInvoice

--- a/index.d.ts
+++ b/index.d.ts
@@ -608,7 +608,27 @@ export class LspError extends Error {
 // LNURL-pay (LUD-06 / LUD-16)
 // ───────────────────────────────────────────────────────────────────
 
-export function parseLightningAddress(addr: string, opts?: { allowHttp?: boolean }): { username: string; host: string; discoveryUrl: string }
+export const UMA_PREFIX: '$'
+export const UMA_MAX_USERNAME_LENGTH: 64
+
+export interface ParsedLightningAddress {
+  /** Local part with any UMA prefix removed. */
+  username: string
+  /** Address host, including a port when supplied. */
+  host: string
+  /** Alias for `host`, matching WDK's address vocabulary. */
+  domain: string
+  /** Canonical `username@domain` form without an UMA prefix. */
+  address: string
+  /** Whether the input used UMA's leading `$` form. */
+  isUma: boolean
+  /** LUD-16 discovery endpoint for the canonical address. */
+  discoveryUrl: string
+}
+
+export function isUmaAddress(address: unknown): boolean
+export function normalizeLightningAddress(address: string): string
+export function parseLightningAddress(addr: string, opts?: { allowHttp?: boolean }): ParsedLightningAddress
 export interface LnurlPayOptions {
   fetch?: typeof fetch
   timeoutMs?: number
@@ -730,6 +750,7 @@ export interface SendAssetResult extends LspBridgeResult {
 }
 
 export interface PayAddressOptions {
+  /** Lightning Address or UMA address in `$user@host` form. */
   address: string
   amtMsat: bigint | number | string
   asset?: { assetId: string; assetAmount: bigint | number | string }

--- a/src/lnurl-pay.js
+++ b/src/lnurl-pay.js
@@ -14,6 +14,7 @@ import { toUint64String } from './lsp-utils.js'
 // Spec references:
 //   https://github.com/lnurl/luds/blob/luds/16.md   (Lightning Address)
 //   https://github.com/lnurl/luds/blob/luds/06.md   (LNURL-pay)
+//   https://github.com/uma-universal-money-address/protocol/blob/main/umad-01-addresses.md
 //
 // We deliberately do not verify the BOLT11 invoice's description-hash
 // matches the metadata here — that's the responsibility of the caller
@@ -46,46 +47,95 @@ export class LnurlPayError extends Error {
 /** Default request timeout for both discovery + callback fetches. */
 const DEFAULT_TIMEOUT_MS = 15_000
 
+/** Prefix that distinguishes a UMA address from a Lightning Address. */
+export const UMA_PREFIX = '$'
+
+/** Maximum UMA username length, including the leading `$`, per UMAD-01. */
+export const UMA_MAX_USERNAME_LENGTH = 64
+
+const LIGHTNING_ADDRESS_USERNAME_RE = /^[a-z0-9._+-]+$/
+
 /**
- * Parse `user@host` (case-insensitive on the host part, lowercase on
- * the local-part per LUD-16). Returns the canonical components plus
- * the discovery URL the wallet should fetch.
+ * Return whether an address uses UMA's leading `$` form.
+ *
+ * @param {unknown} address - Candidate address.
+ * @returns {boolean} - Whether the trimmed string starts with `$`.
+ */
+export function isUmaAddress (address) {
+  return typeof address === 'string' && address.trim().startsWith(UMA_PREFIX)
+}
+
+/**
+ * Convert a UMA address to Lightning Address form.
+ *
+ * Plain Lightning Addresses are trimmed and otherwise left unchanged. UMA
+ * addresses are lowercased because UMAD-01 defines them as case-insensitive.
+ * This helper normalizes syntax only; use {@link parseLightningAddress} when
+ * validation is required.
+ *
+ * @param {string} address - Lightning Address or UMA address.
+ * @returns {string} - Address without the UMA prefix.
+ * @throws {LnurlPayError} - If `address` is not a string.
+ */
+export function normalizeLightningAddress (address) {
+  if (typeof address !== 'string') {
+    throw new LnurlPayError('normalizeLightningAddress: address must be a string')
+  }
+
+  const trimmed = address.trim()
+  return trimmed.startsWith(UMA_PREFIX)
+    ? trimmed.slice(UMA_PREFIX.length).toLowerCase()
+    : trimmed
+}
+
+/**
+ * Parse `user@host` or UMA's `$user@host` form. The UMA prefix is removed
+ * before LNURL discovery. The host is case-insensitive and the local part is
+ * lowercased per LUD-16.
  *
  * `allowHttp` defaults to false for safety. We auto-allow http for
- * loopback hosts (`localhost`, `127.0.0.1`, `[::1]`, `*.local`) since
- * those are almost always dev/regtest. `.onion` per LUD-16 always uses
- * http.
+ * loopback hosts (`localhost`, `127.0.0.1`, `[::1]`, `10.0.2.2`,
+ * `*.local`) since those are almost always dev/regtest. `.onion` per LUD-16
+ * always uses http.
  *
- * @param {string} addr - Lightning Address in `user@host` form.
+ * @param {string} addr - Lightning Address or UMA address.
  * @param {object} [opts] - Address parsing options.
  * @param {boolean} [opts.allowHttp] - Whether non-loopback hosts may use
  *   plain HTTP. Defaults to `false`.
- * @returns {{ username:string, host:string, discoveryUrl:string }} - Canonical
- *   address components and discovery URL.
+ * @returns {{ username:string, host:string, domain:string, address:string, isUma:boolean, discoveryUrl:string }} -
+ *   Canonical address components and discovery URL.
  * @throws {LnurlPayError} - If the address or host is malformed.
  */
 export function parseLightningAddress (addr, opts = {}) {
-  if (typeof addr !== 'string' || addr.length === 0) {
+  if (typeof addr !== 'string' || addr.trim().length === 0) {
     throw new LnurlPayError('parseLightningAddress: address required')
   }
-  const at = addr.lastIndexOf('@')
-  if (at <= 0 || at === addr.length - 1) {
+  const isUma = isUmaAddress(addr)
+  const normalized = normalizeLightningAddress(addr)
+  const at = normalized.lastIndexOf('@')
+  if (at <= 0 || at === normalized.length - 1) {
     throw new LnurlPayError(`parseLightningAddress: malformed address '${addr}'`)
   }
   // LUD-16 §spec normalises the local-part to lowercase. The host is
   // already case-insensitive at the DNS layer; we lowercase too so the
   // discovery URL is stable.
-  const username = addr.slice(0, at).toLowerCase()
-  const host = addr.slice(at + 1).toLowerCase()
-  if (!/^[a-z0-9._+-]+$/.test(username)) {
+  const username = normalized.slice(0, at).toLowerCase()
+  const host = normalized.slice(at + 1).toLowerCase()
+  if (!LIGHTNING_ADDRESS_USERNAME_RE.test(username)) {
     throw new LnurlPayError(`parseLightningAddress: invalid local-part '${username}'`)
+  }
+  if (isUma && username.length + UMA_PREFIX.length > UMA_MAX_USERNAME_LENGTH) {
+    throw new LnurlPayError(
+      `parseLightningAddress: UMA local-part exceeds ${UMA_MAX_USERNAME_LENGTH} characters including '${UMA_PREFIX}'`
+    )
   }
   if (!/^[a-z0-9.[\]:_-]+$/.test(host)) {
     throw new LnurlPayError(`parseLightningAddress: invalid host '${host}'`)
   }
+  const address = `${username}@${host}`
   const scheme = pickScheme(host, opts.allowHttp === true)
   const discoveryUrl = `${scheme}://${host}/.well-known/lnurlp/${encodeURIComponent(username)}`
-  return { username, host, discoveryUrl }
+  return { username, host, domain: host, address, isUma, discoveryUrl }
 }
 
 function pickScheme (host, allowHttp) {
@@ -100,6 +150,7 @@ function isLoopback (host) {
   return noPort === 'localhost' ||
     noPort === '127.0.0.1' ||
     noPort === '::1' ||
+    noPort === '10.0.2.2' ||
     noPort.endsWith('.local') ||
     noPort.endsWith('.localhost')
 }
@@ -111,10 +162,9 @@ function isLoopback (host) {
  * compute `metadata` hash from the returned `metadata` string when
  * checking the invoice's description-hash anchor.
  *
- * @param {string} addr - Lightning Address (`user@host`) or a full URL
- *                      to a `/.well-known/lnurlp/<user>` endpoint
- *                      (useful for `LspClient.lnurlDiscovery` callers
- *                      who already have an LSP URL).
+ * @param {string} addr - Lightning Address, UMA address, or a full URL to a
+ *   `/.well-known/lnurlp/<user>` endpoint (useful for
+ *   `LspClient.lnurlDiscovery` callers who already have an LSP URL).
  * @param {object} [opts] - Discovery request options.
  * @param {typeof fetch} [opts.fetch] - Fetch implementation. Defaults to the
  *   runtime's global `fetch`.
@@ -147,8 +197,8 @@ export async function fetchDiscovery (addr, opts = {}) {
  * can verify the description-hash anchor against the returned invoice
  * after decoding it.
  *
- * @param {string} addr - Lightning Address in `user@host` form or discovery
- *   endpoint URL.
+ * @param {string} addr - Lightning Address, UMA address, or discovery endpoint
+ *   URL.
  * @param {bigint|number|string} amountMsat - Amount to request, in
  *   millisatoshis.
  * @param {object} [opts] - LNURL resolution options.

--- a/src/lsp-helpers.js
+++ b/src/lsp-helpers.js
@@ -30,7 +30,8 @@ import { toUint64 } from './lsp-utils.js'
  *
  * @param {object} account - Account-like object exposing
  *   `sendPayment({ invoice })`.
- * @param {string} addr - Lightning Address in `user@host` form.
+ * @param {string} addr - Lightning Address in `user@host` form or UMA address
+ *   in `$user@host` form.
  * @param {bigint|number|string} amountMsat - Amount to pay, in millisatoshis.
  * @param {object} [opts] - LNURL resolution and payment options.
  * @param {typeof fetch} [opts.fetch] - Fetch implementation used for LNURL

--- a/src/utexo-lsp.js
+++ b/src/utexo-lsp.js
@@ -352,7 +352,8 @@ export class UtexoLsp {
    * by mistake.
    *
    * @param {object} opts - Lightning Address payment request.
-   * @param {string} opts.address - Lightning Address in `user@host` form.
+   * @param {string} opts.address - Lightning Address in `user@host` form or
+   *   UMA address in `$user@host` form.
    * @param {bigint|number|string} opts.amtMsat - Payment amount in
    *   millisatoshis.
    * @param {object} [opts.asset] - Optional RGB asset ID and amount.
@@ -387,7 +388,7 @@ export class UtexoLsp {
     }
 
     if (useStandardResolver) {
-      const resolved = await resolveAddressToInvoice(address, opts.amtMsat, {
+      const resolved = await resolveAddressToInvoice(parsed.address, opts.amtMsat, {
         allowHttp: this.peer.allowHttp === true,
         allowCrossHostCallback: opts.allowCrossHostCallback === true,
         assetId: opts.asset?.assetId,

--- a/src/wallet-account-rgb-lightning.js
+++ b/src/wallet-account-rgb-lightning.js
@@ -872,8 +872,8 @@ export default class WalletAccountRgbLightning extends WalletAccountReadOnlyRgbL
   // composition over instance methods (e.g. for read-only accounts).
 
   /**
-   * Pay a Lightning Address (LUD-06). Works against any LNURL-pay
-   * server, including but not limited to utexo-lsp.
+   * Pay a Lightning Address (LUD-06), including UMA's `$user@host` form.
+   * Works against any LNURL-pay server, including but not limited to utexo-lsp.
    * @see ./lsp-helpers.js#payLightningAddress
    */
   payLightningAddress (addr, amountMsat, opts) {

--- a/tests/lnurl-exports.test.js
+++ b/tests/lnurl-exports.test.js
@@ -1,0 +1,24 @@
+// Copyright 2026 UTEXO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+import * as bareEntry from '../index-bare.js'
+import * as nodeEntry from '../index-node.js'
+
+describe.each([
+  ['Node', nodeEntry],
+  ['Bare', bareEntry]
+])('%s entry LNURL exports', (runtime, entry) => {
+  it('exposes UMA normalization consistently', () => {
+    expect(entry.default.Binding).toBe(entry[`${runtime}RgbLightningBinding`])
+    expect(entry.UMA_PREFIX).toBe('$')
+    expect(entry.UMA_MAX_USERNAME_LENGTH).toBe(64)
+    expect(entry.isUmaAddress('$alice@example.com')).toBe(true)
+    expect(entry.normalizeLightningAddress('$alice@example.com')).toBe('alice@example.com')
+    expect(entry.parseLightningAddress('$alice@example.com')).toMatchObject({
+      address: 'alice@example.com',
+      isUma: true
+    })
+  })
+})

--- a/tests/lnurl-pay.test.js
+++ b/tests/lnurl-pay.test.js
@@ -10,6 +10,10 @@
 import { jest } from '@jest/globals'
 import {
   LnurlPayError,
+  UMA_PREFIX,
+  UMA_MAX_USERNAME_LENGTH,
+  isUmaAddress,
+  normalizeLightningAddress,
   parseLightningAddress,
   fetchDiscovery,
   resolveAddressToInvoice
@@ -54,14 +58,87 @@ describe('LnurlPayError', () => {
   })
 })
 
+describe('UMA address normalization', () => {
+  it('detects UMA addresses without throwing on other input types', () => {
+    expect(isUmaAddress('$bob@example.com')).toBe(true)
+    expect(isUmaAddress('  $bob@example.com  ')).toBe(true)
+    expect(isUmaAddress('bob@example.com')).toBe(false)
+    expect(isUmaAddress(undefined)).toBe(false)
+    expect(isUmaAddress(null)).toBe(false)
+  })
+
+  it('strips the UMA prefix and lowercases the case-insensitive address', () => {
+    expect(UMA_PREFIX).toBe('$')
+    expect(normalizeLightningAddress('$Bob@Example.COM')).toBe('bob@example.com')
+  })
+
+  it('is idempotent and preserves plain-address case', () => {
+    const normalized = normalizeLightningAddress('  $bob@example.com  ')
+    expect(normalized).toBe('bob@example.com')
+    expect(normalizeLightningAddress(normalized)).toBe(normalized)
+    expect(normalizeLightningAddress(' Bob@Example.com ')).toBe('Bob@Example.com')
+  })
+
+  it('rejects non-string input with the module error type', () => {
+    expect(() => normalizeLightningAddress(42)).toThrow(LnurlPayError)
+    expect(() => normalizeLightningAddress(42)).toThrow(/address must be a string/)
+  })
+})
+
 describe('parseLightningAddress', () => {
   it('parses a canonical user@host and builds the https discovery URL', () => {
     const out = parseLightningAddress('Alice@GetAlby.com')
     expect(out).toEqual({
       username: 'alice',
       host: 'getalby.com',
+      domain: 'getalby.com',
+      address: 'alice@getalby.com',
+      isUma: false,
       discoveryUrl: 'https://getalby.com/.well-known/lnurlp/alice'
     })
+  })
+
+  it('parses UMA and plain forms to the same canonical address', () => {
+    const plain = parseLightningAddress('Recipient@Example.com')
+    const uma = parseLightningAddress('  $Recipient@Example.com  ')
+
+    expect(plain).toMatchObject({
+      username: 'recipient',
+      domain: 'example.com',
+      address: 'recipient@example.com',
+      isUma: false
+    })
+    expect(uma).toMatchObject({
+      username: 'recipient',
+      domain: 'example.com',
+      address: 'recipient@example.com',
+      isUma: true
+    })
+    expect(uma.discoveryUrl).toBe(plain.discoveryUrl)
+  })
+
+  it('enforces the UMAD-01 username length limit including the prefix', () => {
+    const maximumUsername = 'a'.repeat(UMA_MAX_USERNAME_LENGTH - UMA_PREFIX.length)
+    expect(parseLightningAddress(`$${maximumUsername}@example.com`).username)
+      .toBe(maximumUsername)
+
+    const overLimitUsername = 'a'.repeat(UMA_MAX_USERNAME_LENGTH)
+    expect(() => parseLightningAddress(`$${overLimitUsername}@example.com`))
+      .toThrow(/exceeds 64 characters/)
+    expect(parseLightningAddress(`${overLimitUsername}@example.com`).username)
+      .toBe(overLimitUsername)
+  })
+
+  it('accepts the UMAD-01 username character set', () => {
+    const out = parseLightningAddress('$a-b_c.d+e@example.com')
+    expect(out.username).toBe('a-b_c.d+e')
+    expect(out.discoveryUrl).toBe('https://example.com/.well-known/lnurlp/a-b_c.d%2Be')
+  })
+
+  it('rejects malformed UMA local parts', () => {
+    expect(() => parseLightningAddress('$bob!@example.com')).toThrow(/invalid local-part/)
+    expect(() => parseLightningAddress('$$bob@example.com')).toThrow(/invalid local-part/)
+    expect(() => parseLightningAddress('$@example.com')).toThrow(/malformed address/)
   })
 
   it('percent-encodes the local-part in the discovery URL', () => {
@@ -87,6 +164,8 @@ describe('parseLightningAddress', () => {
       .toBe('http://node.local/.well-known/lnurlp/bob')
     expect(parseLightningAddress('bob@dev.localhost').discoveryUrl)
       .toBe('http://dev.localhost/.well-known/lnurlp/bob')
+    expect(parseLightningAddress('bob@10.0.2.2:8080').discoveryUrl)
+      .toBe('http://10.0.2.2:8080/.well-known/lnurlp/bob')
   })
 
   it('uses http for .onion hosts regardless of allowHttp', () => {
@@ -132,6 +211,12 @@ describe('fetchDiscovery', () => {
     expect(url).toBe('https://getalby.com/.well-known/lnurlp/alice')
     expect(init.headers).toEqual({ Accept: 'application/json' })
     expect(init.signal === undefined || typeof init.signal === 'object').toBe(true)
+  })
+
+  it('normalizes an UMA address before requesting discovery', async () => {
+    const fetch = jest.fn(async () => makeResponse({ body: discoveryDoc() }))
+    await fetchDiscovery('$Alice@GetAlby.com', { fetch })
+    expect(fetch.mock.calls[0][0]).toBe('https://getalby.com/.well-known/lnurlp/alice')
   })
 
   it('passes a full http(s) URL straight through without parsing it as an address', async () => {
@@ -274,6 +359,15 @@ describe('resolveAddressToInvoice', () => {
     // discovery + callback = exactly two fetches.
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(fetch.mock.calls[1][0]).toBe('https://b.com/lnurlp/cb?amount=5000')
+  })
+
+  it('normalizes an UMA address before both LNURL-pay requests', async () => {
+    const fetch = twoStepFetch(discoveryDoc(), { pr: 'lnbc-uma' })
+    const out = await resolveAddressToInvoice('$Alice@B.com', 5000, { fetch })
+
+    expect(fetch.mock.calls[0][0]).toBe('https://b.com/.well-known/lnurlp/alice')
+    expect(fetch.mock.calls[1][0]).toBe('https://b.com/lnurlp/cb?amount=5000')
+    expect(out.pr).toBe('lnbc-uma')
   })
 
   it('defaults routes to an empty array when the callback omits them', async () => {

--- a/tests/lsp-helpers.test.js
+++ b/tests/lsp-helpers.test.js
@@ -86,6 +86,16 @@ describe('payLightningAddress', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
+  it('accepts an UMA address and strips the prefix before discovery', async () => {
+    const fetch = makeLnurlFetch()
+    const account = { sendPayment: jest.fn(async () => ({ payment_hash: 'uma' })) }
+
+    await payLightningAddress(account, '$Alice@Host.Example', 5000, { fetch })
+
+    expect(fetch.mock.calls[0][0]).toBe('https://host.example/.well-known/lnurlp/alice')
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: BOLT11, amt_msat: 5000 })
+  })
+
   it('omits amt_msat when opts.skipAmount is set', async () => {
     const fetch = makeLnurlFetch()
     const account = { sendPayment: jest.fn(async () => ({ ok: true })) }

--- a/tests/types-contract.ts
+++ b/tests/types-contract.ts
@@ -3,8 +3,13 @@ import type { IWalletAccount, IWalletAccountReadOnly } from '@tetherto/wdk-walle
 
 import {
   BareRgbLightningBinding,
+  isUmaAddress,
   LnurlPayError,
-  NodeRgbLightningBinding
+  NodeRgbLightningBinding,
+  normalizeLightningAddress,
+  parseLightningAddress,
+  UMA_MAX_USERNAME_LENGTH,
+  UMA_PREFIX
 } from '../index.js'
 
 import type WalletManagerRgbLightning from '../index.js'
@@ -12,6 +17,7 @@ import type {
   IRgbLightningBinding,
   LnurlPayOptions,
   LspLiquidityTimeoutError,
+  ParsedLightningAddress,
   PayAddressOptions,
   WalletAccountReadOnlyRgbLightning,
   WalletAccountRgbLightning
@@ -50,6 +56,13 @@ const lnurlError = new LnurlPayError('request failed', {
 })
 const lnurlStatus: number | undefined = lnurlError.status
 const lnurlBody: string | undefined = lnurlError.body
+const umaPrefix: '$' = UMA_PREFIX
+const umaMaxUsernameLength: 64 = UMA_MAX_USERNAME_LENGTH
+const normalizedAddress: string = normalizeLightningAddress('$alice@example.com')
+const umaAddress: boolean = isUmaAddress('$alice@example.com')
+const nonStringUmaAddress: boolean = isUmaAddress(42)
+const parsedAddress: ParsedLightningAddress = parseLightningAddress('$alice@example.com')
+const parsedDomain: string = parsedAddress.domain
 
 binding.ensureNode()
 // @ts-expect-error IRgbLightningBinding exposes ensureNode(), not a node property.
@@ -62,3 +75,10 @@ void nodeHealth
 void bareHealth
 void lnurlStatus
 void lnurlBody
+void umaPrefix
+void umaMaxUsernameLength
+void normalizedAddress
+void umaAddress
+void nonStringUmaAddress
+void parsedAddress
+void parsedDomain

--- a/tests/utexo-lsp.test.js
+++ b/tests/utexo-lsp.test.js
@@ -580,6 +580,20 @@ describe('payAddress', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled()
   })
 
+  it('normalizes a same-host UMA address before using the LSP client', async () => {
+    const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'uma-local' })) })
+    const lsp = makeLsp(account)
+
+    await lsp.payAddress({ address: '$Alice@LSP.Example.IO', amtMsat: 2000 })
+
+    expect(lsp.http.resolveAddress).toHaveBeenCalledWith('alice', 2000, {
+      assetId: undefined,
+      assetAmount: undefined
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(account.sendPayment).toHaveBeenCalledWith({ invoice: 'lnbcrt-resolved' })
+  })
+
   it('uses the shared LNURL resolver directly for an external address', async () => {
     const account = makeAccount({ sendPayment: jest.fn(async () => ({ payment_hash: 'fb' })) })
     const lsp = makeLsp(account)
@@ -600,6 +614,18 @@ describe('payAddress', () => {
     expect(secondUrl).toContain('&asset_id=assetY')
     expect(secondUrl).toContain('&asset_amount=9')
     expect(out).toEqual({ invoice: 'lnbcrt-lnurl', sendResult: { payment_hash: 'fb' } })
+  })
+
+  it('routes a foreign UMA address by its own domain without querying the LSP', async () => {
+    const lsp = makeLsp(makeAccount())
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://other.test/cb')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-uma-external' }))
+
+    await lsp.payAddress({ address: '$Bob@Other.Test', amtMsat: 3000 })
+
+    expect(lsp.http.resolveAddress).not.toHaveBeenCalled()
+    expect(globalThis.fetch.mock.calls[0][0]).toBe('https://other.test/.well-known/lnurlp/bob')
   })
 
   it('rejects a delegated callback by default', async () => {
@@ -666,6 +692,19 @@ describe('payAddress', () => {
       .resolves.toMatchObject({ invoice: 'lnbcrt-fallback' })
     expect(lsp.http.resolveAddress).toHaveBeenCalledTimes(1)
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the normalized address when an UMA same-host payment falls back', async () => {
+    const lsp = makeLsp(makeAccount())
+    lsp.http.resolveAddress = jest.fn(async () => { throw new Error('LSP unavailable') })
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(lnurlResponse(lnurlDiscovery('https://lsp.example.io/cb')))
+      .mockResolvedValueOnce(lnurlResponse({ pr: 'lnbcrt-uma-fallback' }))
+
+    await lsp.payAddress({ address: '$Alice@LSP.Example.IO', amtMsat: 2 })
+
+    expect(globalThis.fetch.mock.calls[0][0])
+      .toBe('https://lsp.example.io/.well-known/lnurlp/alice')
   })
 
   it('throws when no invoice is returned from either path', async () => {


### PR DESCRIPTION
## Summary

- accept UMA addresses such as `$recipient@example.com` anywhere Lightning Addresses are accepted
- normalize UMA input in the shared LNURL layer and expose `isUmaAddress`, `normalizeLightningAddress`, `UMA_PREFIX`, and `UMA_MAX_USERNAME_LENGTH`
- return canonical address metadata from `parseLightningAddress` while preserving its existing fields
- keep same-host payments on the authenticated LSP path and foreign addresses on their own LNURL domain
- export the new API consistently from Node and Bare entry points and update TypeScript declarations and documentation
- align LNURL loopback handling with the existing LSP client for Android's `10.0.2.2` host alias

## Scope

This adds UMA address-format compatibility by converting `$user@host` to `user@host` before LNURL discovery. It does not implement signed UMA protocol requests, compliance exchange, payer identity, or currency negotiation.

## Validation

- `npm run lint`
- `npm run check:types`
- `npm run test:coverage` - 15 suites and 532 tests passed; 99.25% statements, 95.81% branches, 98.85% functions, 99.63% lines
- `npm run check:package`
- `npm run smoke:package:node`
- `npm audit --omit=dev` - 0 production vulnerabilities
- `git diff --check`
